### PR TITLE
Increase food spawn rates for low energy

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -44,9 +44,10 @@ AUTO_FOOD_SPAWN_RATE = 90  # Spawn food every 3 seconds (90 frames at 30fps) - B
 AUTO_FOOD_ENABLED = True  # Enable/disable automatic food spawning
 
 # Dynamic food spawn scaling based on population and energy
-AUTO_FOOD_LOW_ENERGY_THRESHOLD = 2000  # Double spawn rate below this total energy
-AUTO_FOOD_HIGH_ENERGY_THRESHOLD_1 = 4000  # Reduce spawn rate above this total energy
-AUTO_FOOD_HIGH_ENERGY_THRESHOLD_2 = 6000  # Further reduce spawn rate above this total energy
+AUTO_FOOD_ULTRA_LOW_ENERGY_THRESHOLD = 1500  # Quadruple spawn rate below this total energy (critical)
+AUTO_FOOD_LOW_ENERGY_THRESHOLD = 3500  # Triple spawn rate below this total energy
+AUTO_FOOD_HIGH_ENERGY_THRESHOLD_1 = 4500  # Reduce spawn rate above this total energy
+AUTO_FOOD_HIGH_ENERGY_THRESHOLD_2 = 6500  # Further reduce spawn rate above this total energy
 AUTO_FOOD_HIGH_POP_THRESHOLD_1 = 15  # Reduce spawn rate above this fish count
 AUTO_FOOD_HIGH_POP_THRESHOLD_2 = 20  # Further reduce spawn rate above this fish count
 

--- a/core/simulators/base_simulator.py
+++ b/core/simulators/base_simulator.py
@@ -12,6 +12,7 @@ from core.constants import (
     SCREEN_HEIGHT,
     AUTO_FOOD_SPAWN_RATE,
     AUTO_FOOD_ENABLED,
+    AUTO_FOOD_ULTRA_LOW_ENERGY_THRESHOLD,
     AUTO_FOOD_LOW_ENERGY_THRESHOLD,
     AUTO_FOOD_HIGH_ENERGY_THRESHOLD_1,
     AUTO_FOOD_HIGH_ENERGY_THRESHOLD_2,
@@ -317,8 +318,12 @@ class BaseSimulator(ABC):
         spawn_rate = AUTO_FOOD_SPAWN_RATE
 
         # Priority 1: Emergency feeding when energy is critically low
-        if total_energy < AUTO_FOOD_LOW_ENERGY_THRESHOLD:
-            spawn_rate = AUTO_FOOD_SPAWN_RATE // 2  # Double the drop rate (every 1.5 sec)
+        if total_energy < AUTO_FOOD_ULTRA_LOW_ENERGY_THRESHOLD:
+            # Critical starvation: Quadruple spawn rate (every 0.75 sec)
+            spawn_rate = AUTO_FOOD_SPAWN_RATE // 4
+        elif total_energy < AUTO_FOOD_LOW_ENERGY_THRESHOLD:
+            # Low energy: Triple spawn rate (every 1 sec)
+            spawn_rate = AUTO_FOOD_SPAWN_RATE // 3
 
         # Priority 2: Reduce feeding when energy or population is high
         elif (


### PR DESCRIPTION
- Add ultra-low energy threshold (1500) for critical starvation
- Increase low energy threshold from 2000 to 3500
- Quadruple spawn rate when total energy < 1500 (every 0.75 sec)
- Triple spawn rate when total energy < 3500 (every 1 sec)
- Also increase high energy thresholds to 4500 and 6500 for better balance

This ensures fish have more food available when ecosystem total energy is low.