### PR TITLE
Fix poker game not displaying

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -31,6 +31,17 @@ class EntityData(BaseModel):
     plant_type: Optional[int] = None
 
 
+class PokerEventData(BaseModel):
+    """A single poker game event."""
+    frame: int
+    winner_id: int  # -1 for tie
+    loser_id: int
+    winner_hand: str
+    loser_hand: str
+    energy_transferred: float
+    message: str
+
+
 class PokerStatsData(BaseModel):
     """Poker game statistics."""
     total_games: int
@@ -67,6 +78,7 @@ class SimulationUpdate(BaseModel):
     elapsed_time: int
     entities: List[EntityData]
     stats: StatsData
+    poker_events: List[PokerEventData] = []
 
 
 class Command(BaseModel):

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -14,7 +14,7 @@ from simulation_engine import SimulationEngine
 from core import entities
 from core.behavior_algorithms import get_algorithm_index
 from core.constants import SCREEN_WIDTH, SCREEN_HEIGHT
-from models import EntityData, StatsData, SimulationUpdate, PokerStatsData
+from models import EntityData, StatsData, SimulationUpdate, PokerStatsData, PokerEventData
 
 
 class SimulationRunner:
@@ -107,11 +107,26 @@ class SimulationRunner:
                 poker_stats=poker_stats_data
             )
 
+            # Get recent poker events
+            poker_events = []
+            recent_events = self.engine.get_recent_poker_events(max_age_frames=180)
+            for event in recent_events:
+                poker_events.append(PokerEventData(
+                    frame=event['frame'],
+                    winner_id=event['winner_id'],
+                    loser_id=event['loser_id'],
+                    winner_hand=event['winner_hand'],
+                    loser_hand=event['loser_hand'],
+                    energy_transferred=event['energy_transferred'],
+                    message=event['message']
+                ))
+
             return SimulationUpdate(
                 frame=self.engine.frame_count,
                 elapsed_time=self.engine.elapsed_time if hasattr(self.engine, 'elapsed_time') else self.engine.frame_count * 33,
                 entities=entities_data,
-                stats=stats_data
+                stats=stats_data,
+                poker_events=poker_events
             )
 
     def _entity_to_data(self, entity: entities.Agent) -> Optional[EntityData]:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { useWebSocket } from './hooks/useWebSocket';
 import { Canvas } from './components/Canvas';
 import { ControlPanel } from './components/ControlPanel';
 import { StatsPanel } from './components/StatsPanel';
+import PokerEvents from './components/PokerEvents';
 import './App.css';
 
 function App() {
@@ -23,6 +24,10 @@ function App() {
       <main className="main">
         <div className="canvas-section">
           <Canvas state={state} width={800} height={600} />
+          <PokerEvents
+            events={state?.poker_events ?? []}
+            currentFrame={state?.frame ?? 0}
+          />
         </div>
 
         <div className="sidebar">

--- a/frontend/src/components/PokerEvents.tsx
+++ b/frontend/src/components/PokerEvents.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+interface PokerEvent {
+  frame: number;
+  winner_id: number;
+  loser_id: number;
+  winner_hand: string;
+  loser_hand: string;
+  energy_transferred: number;
+  message: string;
+}
+
+interface PokerEventsProps {
+  events: PokerEvent[];
+  currentFrame: number;
+}
+
+const PokerEvents: React.FC<PokerEventsProps> = ({ events, currentFrame }) => {
+  if (events.length === 0) {
+    return null;
+  }
+
+  const styles = {
+    container: {
+      position: 'fixed' as const,
+      bottom: '20px',
+      right: '20px',
+      width: '400px',
+      maxHeight: '250px',
+      overflowY: 'auto' as const,
+      pointerEvents: 'none' as const,
+      zIndex: 1000,
+    },
+    event: (age: number) => ({
+      backgroundColor: 'rgba(20, 20, 40, 0.9)',
+      padding: '8px 12px',
+      marginBottom: '5px',
+      borderRadius: '4px',
+      fontSize: '13px',
+      color: age > 120 ? `rgba(200, 255, 150, ${Math.max(0.3, 1 - (age - 120) / 60)})` : 'rgb(200, 255, 150)',
+      transition: 'opacity 0.5s',
+      border: '1px solid rgba(100, 255, 100, 0.3)',
+      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.3)',
+    }),
+    tieEvent: (age: number) => ({
+      backgroundColor: 'rgba(20, 20, 40, 0.9)',
+      padding: '8px 12px',
+      marginBottom: '5px',
+      borderRadius: '4px',
+      fontSize: '13px',
+      color: age > 120 ? `rgba(255, 255, 100, ${Math.max(0.3, 1 - (age - 120) / 60)})` : 'rgb(255, 255, 100)',
+      transition: 'opacity 0.5s',
+      border: '1px solid rgba(255, 255, 100, 0.3)',
+      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.3)',
+    }),
+  };
+
+  return (
+    <div style={styles.container}>
+      {events.slice().reverse().map((event, index) => {
+        const age = currentFrame - event.frame;
+        const isTie = event.winner_id === -1;
+        return (
+          <div
+            key={`${event.frame}-${index}`}
+            style={isTie ? styles.tieEvent(age) : styles.event(age)}
+          >
+            {event.message}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PokerEvents;

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -32,6 +32,16 @@ export interface EntityData {
   plant_type?: number;
 }
 
+export interface PokerEventData {
+  frame: number;
+  winner_id: number;  // -1 for tie
+  loser_id: number;
+  winner_hand: string;
+  loser_hand: string;
+  energy_transferred: number;
+  message: string;
+}
+
 export interface PokerStatsData {
   total_games: number;
   total_wins: number;
@@ -65,6 +75,7 @@ export interface SimulationUpdate {
   elapsed_time: number;
   entities: EntityData[];
   stats: StatsData;
+  poker_events: PokerEventData[];
 }
 
 export interface Command {


### PR DESCRIPTION
Users can now see poker games happening in real-time with detailed notifications showing the winner, hands, and energy transferred.

Changes:
- Pygame version: Added notification system in bottom-right corner
  - Shows recent poker games with fade-out effect
  - Color-coded: green for wins, yellow for ties
  - Auto-expires after 6 seconds

- React version: Created PokerEvents component
  - Displays poker events received via WebSocket
  - Positioned in bottom-right with fade animations
  - Shows winner, hands played, and energy changes

- Backend: Enhanced simulation engine to track poker events
  - Added poker_events list to track recent games
  - Events sent to frontend via WebSocket
  - Includes frame, hands, winner, and energy data

This makes the poker feature visible and engaging rather than just being tracked in background statistics.