### PR TITLE
Balance game economy difficulty

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -34,7 +34,7 @@ PLANT_SWAY_SPEED = 0.0005
 FOOD_SINK_ACCELERATION = 0.01
 
 # Automatic food spawning
-AUTO_FOOD_SPAWN_RATE = 60  # Spawn food every 2 seconds (60 frames at 30fps) - REDUCED for increased difficulty
+AUTO_FOOD_SPAWN_RATE = 120  # Spawn food every 4 seconds (120 frames at 30fps) - REDUCED for increased difficulty
 AUTO_FOOD_ENABLED = True  # Enable/disable automatic food spawning
 
 # Food type definitions with nutrient properties
@@ -42,7 +42,7 @@ FOOD_TYPES = {
     'algae': {
         'name': 'Algae Flake',
         'files': ['food_algae1.png', 'food_algae2.png'],
-        'energy': 30.0,  # Moderate energy - increased 50% for sustainability
+        'energy': 20.0,  # Low energy - basic food source
         'rarity': 0.35,  # 35% spawn rate
         'sink_multiplier': 0.8,  # Sinks slower (lighter)
         'stationary': False,
@@ -50,7 +50,7 @@ FOOD_TYPES = {
     'protein': {
         'name': 'Protein Flake',
         'files': ['food_protein1.png', 'food_protein2.png'],
-        'energy': 52.5,  # High energy - increased 50% for sustainability
+        'energy': 35.0,  # Good energy - valuable food
         'rarity': 0.25,  # 25% spawn rate
         'sink_multiplier': 1.2,  # Sinks faster (heavier)
         'stationary': False,
@@ -58,7 +58,7 @@ FOOD_TYPES = {
     'vitamin': {
         'name': 'Vitamin Flake',
         'files': ['food_vitamin1.png', 'food_vitamin2.png'],
-        'energy': 37.5,  # Moderate energy - increased 50% for sustainability
+        'energy': 25.0,  # Moderate energy
         'rarity': 0.20,  # 20% spawn rate
         'sink_multiplier': 0.9,  # Sinks slightly slower
         'stationary': False,
@@ -66,7 +66,7 @@ FOOD_TYPES = {
     'energy': {
         'name': 'Energy Flake',
         'files': ['food_energy1.png', 'food_energy2.png'],
-        'energy': 45.0,  # High energy - increased 50% for sustainability
+        'energy': 30.0,  # Good energy
         'rarity': 0.15,  # 15% spawn rate
         'sink_multiplier': 1.0,  # Normal sink rate
         'stationary': False,
@@ -74,7 +74,7 @@ FOOD_TYPES = {
     'rare': {
         'name': 'Rainbow Flake',
         'files': ['food_rare1.png', 'food_rare2.png'],
-        'energy': 75.0,  # Very high energy - increased 50% for sustainability
+        'energy': 50.0,  # High energy - rare treat
         'rarity': 0.05,  # 5% spawn rate (rare)
         'sink_multiplier': 1.1,  # Sinks bit faster
         'stationary': False,
@@ -82,7 +82,7 @@ FOOD_TYPES = {
     'nectar': {
         'name': 'Plant Nectar',
         'files': ['food_vitamin1.png', 'food_vitamin2.png'],
-        'energy': 60.0,  # Rewarding snack - increased 50% for sustainability
+        'energy': 40.0,  # Rewarding stationary food
         'rarity': 0.15,  # Used for plant-only spawn weighting
         'sink_multiplier': 0.0,  # Remains in place
         'stationary': True,

--- a/core/entities.py
+++ b/core/entities.py
@@ -187,12 +187,12 @@ class Fish(Agent):
 
     # Energy constants (DIFFICULTY INCREASED - survival is more challenging)
     BASE_MAX_ENERGY = 100.0
-    ENERGY_FROM_FOOD = 40.0  # More energy from food
-    EXISTENCE_ENERGY_COST = 0.01  # Small cost just for being alive (not affected by genes)
-    BASE_METABOLISM = 0.030  # Increased from 0.018 - fish burn energy faster
-    MOVEMENT_ENERGY_COST = 0.015  # Increased from 0.008 - movement is expensive
+    ENERGY_FROM_FOOD = 1.0  # Energy from food is determined by food type in constants.py
+    EXISTENCE_ENERGY_COST = 0.02  # Increased cost just for being alive
+    BASE_METABOLISM = 0.045  # Increased from 0.030 - fish burn energy faster
+    MOVEMENT_ENERGY_COST = 0.025  # Increased from 0.015 - movement is expensive
     SHARP_TURN_DOT_THRESHOLD = -0.85  # Threshold for detecting near-180 degree turns
-    SHARP_TURN_ENERGY_COST = 0.05  # Increased from 0.03 - sharp turns are costly
+    SHARP_TURN_ENERGY_COST = 0.08  # Increased from 0.05 - sharp turns are costly
 
     # Predator encounter tracking
     PREDATOR_ENCOUNTER_WINDOW = 150  # 5 seconds - recent conflict window for death attribution
@@ -239,7 +239,7 @@ class Fish(Agent):
 
         # Energy & metabolism
         self.max_energy: float = self.BASE_MAX_ENERGY * self.genome.max_energy
-        self.energy: float = self.max_energy  # Start with full energy
+        self.energy: float = self.max_energy * 0.5  # Start with 50% energy - harder survival
 
         # Predator tracking (for death attribution)
         self.last_predator_encounter_age: int = -1000  # Age when last encountered a predator
@@ -632,8 +632,8 @@ class Plant(Agent):
         current_food_count: Current number of food items from this plant
     """
 
-    BASE_FOOD_PRODUCTION_RATE = 60  # 2 seconds at 30fps (IMPROVED from 3s for better food supply)
-    MAX_FOOD_CAPACITY = 15  # Maximum food items per plant (INCREASED from 10 to support population)
+    BASE_FOOD_PRODUCTION_RATE = 120  # 4 seconds at 30fps - REDUCED production for harder survival
+    MAX_FOOD_CAPACITY = 10  # Maximum food items per plant - REDUCED for scarcity
     STATIONARY_FOOD_CHANCE = 0.35  # Increased from 0.25 to grow more stationary nectar
     STATIONARY_FOOD_TYPE = 'nectar'
 


### PR DESCRIPTION
Economic changes to increase difficulty:

Food spawning:
- Auto-spawn rate: 60 → 120 frames (2s → 4s)
- Plant production rate: 60 → 120 frames
- Plant max capacity: 15 → 10 items

Food energy values (reduced ~33%):
- Algae: 30 → 20 energy
- Protein: 52.5 → 35 energy
- Vitamin: 37.5 → 25 energy
- Energy flake: 45 → 30 energy
- Rare: 75 → 50 energy
- Nectar: 60 → 40 energy

Energy costs (increased ~50-60%):
- Existence: 0.01 → 0.02/frame
- Metabolism: 0.030 → 0.045/frame
- Movement: 0.015 → 0.025/frame
- Sharp turns: 0.05 → 0.08/frame

Fish starting conditions:
- Initial energy: 100% → 50% of max

These changes create real survival pressure by reducing food availability and increasing energy demands.