### PR TITLE
Display algorithm number on fish health meter

### DIFF
--- a/behavior_algorithms.py
+++ b/behavior_algorithms.py
@@ -1766,6 +1766,22 @@ ALL_ALGORITHMS = [
 ]
 
 
+def get_algorithm_index(algorithm: BehaviorAlgorithm) -> int:
+    """Get the index of an algorithm in the ALL_ALGORITHMS list.
+
+    Args:
+        algorithm: The behavior algorithm instance
+
+    Returns:
+        Index (0-47) of the algorithm, or -1 if not found
+    """
+    algorithm_class = type(algorithm)
+    try:
+        return ALL_ALGORITHMS.index(algorithm_class)
+    except ValueError:
+        return -1
+
+
 def get_random_algorithm() -> BehaviorAlgorithm:
     """Get a random behavior algorithm instance."""
     algorithm_class = random.choice(ALL_ALGORITHMS)

--- a/fishtank.py
+++ b/fishtank.py
@@ -353,6 +353,23 @@ class FishTankSimulator:
         if filled_width > 0:
             pygame.draw.rect(self.screen, color, (bar_x, bar_y, filled_width, bar_height))
 
+        # Display algorithm number if fish has a behavior algorithm
+        if fish.genome.behavior_algorithm is not None:
+            from behavior_algorithms import get_algorithm_index
+            algo_index = get_algorithm_index(fish.genome.behavior_algorithm)
+
+            if algo_index >= 0:
+                # Create a small font for the algorithm number
+                small_font = pygame.font.Font(None, 16)
+                algo_text = f"#{algo_index}"
+                text_surface = small_font.render(algo_text, True, (200, 200, 200))
+
+                # Position text below the health bar, centered
+                text_x = fish.rect.centerx - text_surface.get_width() // 2
+                text_y = bar_y + bar_height + 1
+
+                self.screen.blit(text_surface, (text_x, text_y))
+
     def draw_stats_panel(self) -> None:
         """Draw statistics panel showing ecosystem data."""
         if self.screen is None or self.stats_font is None or self.ecosystem is None:


### PR DESCRIPTION
Added functionality to show which behavior algorithm (0-47) each fish is using when the health meter display is active (toggled with 'H' key).

Changes:
- Added get_algorithm_index() helper function in behavior_algorithms.py
- Modified draw_health_bar() in fishtank.py to display algorithm # below health bar
- Algorithm number is shown as small gray text (e.g., "#23") centered below the energy bar