### PR TITLE
Increase fish reproduction rate for evolution

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -34,7 +34,7 @@ PLANT_SWAY_SPEED = 0.0005
 FOOD_SINK_ACCELERATION = 0.01
 
 # Automatic food spawning
-AUTO_FOOD_SPAWN_RATE = 120  # Spawn food every 4 seconds (120 frames at 30fps) - REDUCED for increased difficulty
+AUTO_FOOD_SPAWN_RATE = 90  # Spawn food every 3 seconds (90 frames at 30fps) - Increased for better fish survival
 AUTO_FOOD_ENABLED = True  # Enable/disable automatic food spawning
 
 # Food type definitions with nutrient properties

--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -146,7 +146,7 @@ class EcosystemManager:
         generation_stats: Statistics per generation
     """
 
-    def __init__(self, max_population: int = 50):
+    def __init__(self, max_population: int = 75):
         """Initialize the ecosystem manager.
 
         Args:

--- a/core/fish/reproduction_component.py
+++ b/core/fish/reproduction_component.py
@@ -30,8 +30,8 @@ class ReproductionComponent:
     """
 
     # Reproduction constants
-    REPRODUCTION_ENERGY_THRESHOLD = 35.0  # Minimum energy to reproduce
-    REPRODUCTION_COOLDOWN = 360  # 12 seconds (reduced for better breeding)
+    REPRODUCTION_ENERGY_THRESHOLD = 25.0  # Minimum energy to reproduce (reduced for more breeding)
+    REPRODUCTION_COOLDOWN = 240  # 8 seconds (reduced for better breeding)
     PREGNANCY_DURATION = 300  # 10 seconds
     MATING_DISTANCE = 60.0  # Maximum distance for mating
     REPRODUCTION_ENERGY_COST = 10.0  # Energy cost for mating


### PR DESCRIPTION
Adjusted key reproduction and resource parameters to allow fish to reproduce more frequently and sustain populations for evolution:

Changes:
- Reduced REPRODUCTION_ENERGY_THRESHOLD from 35 to 25 energy (Fish can now reproduce at lower energy levels)
- Reduced REPRODUCTION_COOLDOWN from 360 to 240 frames (12s to 8s) (Fish can mate more frequently)
- Increased food spawn rate from 120 to 90 frames (4s to 3s) (More food available for fish to maintain energy)
- Raised default ecosystem carrying capacity from 50 to 75 fish (Allows larger populations for genetic diversity)

These changes address the core issue where fish struggled to maintain the high energy threshold needed for reproduction, combined with long cooldowns that prevented evolutionary selection from occurring at a meaningful pace.