### PR TITLE
Fix missing register_fish method in EcosystemManager

### DIFF
--- a/simulation_engine.py
+++ b/simulation_engine.py
@@ -109,10 +109,7 @@ class SimulationEngine(BaseSimulator):
             # Add offspring to population
             offspring = poker.result.offspring
             self.add_entity(offspring)
-
-            # Register with ecosystem if available
-            if self.ecosystem is not None:
-                self.ecosystem.register_fish(offspring)
+            # Note: Birth is automatically recorded by Fish.__init__ when ecosystem is provided
 
     def update(self) -> None:
         """Update the state of the simulation."""


### PR DESCRIPTION
The EcosystemManager class does not have a register_fish() method. Birth registration is already handled automatically by the Fish.__init__ method when an ecosystem is provided to the constructor.

Removed the unnecessary call to ecosystem.register_fish(offspring) in handle_poker_result() since the offspring Fish is created with the ecosystem parameter, which triggers automatic birth registration.

Fixes: AttributeError: 'EcosystemManager' object has no attribute 'register_fish'