### PR TITLE
Fix poker game economics to be negative sum

### DIFF
--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -407,14 +407,23 @@ class EcosystemManager:
         """
         return sum(stats.population for stats in self.generation_stats.values())
 
-    def get_summary_stats(self) -> Dict[str, any]:
+    def get_summary_stats(self, entities: Optional[List] = None) -> Dict[str, any]:
         """Get summary statistics for the ecosystem.
+
+        Args:
+            entities: Optional list of entities to calculate total energy from
 
         Returns:
             Dictionary with key ecosystem metrics
         """
         total_pop = self.get_total_population()
         poker_summary = self.get_poker_stats_summary()
+
+        # Calculate total energy if entities provided
+        total_energy = 0.0
+        if entities is not None:
+            from core.entities import Fish
+            total_energy = sum(e.energy for e in entities if isinstance(e, Fish))
 
         return {
             'total_population': total_pop,
@@ -429,6 +438,7 @@ class EcosystemManager:
             'death_causes': dict(self.death_causes),
             'generations_alive': len([g for g, s in self.generation_stats.items() if s.population > 0]),
             'poker_stats': poker_summary,
+            'total_energy': total_energy,
         }
 
     def get_poker_stats_summary(self) -> Dict[str, any]:

--- a/fishtank.py
+++ b/fishtank.py
@@ -251,7 +251,7 @@ class FishTankSimulator(BaseSimulator):
                     self.ui_renderer.draw_health_bar(sprite)
 
             # Draw stats panel
-            self.ui_renderer.draw_stats_panel(self.ecosystem, self.time_system, self.paused)
+            self.ui_renderer.draw_stats_panel(self.ecosystem, self.time_system, self.paused, self.get_all_entities())
 
         # Draw poker notifications (always visible)
         if self.ui_renderer is not None:
@@ -334,7 +334,7 @@ class FishTankSimulator(BaseSimulator):
             print("\n" + "=" * 60)
             print("SIMULATION ENDED - Final Statistics")
             print("=" * 60)
-            stats = self.ecosystem.get_summary_stats()
+            stats = self.ecosystem.get_summary_stats(self.get_all_entities())
             for key, value in stats.items():
                 print(f"  {key}: {value}")
             print("=" * 60)

--- a/rendering/ui_renderer.py
+++ b/rendering/ui_renderer.py
@@ -91,22 +91,23 @@ class UIRenderer:
 
                 self.screen.blit(text_surface, (text_x, text_y))
 
-    def draw_stats_panel(self, ecosystem: Any, time_system: Any, paused: bool) -> None:
+    def draw_stats_panel(self, ecosystem: Any, time_system: Any, paused: bool, entities: Optional[List[Any]] = None) -> None:
         """Draw statistics panel showing ecosystem data.
 
         Args:
             ecosystem: Ecosystem manager with statistics
             time_system: Time system for day/night cycle
             paused: Whether the simulation is paused
+            entities: Optional list of entities for energy calculation
         """
-        # Semi-transparent background (larger to fit poker stats)
-        panel_surface = pygame.Surface((280, 300))
+        # Semi-transparent background (larger to fit poker stats + energy stat)
+        panel_surface = pygame.Surface((280, 320))
         panel_surface.set_alpha(200)
         panel_surface.fill((20, 20, 40))
         self.screen.blit(panel_surface, (10, 10))
 
         # Get stats
-        stats = ecosystem.get_summary_stats()
+        stats = ecosystem.get_summary_stats(entities)
         time_str = time_system.get_time_string()
 
         # Render text lines
@@ -115,6 +116,7 @@ class UIRenderer:
             f"Time: {time_str}",
             f"Population: {stats['total_population']}/{ecosystem.max_population}",
             f"Generation: {stats['current_generation']}",
+            f"Total Energy: {stats.get('total_energy', 0):.1f}",
             f"Births: {stats['total_births']}",
             f"Deaths: {stats['total_deaths']}",
             f"Capacity: {stats['capacity_usage']}",

--- a/simulation_engine.py
+++ b/simulation_engine.py
@@ -218,7 +218,7 @@ class SimulationEngine(BaseSimulator):
         if self.ecosystem is None:
             return {}
 
-        stats = self.ecosystem.get_summary_stats()
+        stats = self.ecosystem.get_summary_stats(self.get_all_entities())
         stats['frame_count'] = self.frame_count
         stats['time_string'] = self.time_system.get_time_string()
         stats['elapsed_real_time'] = time.time() - self.start_time


### PR DESCRIPTION
Changes:
- Add total_energy field to ecosystem statistics that sums energy from all fish
- Update UI to display total energy stat in the stats panel
- Pass entities list to get_summary_stats() in all callers
- Increase stats panel height to accommodate new stat

This helps monitor the energy economy and verify that poker's 5% house cut is working correctly as a less-than-zero-sum game.

Related to poker economics verification.