### PR TITLE
Phase 1: decouple environment

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -1,18 +1,22 @@
-from typing import List, Optional, Type
-import pygame
-from agents import Agent
+from typing import Iterable, List, Optional, Type
+
+# Avoid importing pygame-dependent Agent during tests
+try:
+    from agents import Agent
+except Exception:  # pragma: no cover - fallback for environments without pygame
+    Agent = object
 
 class Environment:
     """
     The environment in which the agents operate. 
     This class provides methods to interact with and query the state of the environment.
     """
-    def __init__(self, agents: Optional[pygame.sprite.Group] = None):
+    def __init__(self, agents: Optional[Iterable[Agent]] = None):
         """
         Initialize the environment.
 
         Args:
-            agents (pygame.sprite.Group, optional): A group of agents. Defaults to None.
+            agents (Iterable[Agent], optional): A collection of agents. Defaults to None.
         """
         self.agents = agents
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,27 @@
+import math
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from environment import Environment
+
+class Vec:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+    def __sub__(self, other):
+        return Vec(self.x - other.x, self.y - other.y)
+    def length(self):
+        return math.hypot(self.x, self.y)
+
+def make_agent(x, y):
+    return type('Dummy', (), {'pos': Vec(x, y)})()
+
+def test_nearby_agents():
+    a1 = make_agent(0, 0)
+    a2 = make_agent(1, 0)
+    a3 = make_agent(5, 0)
+    env = Environment([a1, a2, a3])
+    res = env.nearby_agents(a1, radius=2)
+    assert a2 in res
+    assert a3 not in res


### PR DESCRIPTION
## Summary
- remove pygame dependency from `environment` module
- provide fallback Agent type for non-graphical test runs
- add a simple unit test for `Environment.nearby_agents`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cd7fcffc8331b20e69d458c67b55