### PR TITLE
Fix undefined predator_nearby variable error

### DIFF
--- a/core/algorithms/food_seeking.py
+++ b/core/algorithms/food_seeking.py
@@ -171,6 +171,7 @@ class EnergyAwareFoodSeeker(BehaviorAlgorithm):
         # Check for predators - even urgent fish should avoid immediate danger
         nearest_predator = self._find_nearest(fish, Crab)
         predator_distance = (nearest_predator.pos - fish.pos).length() if nearest_predator else 999
+        predator_nearby = predator_distance < 100  # Define predator proximity threshold
 
         # IMPROVEMENT: Critical energy mode - must find food NOW
         if is_critical:


### PR DESCRIPTION
Added missing predator_nearby boolean variable definition in the EnergyAwareFoodSeeker.execute() method. The variable is set based on a 100-pixel proximity threshold, consistent with other algorithms.