### PR TITLE
Add button to spawn fresh fish

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -233,7 +233,7 @@ class SimulationRunner:
         """Handle a command from the client.
 
         Args:
-            command: Command type ('add_food', 'pause', 'resume', 'reset')
+            command: Command type ('add_food', 'spawn_fish', 'pause', 'resume', 'reset')
             data: Optional command data
         """
         with self.lock:
@@ -251,6 +251,34 @@ class SimulationRunner:
                 )
                 food.pos.y = 0
                 self.engine.entities_list.append(food)
+
+            elif command == 'spawn_fish':
+                # Spawn a new fish at random position
+                from core.genetics import Genome
+                from core import movement_strategy
+                from core.constants import FILES
+
+                # Random spawn position (avoid edges)
+                SPAWN_MARGIN = 50
+                x = random.randint(SPAWN_MARGIN, SCREEN_WIDTH - SPAWN_MARGIN)
+                y = random.randint(SPAWN_MARGIN, SCREEN_HEIGHT - SPAWN_MARGIN)
+
+                # Create new fish with random genome
+                genome = Genome.random(use_algorithm=True)
+                new_fish = entities.Fish(
+                    self.engine.environment,
+                    movement_strategy.AlgorithmicMovement(),
+                    FILES['schooling_fish'][0],
+                    x, y,
+                    4,  # Base speed
+                    genome=genome,
+                    generation=0,
+                    ecosystem=self.engine.ecosystem,
+                    screen_width=SCREEN_WIDTH,
+                    screen_height=SCREEN_HEIGHT
+                )
+                self.engine.add_entity(new_fish)
+                logger.info("Spawned new fish at (%d, %d)", x, y)
 
             elif command == 'pause':
                 self.engine.paused = True

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -17,6 +17,10 @@ export function ControlPanel({ onCommand, isConnected }: ControlPanelProps) {
     onCommand({ command: 'add_food' });
   };
 
+  const handleSpawnFish = () => {
+    onCommand({ command: 'spawn_fish' });
+  };
+
   const handlePause = () => {
     if (isPaused) {
       onCommand({ command: 'resume' });
@@ -61,6 +65,17 @@ export function ControlPanel({ onCommand, isConnected }: ControlPanelProps) {
         </button>
 
         <button
+          onClick={handleSpawnFish}
+          disabled={!isConnected}
+          style={{
+            ...styles.button,
+            ...styles.buttonSuccess,
+          }}
+        >
+          🐟 Spawn Fish
+        </button>
+
+        <button
           onClick={handlePause}
           disabled={!isConnected}
           style={{
@@ -88,6 +103,9 @@ export function ControlPanel({ onCommand, isConnected }: ControlPanelProps) {
         <ul style={styles.helpList}>
           <li>
             <strong>Add Food:</strong> Drop food into the tank
+          </li>
+          <li>
+            <strong>Spawn Fish:</strong> Add a new fish with random genetics
           </li>
           <li>
             <strong>Pause:</strong> Pause/resume the simulation
@@ -146,6 +164,10 @@ const styles = {
   },
   buttonPrimary: {
     backgroundColor: '#3b82f6',
+    color: '#ffffff',
+  },
+  buttonSuccess: {
+    backgroundColor: '#10b981',
     color: '#ffffff',
   },
   buttonSecondary: {

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -110,7 +110,7 @@ export interface SimulationUpdate {
 }
 
 export interface Command {
-  command: 'add_food' | 'pause' | 'resume' | 'reset';
+  command: 'add_food' | 'spawn_fish' | 'pause' | 'resume' | 'reset';
   data?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
Implements a new 'Spawn Fish' button that allows users to manually add a fresh fish to the tank with random genetics. The fish is spawned at a random position with a random genome and uses the AlgorithmicMovement strategy.

Changes:
- Added spawn_fish command handler in backend/simulation_runner.py
- Updated TypeScript Command type to include 'spawn_fish'
- Added green 'Spawn Fish' button in ControlPanel component
- Updated help section to document the new feature