### PR TITLE
Fix missing PREDATOR_ENCOUNTER_WINDOW attribute

### DIFF
--- a/core/entities.py
+++ b/core/entities.py
@@ -493,7 +493,7 @@ class Fish(Agent):
         """
         if self.energy <= 0:
             # Check if there was a recent predator encounter
-            if self.age - self.last_predator_encounter_age <= self.PREDATOR_ENCOUNTER_WINDOW:
+            if self.age - self.last_predator_encounter_age <= PREDATOR_ENCOUNTER_WINDOW:
                 return 'predation'  # Death after conflict
             else:
                 return 'starvation'  # Death without recent conflict


### PR DESCRIPTION
Changed self.PREDATOR_ENCOUNTER_WINDOW to PREDATOR_ENCOUNTER_WINDOW in Fish.get_death_cause() method. The constant is imported from core.constants and should not be accessed as an instance attribute.