### PR TITLE
Fix missing REPRODUCTION_COOLDOWN attribute in Fish

### DIFF
--- a/core/fish_poker.py
+++ b/core/fish_poker.py
@@ -154,6 +154,7 @@ class PokerInteraction:
         from core.constants import (
             POST_POKER_CROSSOVER_WINNER_WEIGHT,
             POST_POKER_MATING_DISTANCE,
+            REPRODUCTION_COOLDOWN,
         )
         from core.genetics import Genome
 
@@ -214,8 +215,8 @@ class PokerInteraction:
         loser_fish.energy -= loser_energy_transfer
 
         # Set reproduction cooldown for both parents
-        winner_fish.reproduction_cooldown = winner_fish.REPRODUCTION_COOLDOWN
-        loser_fish.reproduction_cooldown = loser_fish.REPRODUCTION_COOLDOWN
+        winner_fish.reproduction_cooldown = REPRODUCTION_COOLDOWN
+        loser_fish.reproduction_cooldown = REPRODUCTION_COOLDOWN
 
         # Both parents become pregnant (simulate gestation)
         # In this case we'll just create the baby immediately


### PR DESCRIPTION
Fixed AttributeError where fish_poker.py was trying to access REPRODUCTION_COOLDOWN as a Fish class attribute (e.g., winner_fish.REPRODUCTION_COOLDOWN), but it's actually a module-level constant that needs to be imported from core.constants.

Changes:
- Added REPRODUCTION_COOLDOWN to imports from core.constants
- Changed winner_fish.REPRODUCTION_COOLDOWN to REPRODUCTION_COOLDOWN
- Changed loser_fish.REPRODUCTION_COOLDOWN to REPRODUCTION_COOLDOWN

This follows the same pattern as the previous PREDATOR_ENCOUNTER_WINDOW fix.