### PR TITLE
Fix missing poker games won key error

### DIFF
--- a/core/behavioral_learning.py
+++ b/core/behavioral_learning.py
@@ -77,21 +77,26 @@ class BehavioralLearningSystem:
         self.learning_rate = learning_rate
         self.decay_rate = decay_rate
 
-        # Initialize learned_behaviors if empty
-        if not self.genome.learned_behaviors:
-            self.genome.learned_behaviors = {
-                'food_finding_efficiency': 0.0,  # -0.3 to +0.3 adjustment
-                'predator_escape_skill': 0.0,
-                'poker_hand_selection': 0.0,
-                'poker_positional_awareness': 0.0,
-                'poker_aggression_tuning': 0.0,
-                'energy_conservation': 0.0,
-                'spatial_memory_strength': 0.0,
-                'successful_food_finds': 0.0,  # Counter
-                'successful_predator_escapes': 0.0,  # Counter
-                'poker_games_won': 0.0,  # Counter
-                'poker_games_lost': 0.0,  # Counter
-            }
+        # Initialize learned_behaviors - ensure all required keys exist
+        # This handles both empty dicts and partially populated ones from inheritance
+        required_keys = {
+            'food_finding_efficiency': 0.0,  # -0.3 to +0.3 adjustment
+            'predator_escape_skill': 0.0,
+            'poker_hand_selection': 0.0,
+            'poker_positional_awareness': 0.0,
+            'poker_aggression_tuning': 0.0,
+            'energy_conservation': 0.0,
+            'spatial_memory_strength': 0.0,
+            'successful_food_finds': 0.0,  # Counter
+            'successful_predator_escapes': 0.0,  # Counter
+            'poker_games_won': 0.0,  # Counter
+            'poker_games_lost': 0.0,  # Counter
+        }
+
+        # Add any missing keys while preserving existing values
+        for key, default_value in required_keys.items():
+            if key not in self.genome.learned_behaviors:
+                self.genome.learned_behaviors[key] = default_value
 
     def learn_from_event(self, event: LearningEvent) -> None:
         """Process a learning event and update learned behaviors.


### PR DESCRIPTION
The BehavioralLearningSystem.__init__ was only initializing learned_behaviors when the dictionary was completely empty. This caused KeyError for offspring fish that had partially populated dictionaries from cultural inheritance.

Changed to check and add each required key individually, ensuring all keys are present regardless of whether the dict starts empty or partially populated.

Fixes the error:
KeyError: 'poker_games_won' in _learn_poker_strategy at line 167