### PR TITLE
Add poker predation statistics to simulation

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -31,6 +31,19 @@ class EntityData(BaseModel):
     plant_type: Optional[int] = None
 
 
+class PokerStatsData(BaseModel):
+    """Poker game statistics."""
+    total_games: int
+    total_wins: int
+    total_losses: int
+    total_ties: int
+    total_energy_won: float
+    total_energy_lost: float
+    net_energy: float
+    best_hand_rank: int
+    best_hand_name: str
+
+
 class StatsData(BaseModel):
     """Ecosystem statistics."""
     frame: int
@@ -44,6 +57,7 @@ class StatsData(BaseModel):
     fish_count: int
     food_count: int
     plant_count: int
+    poker_stats: PokerStatsData
 
 
 class SimulationUpdate(BaseModel):

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -14,7 +14,7 @@ from simulation_engine import SimulationEngine
 from core import entities
 from core.behavior_algorithms import get_algorithm_index
 from core.constants import SCREEN_WIDTH, SCREEN_HEIGHT
-from models import EntityData, StatsData, SimulationUpdate
+from models import EntityData, StatsData, SimulationUpdate, PokerStatsData
 
 
 class SimulationRunner:
@@ -77,6 +77,21 @@ class SimulationRunner:
 
             # Get ecosystem stats
             stats = self.engine.get_stats()
+
+            # Create poker stats data
+            poker_stats_dict = stats.get('poker_stats', {})
+            poker_stats_data = PokerStatsData(
+                total_games=poker_stats_dict.get('total_games', 0),
+                total_wins=poker_stats_dict.get('total_wins', 0),
+                total_losses=poker_stats_dict.get('total_losses', 0),
+                total_ties=poker_stats_dict.get('total_ties', 0),
+                total_energy_won=poker_stats_dict.get('total_energy_won', 0.0),
+                total_energy_lost=poker_stats_dict.get('total_energy_lost', 0.0),
+                net_energy=poker_stats_dict.get('net_energy', 0.0),
+                best_hand_rank=poker_stats_dict.get('best_hand_rank', 0),
+                best_hand_name=poker_stats_dict.get('best_hand_name', 'None')
+            )
+
             stats_data = StatsData(
                 frame=self.engine.frame_count,
                 population=stats.get('total_population', 0),
@@ -88,7 +103,8 @@ class SimulationRunner:
                 death_causes=stats.get('death_causes', {}),
                 fish_count=stats.get('fish_count', 0),
                 food_count=stats.get('food_count', 0),
-                plant_count=stats.get('plant_count', 0)
+                plant_count=stats.get('plant_count', 0),
+                poker_stats=poker_stats_data
             )
 
             return SimulationUpdate(

--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -401,6 +401,7 @@ class EcosystemManager:
             Dictionary with key ecosystem metrics
         """
         total_pop = self.get_total_population()
+        poker_summary = self.get_poker_stats_summary()
 
         return {
             'total_population': total_pop,
@@ -411,6 +412,43 @@ class EcosystemManager:
             'capacity_usage': f"{int(100 * total_pop / self.max_population)}%" if self.max_population > 0 else "0%",
             'death_causes': dict(self.death_causes),
             'generations_alive': len([g for g, s in self.generation_stats.items() if s.population > 0]),
+            'poker_stats': poker_summary,
+        }
+
+    def get_poker_stats_summary(self) -> Dict[str, any]:
+        """Get summary poker statistics across all algorithms.
+
+        Returns:
+            Dictionary with aggregated poker statistics
+        """
+        total_games = sum(s.total_games for s in self.poker_stats.values())
+        total_wins = sum(s.total_wins for s in self.poker_stats.values())
+        total_losses = sum(s.total_losses for s in self.poker_stats.values())
+        total_ties = sum(s.total_ties for s in self.poker_stats.values())
+        total_energy_won = sum(s.total_energy_won for s in self.poker_stats.values())
+        total_energy_lost = sum(s.total_energy_lost for s in self.poker_stats.values())
+
+        # Find best hand rank across all algorithms
+        best_hand_rank = max((s.best_hand_rank for s in self.poker_stats.values()), default=0)
+
+        # Get hand rank name
+        hand_rank_names = [
+            "High Card", "Pair", "Two Pair", "Three of a Kind",
+            "Straight", "Flush", "Full House", "Four of a Kind",
+            "Straight Flush", "Royal Flush"
+        ]
+        best_hand_name = hand_rank_names[best_hand_rank] if 0 <= best_hand_rank < len(hand_rank_names) else "Unknown"
+
+        return {
+            'total_games': total_games,
+            'total_wins': total_wins,
+            'total_losses': total_losses,
+            'total_ties': total_ties,
+            'total_energy_won': total_energy_won,
+            'total_energy_lost': total_energy_lost,
+            'net_energy': total_energy_won - total_energy_lost,
+            'best_hand_rank': best_hand_rank,
+            'best_hand_name': best_hand_name,
         }
 
     def record_reproduction(self, algorithm_id: int) -> None:

--- a/fishtank.py
+++ b/fishtank.py
@@ -396,8 +396,8 @@ class FishTankSimulator:
         if self.screen is None or self.stats_font is None or self.ecosystem is None:
             return
 
-        # Semi-transparent background
-        panel_surface = pygame.Surface((250, 200))
+        # Semi-transparent background (larger to fit poker stats)
+        panel_surface = pygame.Surface((280, 300))
         panel_surface.set_alpha(200)
         panel_surface.fill((20, 20, 40))
         self.screen.blit(panel_surface, (10, 10))
@@ -423,8 +423,27 @@ class FishTankSimulator:
             for cause, count in stats['death_causes'].items():
                 lines.append(f"  {cause}: {count}")
 
+        # Add poker stats
+        poker = stats.get('poker_stats', {})
+        if poker and poker.get('total_games', 0) > 0:
+            lines.append("")
+            lines.append("Poker Stats:")
+            lines.append(f"  Games: {poker['total_games']}")
+            lines.append(f"  Wins/Losses/Ties: {poker['total_wins']}/{poker['total_losses']}/{poker['total_ties']}")
+            lines.append(f"  Energy Won: {poker['total_energy_won']:.1f}")
+            lines.append(f"  Energy Lost: {poker['total_energy_lost']:.1f}")
+            net_energy = poker['net_energy']
+            net_color = (100, 255, 100) if net_energy >= 0 else (255, 100, 100)
+            lines.append((f"  Net Energy: {net_energy:+.1f}", net_color))
+            lines.append(f"  Best Hand: {poker['best_hand_name']}")
+
         for line in lines:
-            text_surface = self.stats_font.render(line, True, (220, 220, 255))
+            # Check if line is a tuple (text, color)
+            if isinstance(line, tuple):
+                text, color = line
+                text_surface = self.stats_font.render(text, True, color)
+            else:
+                text_surface = self.stats_font.render(line, True, (220, 220, 255))
             self.screen.blit(text_surface, (20, y_offset))
             y_offset += 22
 

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -84,6 +84,43 @@ export function StatsPanel({ stats }: StatsPanelProps) {
         </div>
       )}
 
+      {stats.poker_stats && stats.poker_stats.total_games > 0 && (
+        <div style={styles.section}>
+          <h3 style={styles.sectionTitle}>Poker Stats</h3>
+          <div style={styles.statRow}>
+            <span style={styles.statLabel}>Games Played:</span>
+            <span style={styles.statValue}>{stats.poker_stats.total_games}</span>
+          </div>
+          <div style={styles.statRow}>
+            <span style={styles.statLabel}>W/L/T:</span>
+            <span style={styles.statValue}>
+              {stats.poker_stats.total_wins}/{stats.poker_stats.total_losses}/{stats.poker_stats.total_ties}
+            </span>
+          </div>
+          <div style={styles.statRow}>
+            <span style={styles.statLabel}>Energy Won:</span>
+            <span style={styles.statValue}>{stats.poker_stats.total_energy_won.toFixed(1)}</span>
+          </div>
+          <div style={styles.statRow}>
+            <span style={styles.statLabel}>Energy Lost:</span>
+            <span style={styles.statValue}>{stats.poker_stats.total_energy_lost.toFixed(1)}</span>
+          </div>
+          <div style={styles.statRow}>
+            <span style={styles.statLabel}>Net Energy:</span>
+            <span style={{
+              ...styles.statValue,
+              color: stats.poker_stats.net_energy >= 0 ? '#4ade80' : '#f87171'
+            }}>
+              {stats.poker_stats.net_energy >= 0 ? '+' : ''}{stats.poker_stats.net_energy.toFixed(1)}
+            </span>
+          </div>
+          <div style={styles.statRow}>
+            <span style={styles.statLabel}>Best Hand:</span>
+            <span style={styles.statValue}>{stats.poker_stats.best_hand_name}</span>
+          </div>
+        </div>
+      )}
+
       <div style={styles.legend}>
         <h3 style={styles.legendTitle}>Species Legend</h3>
         <div style={styles.legendItems}>

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -32,6 +32,18 @@ export interface EntityData {
   plant_type?: number;
 }
 
+export interface PokerStatsData {
+  total_games: number;
+  total_wins: number;
+  total_losses: number;
+  total_ties: number;
+  total_energy_won: number;
+  total_energy_lost: number;
+  net_energy: number;
+  best_hand_rank: number;
+  best_hand_name: string;
+}
+
 export interface StatsData {
   frame: number;
   population: number;
@@ -44,6 +56,7 @@ export interface StatsData {
   fish_count: number;
   food_count: number;
   plant_count: number;
+  poker_stats: PokerStatsData;
 }
 
 export interface SimulationUpdate {


### PR DESCRIPTION
This update adds detailed statistics for the poker interaction system where fish gamble energy when they collide. Poker stats are now visible in both the pygame UI and the React web UI.

Changes:
- Add get_poker_stats_summary() method to EcosystemManager
- Display poker stats in pygame stats panel with color-coded net energy
- Expose poker stats through backend API (PokerStatsData model)
- Update TypeScript types to include poker statistics
- Add poker stats section to React StatsPanel component

Stats tracked:
- Total games played, wins, losses, and ties
- Total energy won and lost
- Net energy transfer (color-coded green/red)
- Best hand achieved across all games