### PR TITLE
Fix poker fish not dying bug

### DIFF
--- a/fishtank.py
+++ b/fishtank.py
@@ -208,6 +208,37 @@ class FishTankSimulator:
                             # Add notification for successful poker game
                             self.add_poker_notification(poker)
 
+                            # Check if either fish died from poker
+                            if fish.is_dead():
+                                if self.ecosystem is not None:
+                                    algorithm_id = None
+                                    if fish.genome.behavior_algorithm is not None:
+                                        algorithm_id = get_algorithm_index(fish.genome.behavior_algorithm)
+                                    self.ecosystem.record_death(
+                                        fish.fish_id,
+                                        fish.generation,
+                                        fish.age,
+                                        fish.get_death_cause(),
+                                        fish.genome,
+                                        algorithm_id=algorithm_id
+                                    )
+                                fish.kill()
+
+                            if collision_sprite.is_dead():
+                                if self.ecosystem is not None:
+                                    algorithm_id = None
+                                    if collision_sprite.genome.behavior_algorithm is not None:
+                                        algorithm_id = get_algorithm_index(collision_sprite.genome.behavior_algorithm)
+                                    self.ecosystem.record_death(
+                                        collision_sprite.fish_id,
+                                        collision_sprite.generation,
+                                        collision_sprite.age,
+                                        collision_sprite.get_death_cause(),
+                                        collision_sprite.genome,
+                                        algorithm_id=algorithm_id
+                                    )
+                                collision_sprite.kill()
+
     def handle_food_collisions(self) -> None:
         """Handle collisions involving food."""
         # Iterate over a copy to safely remove sprites during iteration

--- a/simulation_engine.py
+++ b/simulation_engine.py
@@ -246,6 +246,48 @@ class SimulationEngine:
                             # Track poker event
                             self.add_poker_event(poker)
 
+                            # Check if either fish died from poker
+                            fish_to_remove = []
+
+                            if fish.is_dead() and fish in self.entities_list:
+                                if self.ecosystem is not None:
+                                    algorithm_id = None
+                                    if fish.genome.behavior_algorithm is not None:
+                                        algorithm_id = get_algorithm_index(fish.genome.behavior_algorithm)
+                                    self.ecosystem.record_death(
+                                        fish.fish_id,
+                                        fish.generation,
+                                        fish.age,
+                                        fish.get_death_cause(),
+                                        fish.genome,
+                                        algorithm_id=algorithm_id
+                                    )
+                                fish_to_remove.append(fish)
+
+                            if other.is_dead() and other in self.entities_list:
+                                if self.ecosystem is not None:
+                                    algorithm_id = None
+                                    if other.genome.behavior_algorithm is not None:
+                                        algorithm_id = get_algorithm_index(other.genome.behavior_algorithm)
+                                    self.ecosystem.record_death(
+                                        other.fish_id,
+                                        other.generation,
+                                        other.age,
+                                        other.get_death_cause(),
+                                        other.genome,
+                                        algorithm_id=algorithm_id
+                                    )
+                                fish_to_remove.append(other)
+
+                            # Remove dead fish
+                            for dead_fish in fish_to_remove:
+                                if dead_fish in self.entities_list:
+                                    self.entities_list.remove(dead_fish)
+
+                            # Break if current fish died
+                            if fish in fish_to_remove:
+                                break
+
     def handle_food_collisions(self) -> None:
         """Handle collisions involving food."""
         food_list = [e for e in self.entities_list if isinstance(e, entities.Food)]


### PR DESCRIPTION
Previously, fish that lost all their energy during poker games would remain in the simulation as "zombies" until the next frame's update cycle. This caused the reported behavior where fish would clump and play poker but not die properly.

The fix adds immediate death checks after each poker game completes:
- Check if either fish died (energy <= 0) after the poker game
- Record the death in the ecosystem with proper cause attribution
- Remove dead fish from the entities list immediately
- Break from collision loop if the current fish died

Applied to both simulation_engine.py (headless mode) and fishtank.py (graphical mode) to maintain parity.