### PR TITLE
Fix Net Energy value stuck at negative

### DIFF
--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -112,7 +112,7 @@ class PokerStats:
 
     def get_net_energy(self) -> float:
         """Calculate net energy from poker."""
-        return self.total_energy_won - self.total_energy_lost
+        return self.total_energy_won - self.total_energy_lost - self.total_house_cuts
 
 
 @dataclass
@@ -477,7 +477,7 @@ class EcosystemManager:
             'total_energy_won': total_energy_won,
             'total_energy_lost': total_energy_lost,
             'total_house_cuts': total_house_cuts,
-            'net_energy': total_energy_won - total_energy_lost,
+            'net_energy': total_energy_won - total_energy_lost - total_house_cuts,
             'best_hand_rank': best_hand_rank,
             'best_hand_name': best_hand_name,
         }


### PR DESCRIPTION
The Net Energy display was showing incorrect values because it wasn't subtracting house cuts from the calculation. Each poker game takes a 5% house cut, which was being tracked but not included in the net energy formula.

Fixed in two locations:
- PokerStats.get_net_energy() method
- EcosystemManager.get_poker_stats_summary() return value

Net Energy now correctly calculates as:
energy_won - energy_lost - house_cuts