### PR TITLE
Fix broken code from last commit

### DIFF
--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -4,7 +4,7 @@
 
 export interface EntityData {
   id: number;
-  type: 'fish' | 'food' | 'plant' | 'crab' | 'castle';
+  type: 'fish' | 'food' | 'plant' | 'crab' | 'castle' | 'jellyfish';
   x: number;
   y: number;
   width: number;
@@ -38,6 +38,9 @@ export interface EntityData {
 
   // Plant-specific
   plant_type?: number;
+
+  // Jellyfish-specific
+  jellyfish_id?: number;
 }
 
 export interface PokerEventData {
@@ -134,7 +137,7 @@ export interface SimulationUpdate {
 }
 
 export interface Command {
-  command: 'add_food' | 'spawn_fish' | 'pause' | 'resume' | 'reset';
+  command: 'add_food' | 'spawn_fish' | 'spawn_jellyfish' | 'pause' | 'resume' | 'reset';
   data?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
The last commit added the jellyfish entity and spawn command but forgot to update the TypeScript type definitions. This caused the frontend to fail when receiving jellyfish data from the backend.

Changes:
- Add 'jellyfish' to EntityData type union
- Add 'spawn_jellyfish' to Command type union
- Add jellyfish_id property to EntityData interface

Fixes the broken frontend from commit 533c51e.