### PR TITLE
Fix poker events layout

### DIFF
--- a/frontend/src/components/PokerEvents.css
+++ b/frontend/src/components/PokerEvents.css
@@ -1,0 +1,70 @@
+.poker-events {
+  width: 100%;
+  max-width: 820px;
+  padding: 20px 24px;
+  border-radius: 24px;
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.95));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 25px 45px rgba(2, 6, 23, 0.75);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.poker-events__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.poker-events__header h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.poker-events__header span {
+  font-size: 13px;
+  color: #94a3b8;
+}
+
+.poker-events__list {
+  max-height: 240px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-right: 4px;
+}
+
+.poker-events__empty {
+  font-size: 14px;
+  color: #cbd5f5;
+  padding: 12px 0 4px;
+  text-align: center;
+  opacity: 0.8;
+}
+
+.poker-events__item {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  background: rgba(21, 128, 61, 0.12);
+  font-size: 14px;
+  line-height: 1.4;
+  color: #bbf7d0;
+  transition: opacity 0.5s ease;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}
+
+.poker-events__item.tie {
+  border-color: rgba(250, 204, 21, 0.5);
+  background: rgba(202, 138, 4, 0.12);
+  color: #fef9c3;
+}
+
+@media (max-width: 768px) {
+  .poker-events {
+    padding: 16px;
+  }
+}

--- a/frontend/src/components/PokerEvents.tsx
+++ b/frontend/src/components/PokerEvents.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import './PokerEvents.css';
 
 interface PokerEvent {
   frame: number;
@@ -16,60 +17,37 @@ interface PokerEventsProps {
 }
 
 const PokerEvents: React.FC<PokerEventsProps> = ({ events, currentFrame }) => {
-  if (events.length === 0) {
-    return null;
-  }
-
-  const styles = {
-    container: {
-      position: 'fixed' as const,
-      bottom: '20px',
-      right: '20px',
-      width: '400px',
-      maxHeight: '250px',
-      overflowY: 'auto' as const,
-      pointerEvents: 'none' as const,
-      zIndex: 1000,
-    },
-    event: (age: number) => ({
-      backgroundColor: 'rgba(20, 20, 40, 0.9)',
-      padding: '8px 12px',
-      marginBottom: '5px',
-      borderRadius: '4px',
-      fontSize: '13px',
-      color: age > 120 ? `rgba(200, 255, 150, ${Math.max(0.3, 1 - (age - 120) / 60)})` : 'rgb(200, 255, 150)',
-      transition: 'opacity 0.5s',
-      border: '1px solid rgba(100, 255, 100, 0.3)',
-      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.3)',
-    }),
-    tieEvent: (age: number) => ({
-      backgroundColor: 'rgba(20, 20, 40, 0.9)',
-      padding: '8px 12px',
-      marginBottom: '5px',
-      borderRadius: '4px',
-      fontSize: '13px',
-      color: age > 120 ? `rgba(255, 255, 100, ${Math.max(0.3, 1 - (age - 120) / 60)})` : 'rgb(255, 255, 100)',
-      transition: 'opacity 0.5s',
-      border: '1px solid rgba(255, 255, 100, 0.3)',
-      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.3)',
-    }),
-  };
-
   return (
-    <div style={styles.container}>
-      {events.slice().reverse().map((event, index) => {
-        const age = currentFrame - event.frame;
-        const isTie = event.winner_id === -1;
-        return (
-          <div
-            key={`${event.frame}-${index}`}
-            style={isTie ? styles.tieEvent(age) : styles.event(age)}
-          >
-            {event.message}
-          </div>
-        );
-      })}
-    </div>
+    <section className="poker-events" aria-label="Recent poker activity">
+      <div className="poker-events__header">
+        <h2>Poker Activity</h2>
+        <span>Latest clashes between fish</span>
+      </div>
+      {events.length === 0 ? (
+        <p className="poker-events__empty">No poker activity yet.</p>
+      ) : (
+        <div className="poker-events__list">
+          {events
+            .slice()
+            .reverse()
+            .map((event, index) => {
+              const age = currentFrame - event.frame;
+              const isTie = event.winner_id === -1;
+              const fading = Math.max(0.35, 1 - Math.max(0, age - 90) / 90);
+
+              return (
+                <div
+                  key={`${event.frame}-${index}`}
+                  className={`poker-events__item ${isTie ? 'tie' : ''}`}
+                  style={{ opacity: fading }}
+                >
+                  {event.message}
+                </div>
+              );
+            })}
+        </div>
+      )}
+    </section>
   );
 };
 

--- a/frontend/src/utils/renderer.ts
+++ b/frontend/src/utils/renderer.ts
@@ -145,7 +145,7 @@ export class Renderer {
     this.ctx.restore();
   }
 
-  private updateParticles(width: number, height: number, time: number) {
+  private updateParticles(width: number, height: number, _time: number) {
     for (const particle of this.particles) {
       // Float upward
       particle.y -= particle.speed;
@@ -500,27 +500,6 @@ export class Renderer {
     }
 
     return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
-  }
-
-  private drawEnergyBar(x: number, y: number, width: number, energy: number) {
-    const { ctx } = this;
-    const barHeight = 4;
-    const barWidth = width;
-
-    // Background
-    ctx.fillStyle = '#333333';
-    ctx.fillRect(x, y, barWidth, barHeight);
-
-    // Energy bar
-    let color = '#4ade80'; // green
-    if (energy < 30) {
-      color = '#ef4444'; // red
-    } else if (energy < 60) {
-      color = '#fbbf24'; // yellow
-    }
-
-    ctx.fillStyle = color;
-    ctx.fillRect(x, y, (barWidth * energy) / 100, barHeight);
   }
 
   private drawEnhancedEnergyBar(x: number, y: number, width: number, energy: number) {


### PR DESCRIPTION
## Summary
- replace the fixed-position poker activity overlay with an embedded panel that sits below the simulation canvas and keeps the statistics sidebar unobstructed
- add scoped styles for the new poker activity panel, including a placeholder message when no events have been received yet
- clean up TypeScript warnings in the renderer by removing an unused helper and marking the unused animation parameter

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b45e8e5e48331bc580f31a15968c0)