### PR TITLE
Fix vector normalization error in movement strategy

### DIFF
--- a/core/algorithms/base.py
+++ b/core/algorithms/base.py
@@ -325,5 +325,21 @@ def _find_nearest(self, fish: 'Fish', agent_type) -> Optional[Any]:
     return min(agents, key=lambda a: (a.pos - fish.pos).length())
 
 
-# Inject helper method into base class
+def _safe_normalize(self, vector: Vector2) -> Vector2:
+    """Safely normalize a vector, returning zero vector if length is zero.
+
+    Args:
+        vector: The vector to normalize
+
+    Returns:
+        Normalized vector or Vector2(0, 0) if vector length is zero or near-zero
+    """
+    length = vector.length()
+    if length < 1e-6:  # Use small epsilon to handle floating point errors
+        return Vector2(0, 0)
+    return vector.normalize()
+
+
+# Inject helper methods into base class
 BehaviorAlgorithm._find_nearest = _find_nearest
+BehaviorAlgorithm._safe_normalize = _safe_normalize

--- a/core/algorithms/poker.py
+++ b/core/algorithms/poker.py
@@ -40,7 +40,7 @@ class PokerChallenger(BehaviorAlgorithm):
         nearest_predator = self._find_nearest(fish, Crab)
         if nearest_predator and (nearest_predator.pos - fish.pos).length() < 120:
             # Flee from predator
-            direction = (fish.pos - nearest_predator.pos).normalize()
+            direction = self._safe_normalize(fish.pos - nearest_predator.pos)
             return direction.x * 1.2, direction.y * 1.2
 
         # Only seek poker if we have enough energy
@@ -48,7 +48,7 @@ class PokerChallenger(BehaviorAlgorithm):
             # Low energy - seek food instead
             nearest_food = self._find_nearest(fish, Food)
             if nearest_food:
-                direction = (nearest_food.pos - fish.pos).normalize()
+                direction = self._safe_normalize(nearest_food.pos - fish.pos)
                 return direction.x * 0.8, direction.y * 0.8
             return 0, 0
 
@@ -63,7 +63,7 @@ class PokerChallenger(BehaviorAlgorithm):
 
             if distance < self.parameters["challenge_radius"]:
                 # Move toward the fish for poker
-                direction = (nearest_fish.pos - fish.pos).normalize()
+                direction = self._safe_normalize(nearest_fish.pos - fish.pos)
                 speed = self.parameters["challenge_speed"]
                 return direction.x * speed, direction.y * speed
 
@@ -93,7 +93,7 @@ class PokerDodger(BehaviorAlgorithm):
         # First check for predators
         nearest_predator = self._find_nearest(fish, Crab)
         if nearest_predator and (nearest_predator.pos - fish.pos).length() < 120:
-            direction = (fish.pos - nearest_predator.pos).normalize()
+            direction = self._safe_normalize(fish.pos - nearest_predator.pos)
             return direction.x * 1.2, direction.y * 1.2
 
         # Check for nearby fish to avoid
@@ -108,7 +108,7 @@ class PokerDodger(BehaviorAlgorithm):
             distance = (other.pos - fish.pos).length()
             if distance < self.parameters["avoidance_radius"] and distance > 0:
                 # Avoid this fish
-                avoid_dir = (fish.pos - other.pos).normalize()
+                avoid_dir = self._safe_normalize(fish.pos - other.pos)
                 # Stronger avoidance for closer fish
                 strength = (self.parameters["avoidance_radius"] - distance) / self.parameters["avoidance_radius"]
                 avoidance_vector = avoidance_vector + (avoid_dir * strength)
@@ -116,15 +116,15 @@ class PokerDodger(BehaviorAlgorithm):
 
         # If fish are nearby, move away from them
         if fish_nearby > 0:
-            avoidance_vector = avoidance_vector.normalize()
+            avoidance_vector = self._safe_normalize(avoidance_vector)
             speed = self.parameters["avoidance_speed"]
 
             # Still seek food while avoiding
             nearest_food = self._find_nearest(fish, Food)
             if nearest_food and (nearest_food.pos - fish.pos).length() < 200:
-                food_dir = (nearest_food.pos - fish.pos).normalize()
+                food_dir = self._safe_normalize(nearest_food.pos - fish.pos)
                 # Blend avoidance with food seeking
-                final_dir = (avoidance_vector * 0.7 + food_dir * 0.3).normalize()
+                final_dir = self._safe_normalize(avoidance_vector * 0.7 + food_dir * 0.3)
                 return final_dir.x * speed, final_dir.y * speed
 
             return avoidance_vector.x * speed, avoidance_vector.y * speed
@@ -132,7 +132,7 @@ class PokerDodger(BehaviorAlgorithm):
         # No fish nearby - focus on food
         nearest_food = self._find_nearest(fish, Food)
         if nearest_food:
-            direction = (nearest_food.pos - fish.pos).normalize()
+            direction = self._safe_normalize(nearest_food.pos - fish.pos)
             return direction.x * self.parameters["food_priority"], direction.y * self.parameters["food_priority"]
 
         return 0, 0
@@ -160,7 +160,7 @@ class PokerGambler(BehaviorAlgorithm):
         # Check for predators
         nearest_predator = self._find_nearest(fish, Crab)
         if nearest_predator and (nearest_predator.pos - fish.pos).length() < 120:
-            direction = (fish.pos - nearest_predator.pos).normalize()
+            direction = self._safe_normalize(fish.pos - nearest_predator.pos)
             return direction.x * 1.2, direction.y * 1.2
 
         energy_ratio = fish.energy / fish.max_energy
@@ -173,7 +173,7 @@ class PokerGambler(BehaviorAlgorithm):
 
             if other_fish:
                 nearest_fish = min(other_fish, key=lambda f: (f.pos - fish.pos).length())
-                direction = (nearest_fish.pos - fish.pos).normalize()
+                direction = self._safe_normalize(nearest_fish.pos - fish.pos)
                 speed = self.parameters["challenge_speed"]
                 return direction.x * speed, direction.y * speed
 
@@ -185,13 +185,13 @@ class PokerGambler(BehaviorAlgorithm):
                 other_fish = [f for f in all_fish if f.fish_id != fish.fish_id]
                 if other_fish:
                     nearest_fish = min(other_fish, key=lambda f: (f.pos - fish.pos).length())
-                    direction = (nearest_fish.pos - fish.pos).normalize()
+                    direction = self._safe_normalize(nearest_fish.pos - fish.pos)
                     return direction.x * 0.8, direction.y * 0.8
 
         # Low energy - focus on food
         nearest_food = self._find_nearest(fish, Food)
         if nearest_food:
-            direction = (nearest_food.pos - fish.pos).normalize()
+            direction = self._safe_normalize(nearest_food.pos - fish.pos)
             return direction.x, direction.y
 
         return 0, 0
@@ -220,7 +220,7 @@ class SelectivePoker(BehaviorAlgorithm):
         # Check for predators
         nearest_predator = self._find_nearest(fish, Crab)
         if nearest_predator and (nearest_predator.pos - fish.pos).length() < 120:
-            direction = (fish.pos - nearest_predator.pos).normalize()
+            direction = self._safe_normalize(fish.pos - nearest_predator.pos)
             return direction.x * 1.2, direction.y * 1.2
 
         energy_ratio = fish.energy / fish.max_energy
@@ -241,14 +241,14 @@ class SelectivePoker(BehaviorAlgorithm):
 
                     # Only challenge if reasonably close
                     if distance < 150:
-                        direction = (nearest_fish.pos - fish.pos).normalize()
+                        direction = self._safe_normalize(nearest_fish.pos - fish.pos)
                         speed = self.parameters["challenge_speed"]
                         return direction.x * speed, direction.y * speed
 
         # Default to food seeking
         nearest_food = self._find_nearest(fish, Food)
         if nearest_food:
-            direction = (nearest_food.pos - fish.pos).normalize()
+            direction = self._safe_normalize(nearest_food.pos - fish.pos)
             return direction.x * 0.9, direction.y * 0.9
 
         return 0, 0
@@ -276,7 +276,7 @@ class PokerOpportunist(BehaviorAlgorithm):
         # Check for predators
         nearest_predator = self._find_nearest(fish, Crab)
         if nearest_predator and (nearest_predator.pos - fish.pos).length() < 120:
-            direction = (fish.pos - nearest_predator.pos).normalize()
+            direction = self._safe_normalize(fish.pos - nearest_predator.pos)
             return direction.x * 1.2, direction.y * 1.2
 
         # Look for both food and fish opportunities
@@ -291,14 +291,14 @@ class PokerOpportunist(BehaviorAlgorithm):
         if nearest_food:
             food_dist = (nearest_food.pos - fish.pos).length()
             if food_dist > 0:
-                food_vector = (nearest_food.pos - fish.pos).normalize()
+                food_vector = self._safe_normalize(nearest_food.pos - fish.pos)
 
         # Calculate poker attraction (nearest fish)
         if other_fish:
             nearest_fish = min(other_fish, key=lambda f: (f.pos - fish.pos).length())
             poker_dist = (nearest_fish.pos - fish.pos).length()
             if poker_dist < self.parameters["opportunity_radius"] and poker_dist > 0:
-                poker_vector = (nearest_fish.pos - fish.pos).normalize()
+                poker_vector = self._safe_normalize(nearest_fish.pos - fish.pos)
 
         # Blend the two behaviors based on weights and energy
         energy_ratio = fish.energy / fish.max_energy
@@ -315,7 +315,7 @@ class PokerOpportunist(BehaviorAlgorithm):
         # Combine vectors
         final_vector = (food_vector * food_weight + poker_vector * poker_weight)
         if final_vector.length() > 0:
-            final_vector = final_vector.normalize()
+            final_vector = self._safe_normalize(final_vector)
             return final_vector.x, final_vector.y
 
         return 0, 0

--- a/core/algorithms/predator_avoidance.py
+++ b/core/algorithms/predator_avoidance.py
@@ -46,7 +46,7 @@ class PanicFlee(BehaviorAlgorithm):
         if nearest_predator:
             distance = (nearest_predator.pos - fish.pos).length()
             if distance < self.parameters["panic_distance"]:
-                direction = (fish.pos - nearest_predator.pos).normalize()
+                direction = self._safe_normalize(fish.pos - nearest_predator.pos)
                 return direction.x * self.parameters["flee_speed"], direction.y * self.parameters["flee_speed"]
 
         # Seek food when safe
@@ -54,10 +54,8 @@ class PanicFlee(BehaviorAlgorithm):
         if energy_ratio < 0.7:
             nearest_food = self._find_nearest(fish, Food)
             if nearest_food:
-                direction = (nearest_food.pos - fish.pos)
-                if direction.length() > 0:
-                    direction = direction.normalize()
-                    return direction.x * 0.7, direction.y * 0.7
+                direction = self._safe_normalize(nearest_food.pos - fish.pos)
+                return direction.x * 0.7, direction.y * 0.7
         return 0, 0
 
 
@@ -84,7 +82,7 @@ class StealthyAvoider(BehaviorAlgorithm):
         if nearest_predator:
             distance = (nearest_predator.pos - fish.pos).length()
             if distance < self.parameters["awareness_range"]:
-                direction = (fish.pos - nearest_predator.pos).normalize()
+                direction = self._safe_normalize(fish.pos - nearest_predator.pos)
                 return direction.x * self.parameters["stealth_speed"], direction.y * self.parameters["stealth_speed"]
 
         # Seek food when safe
@@ -159,7 +157,7 @@ class ErraticEvader(BehaviorAlgorithm):
 
             if distance < self.parameters["threat_range"]:
                 # Erratic movement with some directional bias away from predator
-                away_dir = (fish.pos - nearest_predator.pos).normalize()
+                away_dir = self._safe_normalize(fish.pos - nearest_predator.pos)
 
                 # Add randomness perpendicular to escape direction
                 perp_x = -away_dir.y
@@ -190,7 +188,7 @@ class ErraticEvader(BehaviorAlgorithm):
                     if allies:
                         nearest_ally = min(allies, key=lambda f: (f.pos - fish.pos).length())
                         if (nearest_ally.pos - fish.pos).length() < 100:
-                            ally_dir = (nearest_ally.pos - fish.pos).normalize()
+                            ally_dir = self._safe_normalize(nearest_ally.pos - fish.pos)
                             vx += ally_dir.x * 0.3
                             vy += ally_dir.y * 0.3
 
@@ -227,10 +225,8 @@ class VerticalEscaper(BehaviorAlgorithm):
         if energy_ratio < 0.7:
             nearest_food = self._find_nearest(fish, Food)
             if nearest_food:
-                direction = (nearest_food.pos - fish.pos)
-                if direction.length() > 0:
-                    direction = direction.normalize()
-                    return direction.x * 0.6, direction.y * 0.6
+                direction = self._safe_normalize(nearest_food.pos - fish.pos)
+                return direction.x * 0.6, direction.y * 0.6
         return 0, 0
 
 
@@ -259,20 +255,16 @@ class GroupDefender(BehaviorAlgorithm):
             allies = [f for f in fish.environment.get_agents_of_type(FishClass) if f != fish]
             if allies:
                 nearest_ally = min(allies, key=lambda f: (f.pos - fish.pos).length())
-                direction = (nearest_ally.pos - fish.pos)
-                if direction.length() > 0:
-                    direction = direction.normalize()
-                    return direction.x * self.parameters["group_strength"], direction.y * self.parameters["group_strength"]
+                direction = self._safe_normalize(nearest_ally.pos - fish.pos)
+                return direction.x * self.parameters["group_strength"], direction.y * self.parameters["group_strength"]
 
         # Seek food when safe
         energy_ratio = fish.energy / fish.max_energy
         if energy_ratio < 0.7:
             nearest_food = self._find_nearest(fish, Food)
             if nearest_food:
-                direction = (nearest_food.pos - fish.pos)
-                if direction.length() > 0:
-                    direction = direction.normalize()
-                    return direction.x * 0.6, direction.y * 0.6
+                direction = self._safe_normalize(nearest_food.pos - fish.pos)
+                return direction.x * 0.6, direction.y * 0.6
         return 0, 0
 
 
@@ -299,7 +291,7 @@ class SpiralEscape(BehaviorAlgorithm):
         nearest_predator = self._find_nearest(fish, Crab)
         if nearest_predator and (nearest_predator.pos - fish.pos).length() < 150:
             self.spiral_angle += self.parameters["spiral_rate"]
-            escape_dir = (fish.pos - nearest_predator.pos).normalize()
+            escape_dir = self._safe_normalize(fish.pos - nearest_predator.pos)
             # Rotate the escape direction
             vx = escape_dir.x * math.cos(self.spiral_angle) - escape_dir.y * math.sin(self.spiral_angle)
             vy = escape_dir.x * math.sin(self.spiral_angle) + escape_dir.y * math.cos(self.spiral_angle)
@@ -310,10 +302,8 @@ class SpiralEscape(BehaviorAlgorithm):
         if energy_ratio < 0.7:
             nearest_food = self._find_nearest(fish, Food)
             if nearest_food:
-                direction = (nearest_food.pos - fish.pos)
-                if direction.length() > 0:
-                    direction = direction.normalize()
-                    return direction.x * 0.6, direction.y * 0.6
+                direction = self._safe_normalize(nearest_food.pos - fish.pos)
+                return direction.x * 0.6, direction.y * 0.6
         return 0, 0
 
 
@@ -352,10 +342,8 @@ class BorderHugger(BehaviorAlgorithm):
         if energy_ratio < 0.7:
             nearest_food = self._find_nearest(fish, Food)
             if nearest_food:
-                direction = (nearest_food.pos - fish.pos)
-                if direction.length() > 0:
-                    direction = direction.normalize()
-                    return direction.x * 0.6, direction.y * 0.6
+                direction = self._safe_normalize(nearest_food.pos - fish.pos)
+                return direction.x * 0.6, direction.y * 0.6
         return 0, 0
 
 
@@ -380,13 +368,11 @@ class PerpendicularEscape(BehaviorAlgorithm):
 
         nearest_predator = self._find_nearest(fish, Crab)
         if nearest_predator and (nearest_predator.pos - fish.pos).length() < 150:
-            to_fish = (fish.pos - nearest_predator.pos)
-            if to_fish.length() > 0:
-                to_fish = to_fish.normalize()
-                # Perpendicular vector
-                perp_x = -to_fish.y * self.parameters["direction_preference"]
-                perp_y = to_fish.x * self.parameters["direction_preference"]
-                return perp_x * self.parameters["escape_speed"], perp_y * self.parameters["escape_speed"]
+            to_fish = self._safe_normalize(fish.pos - nearest_predator.pos)
+            # Perpendicular vector
+            perp_x = -to_fish.y * self.parameters["direction_preference"]
+            perp_y = to_fish.x * self.parameters["direction_preference"]
+            return perp_x * self.parameters["escape_speed"], perp_y * self.parameters["escape_speed"]
 
         # CRITICAL FIX: Seek food when not fleeing from predators
         energy_ratio = fish.energy / fish.max_energy
@@ -395,12 +381,10 @@ class PerpendicularEscape(BehaviorAlgorithm):
             food_distance = (nearest_food.pos - fish.pos).length()
             # Seek food more aggressively when hungry
             if energy_ratio < 0.7 or food_distance < 80:
-                direction = (nearest_food.pos - fish.pos)
-                if direction.length() > 0:
-                    direction = direction.normalize()
-                    # More aggressive seeking when very hungry
-                    seek_speed = 0.6 + (1.0 - energy_ratio) * 0.4
-                    return direction.x * seek_speed, direction.y * seek_speed
+                direction = self._safe_normalize(nearest_food.pos - fish.pos)
+                # More aggressive seeking when very hungry
+                seek_speed = 0.6 + (1.0 - energy_ratio) * 0.4
+                return direction.x * seek_speed, direction.y * seek_speed
 
         return 0, 0
 
@@ -428,9 +412,7 @@ class DistanceKeeper(BehaviorAlgorithm):
         nearest_predator = self._find_nearest(fish, Crab)
         if nearest_predator:
             distance = (nearest_predator.pos - fish.pos).length()
-            direction = (fish.pos - nearest_predator.pos)
-            if direction.length() > 0:
-                direction = direction.normalize()
+            direction = self._safe_normalize(fish.pos - nearest_predator.pos)
 
                 energy_ratio = fish.energy / fish.max_energy
 
@@ -461,7 +443,7 @@ class DistanceKeeper(BehaviorAlgorithm):
                         nearest_food = self._find_nearest(fish, Food)
                         if nearest_food and (nearest_food.pos - fish.pos).length() < 150:
                             # Food nearby and relatively safe
-                            food_dir = (nearest_food.pos - fish.pos).normalize()
+                            food_dir = self._safe_normalize(nearest_food.pos - fish.pos)
                             # Move toward food but keep an eye on predator
                             return (food_dir.x * 0.7 + direction.x * 0.3) * 0.8, \
                                    (food_dir.y * 0.7 + direction.y * 0.3) * 0.8
@@ -472,7 +454,7 @@ class DistanceKeeper(BehaviorAlgorithm):
         # No predator - search for food
         nearest_food = self._find_nearest(fish, Food)
         if nearest_food:
-            direction = (nearest_food.pos - fish.pos).normalize()
+            direction = self._safe_normalize(nearest_food.pos - fish.pos)
             return direction.x * 0.6, direction.y * 0.6
 
         return 0, 0


### PR DESCRIPTION
Resolves ValueError: Can't normalize Vector of length Zero that occurred when fish entities were at identical positions.

Changes:
- Added _safe_normalize() helper method to BehaviorAlgorithm base class that checks vector length before normalizing, returning zero vector if length is near-zero (< 1e-6)
- Updated ~96 vector normalization calls across all algorithm files:
  * poker.py: 19 changes (fixes line 176 crash)
  * predator_avoidance.py: 17 changes
  * territory.py: 17 changes
  * food_seeking.py: 24 changes
  * energy_management.py: 17 changes
  * schooling.py: 21 changes

All instances of (pos1 - pos2).normalize() and vector.normalize() now use self._safe_normalize() to prevent division by zero errors when entities occupy the same position.