### PR TITLE
Increase food energy and add color

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -55,7 +55,7 @@ FOOD_TYPES = {
     "algae": {
         "name": "Algae Flake",
         "files": ["food_algae1.png", "food_algae2.png"],
-        "energy": 30.0,  # Low energy - basic food source (increased 50%)
+        "energy": 45.0,  # Low energy - basic food source
         "rarity": 0.35,  # 35% spawn rate
         "sink_multiplier": 0.8,  # Sinks slower (lighter)
         "stationary": False,
@@ -63,7 +63,7 @@ FOOD_TYPES = {
     "protein": {
         "name": "Protein Flake",
         "files": ["food_protein1.png", "food_protein2.png"],
-        "energy": 50.0,  # Good energy - valuable food (increased 50%)
+        "energy": 75.0,  # Good energy - valuable food
         "rarity": 0.25,  # 25% spawn rate
         "sink_multiplier": 1.2,  # Sinks faster (heavier)
         "stationary": False,
@@ -71,7 +71,7 @@ FOOD_TYPES = {
     "vitamin": {
         "name": "Vitamin Flake",
         "files": ["food_vitamin1.png", "food_vitamin2.png"],
-        "energy": 40.0,  # Moderate energy (increased 50%)
+        "energy": 60.0,  # Moderate energy
         "rarity": 0.20,  # 20% spawn rate
         "sink_multiplier": 0.9,  # Sinks slightly slower
         "stationary": False,
@@ -79,7 +79,7 @@ FOOD_TYPES = {
     "energy": {
         "name": "Energy Flake",
         "files": ["food_energy1.png", "food_energy2.png"],
-        "energy": 45.0,  # Good energy (increased 50%)
+        "energy": 70.0,  # Good energy
         "rarity": 0.15,  # 15% spawn rate
         "sink_multiplier": 1.0,  # Normal sink rate
         "stationary": False,
@@ -87,7 +87,7 @@ FOOD_TYPES = {
     "rare": {
         "name": "Rainbow Flake",
         "files": ["food_rare1.png", "food_rare2.png"],
-        "energy": 75.0,  # High energy - rare treat (increased 50%)
+        "energy": 115.0,  # High energy - rare treat
         "rarity": 0.05,  # 5% spawn rate (rare)
         "sink_multiplier": 1.1,  # Sinks bit faster
         "stationary": False,
@@ -95,7 +95,7 @@ FOOD_TYPES = {
     "nectar": {
         "name": "Plant Nectar",
         "files": ["food_vitamin1.png", "food_vitamin2.png"],
-        "energy": 60.0,  # Rewarding stationary food (increased 50%)
+        "energy": 90.0,  # Rewarding stationary food
         "rarity": 0.15,  # Used for plant-only spawn weighting
         "sink_multiplier": 0.0,  # Remains in place
         "stationary": True,

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -15,6 +15,22 @@ interface CollapsibleSectionProps {
   defaultExpanded?: boolean;
 }
 
+/**
+ * Get color for total energy based on food spawning thresholds
+ * Matches the dynamic food spawning system in core/constants.py
+ */
+function getEnergyColor(totalEnergy: number): string {
+  if (totalEnergy < 2000) {
+    return '#ef4444'; // Red - Critical/Starvation (double food spawn)
+  } else if (totalEnergy < 4000) {
+    return '#4ade80'; // Green - Normal (normal food spawn)
+  } else if (totalEnergy < 6000) {
+    return '#fbbf24'; // Yellow - High (reduced food spawn)
+  } else {
+    return '#fb923c'; // Orange - Very High (very reduced food spawn)
+  }
+}
+
 function CollapsibleSection({ title, children, defaultExpanded = true }: CollapsibleSectionProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
@@ -64,7 +80,9 @@ export function StatsPanel({ stats }: StatsPanelProps) {
           </div>
           <div style={styles.summaryItem}>
             <div style={styles.summaryLabel}>Energy</div>
-            <div style={styles.summaryValue}>{stats.total_energy.toFixed(0)}</div>
+            <div style={{...styles.summaryValue, color: getEnergyColor(stats.total_energy)}}>
+              {stats.total_energy.toFixed(0)}
+            </div>
           </div>
           <div style={styles.summaryItem}>
             <div style={styles.summaryLabel}>Frame</div>
@@ -92,7 +110,9 @@ export function StatsPanel({ stats }: StatsPanelProps) {
           </div>
           <div style={styles.statRow}>
             <span style={styles.statLabel}>Total Energy:</span>
-            <span style={styles.statValue}>{stats.total_energy.toFixed(1)}</span>
+            <span style={{...styles.statValue, color: getEnergyColor(stats.total_energy)}}>
+              {stats.total_energy.toFixed(1)}
+            </span>
           </div>
         </div>
       </CollapsibleSection>


### PR DESCRIPTION
- Increased all food energy values by 50%:
  * Algae: 30 → 45
  * Protein: 50 → 75
  * Vitamin: 40 → 60
  * Energy: 45 → 70
  * Rare: 75 → 115
  * Nectar: 60 → 90

- Added dynamic color coding to total energy display in StatsPanel:
  * Red (< 2000): Critical/starvation mode - double food spawn rate
  * Green (2000-3999): Normal - standard food spawn rate
  * Yellow (4000-5999): High - reduced food spawn rate
  * Orange (≥ 6000): Very high - heavily reduced food spawn rate

The color coding now visually indicates when food spawning rates increase or decrease based on ecosystem energy levels.