### PR TITLE
Fix string type error in algorithm mutation

### DIFF
--- a/behavior_algorithms.py
+++ b/behavior_algorithms.py
@@ -259,6 +259,10 @@ class BehaviorAlgorithm(ABC):
             mutation_strength: Magnitude of mutations
         """
         for key, current_value in list(self.parameters.items()):
+            # Skip non-numeric parameters (they shouldn't be mutated)
+            if not isinstance(current_value, (int, float)):
+                continue
+
             if random.random() >= mutation_rate:
                 continue
 


### PR DESCRIPTION
Added type checking to skip non-numeric parameters during mutation. This prevents the TypeError: bad operand type for abs(): 'str' that occurred when the mutation algorithm tried to mutate non-numeric values.

The fix adds an isinstance check to ensure only int and float values are mutated, skipping any string or other non-numeric parameters that may be present in the parameters dictionary.