### PR TITLE
Add missing poker statistics display

### DIFF
--- a/fishtank.py
+++ b/fishtank.py
@@ -423,19 +423,22 @@ class FishTankSimulator:
             for cause, count in stats['death_causes'].items():
                 lines.append(f"  {cause}: {count}")
 
-        # Add poker stats
+        # Add poker stats (always show, even if no games played yet)
         poker = stats.get('poker_stats', {})
-        if poker and poker.get('total_games', 0) > 0:
+        if poker:
             lines.append("")
             lines.append("Poker Stats:")
-            lines.append(f"  Games: {poker['total_games']}")
-            lines.append(f"  Wins/Losses/Ties: {poker['total_wins']}/{poker['total_losses']}/{poker['total_ties']}")
-            lines.append(f"  Energy Won: {poker['total_energy_won']:.1f}")
-            lines.append(f"  Energy Lost: {poker['total_energy_lost']:.1f}")
-            net_energy = poker['net_energy']
-            net_color = (100, 255, 100) if net_energy >= 0 else (255, 100, 100)
-            lines.append((f"  Net Energy: {net_energy:+.1f}", net_color))
-            lines.append(f"  Best Hand: {poker['best_hand_name']}")
+            if poker.get('total_games', 0) == 0:
+                lines.append(("  No poker games yet (need 10+ energy & collision)", (150, 150, 150)))
+            else:
+                lines.append(f"  Games: {poker['total_games']}")
+                lines.append(f"  Wins/Losses/Ties: {poker['total_wins']}/{poker['total_losses']}/{poker['total_ties']}")
+                lines.append(f"  Energy Won: {poker['total_energy_won']:.1f}")
+                lines.append(f"  Energy Lost: {poker['total_energy_lost']:.1f}")
+                net_energy = poker['net_energy']
+                net_color = (100, 255, 100) if net_energy >= 0 else (255, 100, 100)
+                lines.append((f"  Net Energy: {net_energy:+.1f}", net_color))
+                lines.append(f"  Best Hand: {poker['best_hand_name']}")
 
         for line in lines:
             # Check if line is a tuple (text, color)

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -84,40 +84,50 @@ export function StatsPanel({ stats }: StatsPanelProps) {
         </div>
       )}
 
-      {stats.poker_stats && stats.poker_stats.total_games > 0 && (
+      {stats.poker_stats && (
         <div style={styles.section}>
           <h3 style={styles.sectionTitle}>Poker Stats</h3>
-          <div style={styles.statRow}>
-            <span style={styles.statLabel}>Games Played:</span>
-            <span style={styles.statValue}>{stats.poker_stats.total_games}</span>
-          </div>
-          <div style={styles.statRow}>
-            <span style={styles.statLabel}>W/L/T:</span>
-            <span style={styles.statValue}>
-              {stats.poker_stats.total_wins}/{stats.poker_stats.total_losses}/{stats.poker_stats.total_ties}
-            </span>
-          </div>
-          <div style={styles.statRow}>
-            <span style={styles.statLabel}>Energy Won:</span>
-            <span style={styles.statValue}>{stats.poker_stats.total_energy_won.toFixed(1)}</span>
-          </div>
-          <div style={styles.statRow}>
-            <span style={styles.statLabel}>Energy Lost:</span>
-            <span style={styles.statValue}>{stats.poker_stats.total_energy_lost.toFixed(1)}</span>
-          </div>
-          <div style={styles.statRow}>
-            <span style={styles.statLabel}>Net Energy:</span>
-            <span style={{
-              ...styles.statValue,
-              color: stats.poker_stats.net_energy >= 0 ? '#4ade80' : '#f87171'
-            }}>
-              {stats.poker_stats.net_energy >= 0 ? '+' : ''}{stats.poker_stats.net_energy.toFixed(1)}
-            </span>
-          </div>
-          <div style={styles.statRow}>
-            <span style={styles.statLabel}>Best Hand:</span>
-            <span style={styles.statValue}>{stats.poker_stats.best_hand_name}</span>
-          </div>
+          {stats.poker_stats.total_games === 0 ? (
+            <div style={styles.statRow}>
+              <span style={{...styles.statValue, fontStyle: 'italic', opacity: 0.7}}>
+                No poker games yet (fish need 10+ energy & to collide)
+              </span>
+            </div>
+          ) : (
+            <>
+              <div style={styles.statRow}>
+                <span style={styles.statLabel}>Games Played:</span>
+                <span style={styles.statValue}>{stats.poker_stats.total_games}</span>
+              </div>
+              <div style={styles.statRow}>
+                <span style={styles.statLabel}>W/L/T:</span>
+                <span style={styles.statValue}>
+                  {stats.poker_stats.total_wins}/{stats.poker_stats.total_losses}/{stats.poker_stats.total_ties}
+                </span>
+              </div>
+              <div style={styles.statRow}>
+                <span style={styles.statLabel}>Energy Won:</span>
+                <span style={styles.statValue}>{stats.poker_stats.total_energy_won.toFixed(1)}</span>
+              </div>
+              <div style={styles.statRow}>
+                <span style={styles.statLabel}>Energy Lost:</span>
+                <span style={styles.statValue}>{stats.poker_stats.total_energy_lost.toFixed(1)}</span>
+              </div>
+              <div style={styles.statRow}>
+                <span style={styles.statLabel}>Net Energy:</span>
+                <span style={{
+                  ...styles.statValue,
+                  color: stats.poker_stats.net_energy >= 0 ? '#4ade80' : '#f87171'
+                }}>
+                  {stats.poker_stats.net_energy >= 0 ? '+' : ''}{stats.poker_stats.net_energy.toFixed(1)}
+                </span>
+              </div>
+              <div style={styles.statRow}>
+                <span style={styles.statLabel}>Best Hand:</span>
+                <span style={styles.statValue}>{stats.poker_stats.best_hand_name}</span>
+              </div>
+            </>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Previously poker stats were completely hidden until the first game was played, making it unclear if the feature was even implemented. Now:

- Poker stats section is always visible in both pygame and web UI
- Shows "No poker games yet (need 10+ energy & collision)" when total_games == 0
- Displays full stats once games start happening
- Helps users understand why poker games may not be happening yet

This improves discoverability and provides better user feedback.