### PR TITLE
Fix fish pause at simulation start

### DIFF
--- a/core/algorithms/energy_management.py
+++ b/core/algorithms/energy_management.py
@@ -31,6 +31,7 @@ class EnergyConserver(BehaviorAlgorithm):
             parameters={
                 "activity_threshold": random.uniform(0.4, 0.7),
                 "rest_speed": random.uniform(0.1, 0.3),
+                "exploration_rate": random.uniform(0.0, 0.4),  # 0 = no exploration, 0.4 = moderate wandering
             }
         )
 
@@ -80,7 +81,15 @@ class EnergyConserver(BehaviorAlgorithm):
                 speed_mult = self.parameters["rest_speed"] * (1.0 + (1.0 - min(food_distance / 50, 1.0)) * 0.5)
                 return direction.x * speed_mult, direction.y * speed_mult
 
-        # Rest mode - minimal movement
+        # Rest mode - gentle exploration based on exploration_rate parameter
+        exploration_rate = self.parameters["exploration_rate"]
+        if exploration_rate > 0:
+            # Gentle wandering to explore for food when idle
+            t = time.time() * 0.2  # Slow time factor for gentle movement
+            vx = math.cos(t + id(fish) * 0.1) * exploration_rate
+            vy = math.sin(t * 0.7 + id(fish) * 0.1) * exploration_rate * 0.5
+            return vx, vy
+
         return 0, 0
 
 
@@ -176,6 +185,7 @@ class OpportunisticRester(BehaviorAlgorithm):
             parameters={
                 "safe_radius": random.uniform(100, 200),
                 "active_speed": random.uniform(0.5, 0.9),
+                "idle_wander_speed": random.uniform(0.0, 0.3),  # 0 = stay still, 0.3 = gentle wandering
             }
         )
 
@@ -194,6 +204,16 @@ class OpportunisticRester(BehaviorAlgorithm):
 
         if has_nearby_food or has_nearby_threat:
             return self.parameters["active_speed"], 0
+
+        # Idle wandering when no stimuli detected
+        idle_speed = self.parameters["idle_wander_speed"]
+        if idle_speed > 0:
+            # Gentle random wandering to explore environment
+            t = time.time() * 0.15  # Very slow wandering
+            vx = math.cos(t + id(fish) * 0.05) * idle_speed
+            vy = math.sin(t * 0.6 + id(fish) * 0.05) * idle_speed * 0.4
+            return vx, vy
+
         return 0, 0
 
 

--- a/core/entity_factory.py
+++ b/core/entity_factory.py
@@ -121,11 +121,35 @@ def create_initial_population(
     plant2 = entities.Plant(env, 2, *INIT_POS['plant2'], screen_width, screen_height)
     plant3 = entities.Plant(env, 1, *INIT_POS['plant3'], screen_width, screen_height)
 
+    # Create initial food items to prevent startup pause
+    # Spawn 8 food items at various locations so fish have immediate targets
+    initial_food = []
+    food_positions = [
+        (screen_width * 0.25, screen_height * 0.3),  # Upper left area
+        (screen_width * 0.5, screen_height * 0.25),   # Upper middle
+        (screen_width * 0.75, screen_height * 0.35),  # Upper right area
+        (screen_width * 0.2, screen_height * 0.5),    # Middle left
+        (screen_width * 0.6, screen_height * 0.45),   # Middle right
+        (screen_width * 0.3, screen_height * 0.65),   # Lower left
+        (screen_width * 0.7, screen_height * 0.6),    # Lower right
+        (screen_width * 0.5, screen_height * 0.55),   # Lower middle
+    ]
+    for x, y in food_positions:
+        food = entities.Food(
+            env, x, y,
+            source_plant=None,
+            food_type=None,  # Random type
+            allow_stationary_types=False,  # No stationary food at startup
+            screen_width=screen_width,
+            screen_height=screen_height
+        )
+        initial_food.append(food)
+
     # Create crab and castle
     crab = entities.Crab(env, None, *INIT_POS['crab'], screen_width, screen_height)
     castle = entities.Castle(env, *INIT_POS['castle'], screen_width, screen_height)
 
     # Add all non-fish entities
-    population.extend([plant1, plant2, plant3, crab, castle])
+    population.extend([plant1, plant2, plant3] + initial_food + [crab, castle])
 
     return population

--- a/test_fish_pause_fix.py
+++ b/test_fish_pause_fix.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""Test script to verify fish pause bug fix."""
+
+import sys
+from core import environment, entities
+from core.entity_factory import create_initial_population
+from core.ecosystem import EcosystemManager
+from core.algorithms.energy_management import EnergyConserver, OpportunisticRester
+
+def test_initial_food_spawning():
+    """Test that initial food is spawned."""
+    print("Testing initial food spawning...")
+
+    env = environment.Environment(width=800, height=600)
+    ecosystem = EcosystemManager()
+
+    population = create_initial_population(env, ecosystem)
+
+    # Count food items
+    food_count = sum(1 for entity in population if isinstance(entity, entities.Food))
+
+    print(f"  Initial food count: {food_count}")
+    assert food_count > 0, "No initial food was spawned!"
+    print(f"  ✓ Successfully spawned {food_count} initial food items")
+
+def test_energy_conserver_exploration():
+    """Test that EnergyConserver has exploration parameter."""
+    print("\nTesting EnergyConserver exploration parameter...")
+
+    algorithm = EnergyConserver()
+
+    assert "exploration_rate" in algorithm.parameters, "exploration_rate parameter missing!"
+    print(f"  exploration_rate: {algorithm.parameters['exploration_rate']:.3f}")
+
+    # Test that parameter is in valid range
+    assert 0.0 <= algorithm.parameters["exploration_rate"] <= 0.4, \
+        f"exploration_rate {algorithm.parameters['exploration_rate']} out of expected range [0.0, 0.4]"
+
+    print("  ✓ EnergyConserver has valid exploration_rate parameter")
+
+def test_opportunistic_rester_wandering():
+    """Test that OpportunisticRester has idle wander parameter."""
+    print("\nTesting OpportunisticRester idle wander parameter...")
+
+    algorithm = OpportunisticRester()
+
+    assert "idle_wander_speed" in algorithm.parameters, "idle_wander_speed parameter missing!"
+    print(f"  idle_wander_speed: {algorithm.parameters['idle_wander_speed']:.3f}")
+
+    # Test that parameter is in valid range
+    assert 0.0 <= algorithm.parameters["idle_wander_speed"] <= 0.3, \
+        f"idle_wander_speed {algorithm.parameters['idle_wander_speed']} out of expected range [0.0, 0.3]"
+
+    print("  ✓ OpportunisticRester has valid idle_wander_speed parameter")
+
+def test_algorithm_parameters_genetic():
+    """Test that new parameters can be inherited genetically."""
+    print("\nTesting genetic inheritance of new parameters...")
+
+    from core.genetics import Genome
+
+    # Test that genomes can be created with algorithms containing new parameters
+    genome1 = Genome.random(use_brain=False, use_algorithm=True)
+
+    if genome1.behavior_algorithm:
+        print(f"  Random genome created with algorithm: {genome1.behavior_algorithm.algorithm_id}")
+
+        # Check if it's one of our modified algorithms
+        if genome1.behavior_algorithm.algorithm_id == "energy_conserver":
+            assert "exploration_rate" in genome1.behavior_algorithm.parameters
+            print(f"    - exploration_rate: {genome1.behavior_algorithm.parameters['exploration_rate']:.3f}")
+        elif genome1.behavior_algorithm.algorithm_id == "opportunistic_rester":
+            assert "idle_wander_speed" in genome1.behavior_algorithm.parameters
+            print(f"    - idle_wander_speed: {genome1.behavior_algorithm.parameters['idle_wander_speed']:.3f}")
+
+    print("  ✓ New parameters are properly integrated into genetic system")
+
+if __name__ == "__main__":
+    try:
+        test_initial_food_spawning()
+        test_energy_conserver_exploration()
+        test_opportunistic_rester_wandering()
+        test_algorithm_parameters_genetic()
+
+        print("\n" + "="*50)
+        print("All tests passed! ✓")
+        print("="*50)
+        sys.exit(0)
+
+    except AssertionError as e:
+        print(f"\n✗ Test failed: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n✗ Error during testing: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
This commit addresses the issue where fish appeared paused for 2-3 seconds when the simulation starts by implementing two key improvements:

1. Initial Food Spawning:
   - Added 8 initial food items spawned at strategic locations across the tank
   - Prevents the startup delay caused by waiting for plant food production (2.5s) and auto-food spawning (3s)
   - Food is distributed throughout upper, middle, and lower areas of the tank

2. Parameterizable Exploration Behavior:
   - Added 'exploration_rate' parameter (0.0-0.4) to EnergyConserver algorithm * Enables gentle wandering when no food/threats are visible * Fish will now explore instead of staying completely still
   - Added 'idle_wander_speed' parameter (0.0-0.3) to OpportunisticRester algorithm
     * Allows configurable idle wandering when outside safe_radius
     * Provides exploratory movement that can help fish discover food

Both parameters are:
- Randomly initialized within their ranges for genetic diversity
- Inherited through the genetic system for evolution
- Fully compatible with existing algorithmic evolution framework

These changes eliminate the startup pause while maintaining energy-conscious behavior patterns. Fish with higher exploration parameters will discover food faster but use more energy, creating an evolutionary trade-off.

Modified files:
- core/entity_factory.py: Added initial food spawning logic
- core/algorithms/energy_management.py: Added exploration parameters to EnergyConserver and OpportunisticRester
- test_fish_pause_fix.py: Added verification tests for all changes