### PR TITLE
Fix AttributeError: Add PREDATOR_ENCOUNTER_WINDOW constant to Fish class

### DIFF
--- a/core/entities.py
+++ b/core/entities.py
@@ -219,6 +219,9 @@ class Fish(Agent):
     PREGNANCY_DURATION = REPRODUCTION_GESTATION
     MATING_DISTANCE = MATING_DISTANCE
 
+    # Predator tracking constant (using centralized constant)
+    PREDATOR_ENCOUNTER_WINDOW = PREDATOR_ENCOUNTER_WINDOW
+
     def __init__(self, environment: 'Environment', movement_strategy: 'MovementStrategy',
                  species: str, x: float, y: float, speed: float,
                  genome: Optional['Genome'] = None, generation: int = 0,


### PR DESCRIPTION
The Fish.get_death_cause() method was trying to access
self.PREDATOR_ENCOUNTER_WINDOW, but this constant was not defined as a
class attribute. Added it following the pattern of other constants in
the Fish class.

Fixes: AttributeError: 'Fish' object has no attribute 'PREDATOR_ENCOUNTER_WINDOW'