### PR TITLE
Show energy cost in Poker Activity

### DIFF
--- a/frontend/src/components/PokerEvents.css
+++ b/frontend/src/components/PokerEvents.css
@@ -63,6 +63,11 @@
   color: #fef9c3;
 }
 
+.poker-events__energy-loss {
+  color: #ff4444;
+  font-weight: 600;
+}
+
 @media (max-width: 768px) {
   .poker-events {
     padding: 16px;

--- a/frontend/src/components/PokerEvents.tsx
+++ b/frontend/src/components/PokerEvents.tsx
@@ -42,6 +42,11 @@ const PokerEvents: React.FC<PokerEventsProps> = ({ events, currentFrame }) => {
                   style={{ opacity: fading }}
                 >
                   {event.message}
+                  {!isTie && event.energy_transferred > 0 && (
+                    <span className="poker-events__energy-loss">
+                      {' '}(-{event.energy_transferred.toFixed(1)} energy)
+                    </span>
+                  )}
                 </div>
               );
             })}


### PR DESCRIPTION
Added visual indication of energy loss in poker events:
- Shows energy lost in red next to the event message
- Format: "(-X.X energy)" in red color
- Only displayed for non-tie poker games
- Enhances visibility of energy transfers in poker interactions