### PR TITLE
Complete app development task

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 # Add parent directory to path so we can import from root tank/ directory
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from models import Command
-from simulation_runner import SimulationRunner
+from backend.models import Command
+from backend.simulation_runner import SimulationRunner
 
 from core.constants import DEFAULT_API_PORT, FRAME_RATE
 

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -161,7 +161,7 @@ class SimulationRunner:
                 leaderboard_data = self.world.ecosystem.get_poker_leaderboard(
                     fish_list=fish_list, limit=10, sort_by="net_energy"
                 )
-                from models import PokerLeaderboardEntry
+                from backend.models import PokerLeaderboardEntry
 
                 poker_leaderboard = [PokerLeaderboardEntry(**entry) for entry in leaderboard_data]
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 3000,
+  },
 })


### PR DESCRIPTION
…port

Fixed three critical issues preventing the app from starting:
1. Fixed incorrect import paths in backend/main.py (models -> backend.models)
2. Fixed incorrect import path in backend/simulation_runner.py
3. Configured Vite frontend to run on port 3000 (was defaulting to 5173)

The app now starts successfully:
- Backend runs on port 8000
- Frontend runs on port 3000 as documented in README