### PR TITLE
Improve tank UI styling and plant placement

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,12 +5,12 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #0f172a;
+  background: radial-gradient(circle at top, #132b45, #050812 65%);
   color: #e2e8f0;
 }
 
@@ -21,10 +21,11 @@ body {
 }
 
 .header {
-  padding: 24px;
-  background: linear-gradient(135deg, #1e3a8a 0%, #1e293b 100%);
-  border-bottom: 2px solid #334155;
+  padding: 32px 24px 24px;
+  background: linear-gradient(125deg, rgba(14, 39, 80, 0.95), rgba(3, 11, 24, 0.9));
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
   text-align: center;
+  box-shadow: 0 20px 45px rgba(2, 6, 23, 0.8);
 }
 
 .title {
@@ -42,9 +43,9 @@ body {
 .main {
   flex: 1;
   display: flex;
-  gap: 24px;
-  padding: 24px;
-  max-width: 1400px;
+  gap: 32px;
+  padding: 32px clamp(16px, 5vw, 48px);
+  max-width: 1600px;
   margin: 0 auto;
   width: 100%;
 }
@@ -52,15 +53,102 @@ body {
 .canvas-section {
   flex: 1;
   display: flex;
-  align-items: flex-start;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  position: relative;
+}
+
+.canvas-wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 820px;
+  padding: 24px;
+  border-radius: 32px;
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.95));
+  box-shadow: 0 45px 80px rgba(2, 6, 23, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  overflow: hidden;
+}
+
+.canvas-wrapper canvas {
+  width: 100%;
+  height: auto;
+  border: 2px solid rgba(94, 234, 212, 0.2);
+  border-radius: 18px;
+  background: transparent;
+  box-shadow: inset 0 0 50px rgba(15, 118, 168, 0.35);
+}
+
+.canvas-glow {
+  position: absolute;
+  inset: 30px;
+  border-radius: 26px;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(34, 211, 238, 0.25), transparent 60%);
+  filter: blur(25px);
+  opacity: 0.7;
+}
+
+.canvas-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.canvas-label {
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 4px;
+}
+
+.canvas-value {
+  font-size: clamp(18px, 3vw, 26px);
+  font-weight: 700;
+  color: #e0f2fe;
+}
+
+.canvas-value span {
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.7);
+  margin-left: 6px;
+}
+
+.canvas-status {
+  font-weight: 600;
+  font-size: 18px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  border: 1px solid transparent;
+}
+
+.canvas-status.online {
+  color: #4ade80;
+  border-color: rgba(74, 222, 128, 0.5);
+  background: rgba(22, 163, 74, 0.1);
+}
+
+.canvas-status.offline {
+  color: #fbbf24;
+  border-color: rgba(251, 191, 36, 0.4);
+  background: rgba(120, 53, 15, 0.15);
 }
 
 .sidebar {
   width: 320px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 24px;
+  position: sticky;
+  top: 32px;
+  align-self: flex-start;
 }
 
 .footer {
@@ -80,13 +168,11 @@ body {
 
   .sidebar {
     width: 100%;
-    flex-direction: row;
-    flex-wrap: wrap;
+    position: static;
   }
 
-  .sidebar > div {
-    flex: 1;
-    min-width: 280px;
+  .canvas-meta {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   }
 }
 
@@ -109,6 +195,10 @@ body {
 
   .sidebar {
     flex-direction: column;
+  }
+
+  .canvas-wrapper {
+    padding: 16px;
   }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,32 @@ function App() {
 
       <main className="main">
         <div className="canvas-section">
-          <Canvas state={state} width={800} height={600} />
+          <div className="canvas-wrapper">
+            <div className="canvas-meta">
+              <div>
+                <p className="canvas-label">Simulation</p>
+                <p className="canvas-value">
+                  {state?.stats?.frame ? state.stats.frame.toLocaleString() : '—'}{' '}
+                  <span>frames</span>
+                </p>
+              </div>
+              <div>
+                <p className="canvas-label">Population</p>
+                <p className="canvas-value">
+                  {state?.stats?.fish_count ?? 0}
+                  <span> fish</span>
+                </p>
+              </div>
+              <div>
+                <p className="canvas-label">Status</p>
+                <p className={`canvas-status ${isConnected ? 'online' : 'offline'}`}>
+                  {isConnected ? 'Connected' : 'Waiting'}
+                </p>
+              </div>
+            </div>
+            <Canvas state={state} width={800} height={600} />
+            <div className="canvas-glow" aria-hidden />
+          </div>
           <PokerEvents
             events={state?.poker_events ?? []}
             currentFrame={state?.frame ?? 0}

--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -50,15 +50,6 @@ export function Canvas({ state, width = 800, height = 600 }: CanvasProps) {
   }, [state, width, height, imagesLoaded]);
 
   return (
-    <canvas
-      ref={canvasRef}
-      width={width}
-      height={height}
-      style={{
-        border: '2px solid #333',
-        borderRadius: '8px',
-        backgroundColor: '#1a4d6d',
-      }}
-    />
+    <canvas ref={canvasRef} width={width} height={height} className="tank-canvas" />
   );
 }

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -103,10 +103,12 @@ export function ControlPanel({ onCommand, isConnected }: ControlPanelProps) {
 
 const styles = {
   container: {
-    padding: '20px',
-    backgroundColor: '#1e293b',
-    borderRadius: '8px',
+    padding: '24px',
+    background: 'linear-gradient(145deg, rgba(30,41,59,0.92), rgba(15,23,42,0.95))',
+    borderRadius: '20px',
     color: '#e2e8f0',
+    border: '1px solid rgba(148,163,184,0.18)',
+    boxShadow: '0 35px 55px rgba(2,6,23,0.65)',
   },
   title: {
     margin: '0 0 16px 0',
@@ -140,6 +142,7 @@ const styles = {
     borderRadius: '6px',
     cursor: 'pointer',
     transition: 'all 0.2s',
+    boxShadow: '0 10px 25px rgba(15,23,42,0.45)',
   },
   buttonPrimary: {
     backgroundColor: '#3b82f6',

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -162,10 +162,12 @@ export function StatsPanel({ stats }: StatsPanelProps) {
 
 const styles = {
   container: {
-    padding: '20px',
-    backgroundColor: '#1e293b',
-    borderRadius: '8px',
+    padding: '24px',
+    background: 'linear-gradient(145deg, rgba(30,41,59,0.92), rgba(15,23,42,0.95))',
+    borderRadius: '20px',
     color: '#e2e8f0',
+    border: '1px solid rgba(148,163,184,0.18)',
+    boxShadow: '0 35px 55px rgba(2,6,23,0.65)',
   },
   title: {
     margin: '0 0 16px 0',
@@ -204,8 +206,9 @@ const styles = {
   legend: {
     marginTop: '24px',
     padding: '16px',
-    backgroundColor: '#0f172a',
-    borderRadius: '6px',
+    backgroundColor: 'rgba(15,23,42,0.85)',
+    borderRadius: '12px',
+    border: '1px solid rgba(148,163,184,0.1)',
   },
   legendTitle: {
     margin: '0 0 12px 0',

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -52,6 +52,7 @@ export interface PokerStatsData {
   net_energy: number;
   best_hand_rank: number;
   best_hand_name: string;
+  total_house_cuts?: number;
 }
 
 export interface StatsData {

--- a/frontend/src/utils/renderer.ts
+++ b/frontend/src/utils/renderer.ts
@@ -36,9 +36,40 @@ export class Renderer {
   }
 
   clear(width: number, height: number) {
-    // Clear with ocean blue background (matching pygame)
-    this.ctx.fillStyle = '#1a4d6d';
+    // Create subtle ocean gradient
+    const gradient = this.ctx.createLinearGradient(0, 0, 0, height);
+    gradient.addColorStop(0, '#04233d');
+    gradient.addColorStop(0.45, '#0b4161');
+    gradient.addColorStop(1, '#0f202c');
+    this.ctx.fillStyle = gradient;
     this.ctx.fillRect(0, 0, width, height);
+
+    // Soft light rays for depth
+    this.ctx.save();
+    this.ctx.globalAlpha = 0.12;
+    for (let i = 0; i < 3; i += 1) {
+      this.ctx.beginPath();
+      this.ctx.moveTo((width / 3) * i + 80, 0);
+      this.ctx.lineTo((width / 3) * i + 200, 0);
+      this.ctx.lineTo((width / 3) * i, height);
+      this.ctx.closePath();
+      this.ctx.fillStyle = '#3dd5ff';
+      this.ctx.fill();
+    }
+    this.ctx.restore();
+
+    // Draw seabed so plants have a home
+    const seabedHeight = Math.max(50, height * 0.12);
+    const seabedGradient = this.ctx.createLinearGradient(
+      0,
+      height - seabedHeight,
+      0,
+      height
+    );
+    seabedGradient.addColorStop(0, 'rgba(227, 188, 117, 0.2)');
+    seabedGradient.addColorStop(1, 'rgba(195, 161, 90, 0.35)');
+    this.ctx.fillStyle = seabedGradient;
+    this.ctx.fillRect(0, height - seabedHeight, width, seabedHeight);
   }
 
   renderEntity(entity: EntityData, elapsedTime: number) {
@@ -141,7 +172,12 @@ export class Renderer {
     const swayAngle = Math.sin(elapsedTime * swaySpeed) * swayRange;
 
     ctx.save();
-    ctx.translate(x + width / 2, y + height);
+    const canvasHeight = ctx.canvas.height;
+    const seabedOffset = Math.max(40, canvasHeight * 0.08);
+    const restingY = canvasHeight - seabedOffset;
+    // Allow slight offset so multiple plants feel organic
+    const swayOffset = Math.sin((x + y) * 0.01) * 6;
+    ctx.translate(x + width / 2 + swayOffset, restingY);
     ctx.rotate((swayAngle * Math.PI) / 180);
     ctx.drawImage(image, -width / 2, -height, width, height);
     ctx.restore();


### PR DESCRIPTION
## Summary
- refresh the React layout with a glassy canvas frame, sidebar cards, and status badges for a more polished look
- anchor plants to the seabed and repaint the canvas background with gradients so vegetation always rests on the bottom
- expose optional poker house cut stats so the build succeeds with the richer panel

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a426894848331807aefb83d570c5a)