### PR TITLE
Fix missing tie statistics in poker stats

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -122,6 +122,9 @@ HEALTH_CRITICAL_COLOR = (200, 50, 50)  # Red (below 30%)
 HEALTH_LOW_COLOR = (200, 200, 50)      # Yellow (30-60%)
 HEALTH_GOOD_COLOR = (50, 200, 50)      # Green (above 60%)
 
+# Fish movement constraints
+FISH_TOP_MARGIN = 20  # Minimum pixels from top to keep energy bar visible
+
 # Fish Energy and Metabolism Constants
 INITIAL_ENERGY_RATIO = 0.5  # Start with 50% energy
 BABY_METABOLISM_MULTIPLIER = 0.7  # Babies need less energy

--- a/core/entities.py
+++ b/core/entities.py
@@ -14,7 +14,8 @@ from core.math_utils import Vector2
 from core.constants import (
     INITIAL_ENERGY_RATIO, BABY_METABOLISM_MULTIPLIER,
     ELDER_METABOLISM_MULTIPLIER, STARVATION_THRESHOLD,
-    CRITICAL_ENERGY_THRESHOLD, LOW_ENERGY_THRESHOLD, SAFE_ENERGY_THRESHOLD
+    CRITICAL_ENERGY_THRESHOLD, LOW_ENERGY_THRESHOLD, SAFE_ENERGY_THRESHOLD,
+    FISH_TOP_MARGIN
 )
 
 if TYPE_CHECKING:
@@ -634,6 +635,24 @@ class Fish(Agent):
         )
 
         return baby
+
+    def handle_screen_edges(self) -> None:
+        """Handle the fish hitting the edge of the screen with top margin for energy bar visibility."""
+        # Horizontal boundaries - reverse velocity and clamp position
+        if self.pos.x < 0:
+            self.pos.x = 0
+            self.vel.x = abs(self.vel.x)  # Bounce right
+        elif self.pos.x + self.width > self.screen_width:
+            self.pos.x = self.screen_width - self.width
+            self.vel.x = -abs(self.vel.x)  # Bounce left
+
+        # Vertical boundaries with top margin for energy bar visibility
+        if self.pos.y < FISH_TOP_MARGIN:
+            self.pos.y = FISH_TOP_MARGIN
+            self.vel.y = abs(self.vel.y)  # Bounce down
+        elif self.pos.y + self.height > self.screen_height:
+            self.pos.y = self.screen_height - self.height
+            self.vel.y = -abs(self.vel.y)  # Bounce up
 
     def update(self, elapsed_time: int, time_modifier: float = 1.0) -> Optional['Fish']:
         """Update the fish state.

--- a/core/fish_poker.py
+++ b/core/fish_poker.py
@@ -218,8 +218,8 @@ class PokerInteraction:
             final_pot=game_state.pot
         )
 
-        # Record in ecosystem if available
-        if self.fish1.ecosystem is not None and winner_id != -1:
+        # Record in ecosystem if available (including ties)
+        if self.fish1.ecosystem is not None:
             # Get algorithm IDs from fish genomes
             fish1_algo_id = None
             if self.fish1.genome.behavior_algorithm is not None:


### PR DESCRIPTION
- Fix poker ties not being recorded in stats by removing winner_id != -1 check
- Add FISH_TOP_MARGIN constant (20px) to keep energy bars visible
- Override Fish.handle_screen_edges() to enforce top margin constraint

This ensures poker W/L/T stats accurately reflect ties and fish don't swim too high where their energy bars would be cut off at the top of the screen.