### PR TITLE
Fix broken UI styling in PokerLeaderboard component

### DIFF
--- a/frontend/src/components/PokerLeaderboard.module.css
+++ b/frontend/src/components/PokerLeaderboard.module.css
@@ -1,0 +1,134 @@
+.pokerLeaderboard {
+  background: rgba(0, 0, 0, 0.8);
+  border: 2px solid #4a9eff;
+  border-radius: 8px;
+  padding: 15px;
+  color: white;
+  font-family: 'Courier New', monospace;
+  max-width: 800px;
+  margin: 10px;
+}
+
+.pokerLeaderboard h3 {
+  margin: 0 0 15px 0;
+  font-size: 18px;
+  color: #ffd700;
+  text-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
+}
+
+.leaderboardTable {
+  overflow-x: auto;
+}
+
+.pokerLeaderboard table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.pokerLeaderboard th {
+  background: rgba(74, 158, 255, 0.3);
+  padding: 8px 6px;
+  text-align: left;
+  font-weight: bold;
+  border-bottom: 2px solid #4a9eff;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.pokerLeaderboard td {
+  padding: 8px 6px;
+  border-bottom: 1px solid rgba(74, 158, 255, 0.2);
+}
+
+.pokerLeaderboard tr:hover {
+  background: rgba(74, 158, 255, 0.1);
+}
+
+.rank1 {
+  background: rgba(255, 215, 0, 0.15);
+}
+
+.rank2 {
+  background: rgba(192, 192, 192, 0.15);
+}
+
+.rank3 {
+  background: rgba(205, 127, 50, 0.15);
+}
+
+.rankCell {
+  font-size: 18px;
+  text-align: center;
+  width: 40px;
+}
+
+.fishCell {
+  min-width: 100px;
+}
+
+.fishInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fishId {
+  font-weight: bold;
+  color: #4a9eff;
+}
+
+.fishGen {
+  font-size: 10px;
+  color: #888;
+}
+
+.gamesInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.totalGames {
+  font-weight: bold;
+}
+
+.winLoss {
+  font-size: 10px;
+  color: #aaa;
+}
+
+.positive {
+  color: #4ade80;
+  font-weight: bold;
+}
+
+.negative {
+  color: #f87171;
+  font-weight: bold;
+}
+
+.neutral {
+  color: #fbbf24;
+}
+
+.bestHand {
+  font-size: 11px;
+  color: #a78bfa;
+}
+
+@media (max-width: 768px) {
+  .pokerLeaderboard table {
+    font-size: 11px;
+  }
+
+  .pokerLeaderboard th,
+  .pokerLeaderboard td {
+    padding: 6px 4px;
+  }
+
+  .fishGen,
+  .winLoss {
+    display: none;
+  }
+}

--- a/frontend/src/components/PokerLeaderboard.tsx
+++ b/frontend/src/components/PokerLeaderboard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { PokerLeaderboardEntry } from '../types/simulation';
+import type { PokerLeaderboardEntry } from '../types/simulation';
+import styles from './PokerLeaderboard.module.css';
 
 interface PokerLeaderboardProps {
   leaderboard: PokerLeaderboardEntry[];
@@ -8,7 +9,7 @@ interface PokerLeaderboardProps {
 export const PokerLeaderboard: React.FC<PokerLeaderboardProps> = ({ leaderboard }) => {
   if (!leaderboard || leaderboard.length === 0) {
     return (
-      <div className="poker-leaderboard">
+      <div className={styles.pokerLeaderboard}>
         <h3>🏆 Poker Leaderboard</h3>
         <p style={{ fontSize: '12px', color: '#888', padding: '10px' }}>
           No poker games yet. Fish will appear here after playing poker!
@@ -18,9 +19,9 @@ export const PokerLeaderboard: React.FC<PokerLeaderboardProps> = ({ leaderboard 
   }
 
   return (
-    <div className="poker-leaderboard">
+    <div className={styles.pokerLeaderboard}>
       <h3>🏆 Poker Leaderboard - Top Players</h3>
-      <div className="leaderboard-table">
+      <div className={styles.leaderboardTable}>
         <table>
           <thead>
             <tr>
@@ -34,183 +35,52 @@ export const PokerLeaderboard: React.FC<PokerLeaderboardProps> = ({ leaderboard 
             </tr>
           </thead>
           <tbody>
-            {leaderboard.map((entry) => (
-              <tr key={entry.fish_id} className={entry.rank <= 3 ? `rank-${entry.rank}` : ''}>
-                <td className="rank-cell">
-                  {entry.rank === 1 && '🥇'}
-                  {entry.rank === 2 && '🥈'}
-                  {entry.rank === 3 && '🥉'}
-                  {entry.rank > 3 && entry.rank}
-                </td>
-                <td className="fish-cell">
-                  <div className="fish-info">
-                    <span className="fish-id">#{entry.fish_id}</span>
-                    <span className="fish-gen">Gen {entry.generation}</span>
-                  </div>
-                </td>
-                <td>
-                  <div className="games-info">
-                    <span className="total-games">{entry.total_games}</span>
-                    <span className="win-loss">
-                      ({entry.wins}W-{entry.losses}L)
+            {leaderboard.map((entry) => {
+              const rankClass = entry.rank === 1 ? styles.rank1 : entry.rank === 2 ? styles.rank2 : entry.rank === 3 ? styles.rank3 : '';
+              return (
+                <tr key={entry.fish_id} className={rankClass}>
+                  <td className={styles.rankCell}>
+                    {entry.rank === 1 && '🥇'}
+                    {entry.rank === 2 && '🥈'}
+                    {entry.rank === 3 && '🥉'}
+                    {entry.rank > 3 && entry.rank}
+                  </td>
+                  <td className={styles.fishCell}>
+                    <div className={styles.fishInfo}>
+                      <span className={styles.fishId}>#{entry.fish_id}</span>
+                      <span className={styles.fishGen}>Gen {entry.generation}</span>
+                    </div>
+                  </td>
+                  <td>
+                    <div className={styles.gamesInfo}>
+                      <span className={styles.totalGames}>{entry.total_games}</span>
+                      <span className={styles.winLoss}>
+                        ({entry.wins}W-{entry.losses}L)
+                      </span>
+                    </div>
+                  </td>
+                  <td className={entry.win_rate >= 50 ? styles.positive : styles.neutral}>
+                    {entry.win_rate.toFixed(1)}%
+                  </td>
+                  <td className={entry.net_energy >= 0 ? styles.positive : styles.negative}>
+                    {entry.net_energy >= 0 ? '+' : ''}
+                    {entry.net_energy.toFixed(1)}
+                  </td>
+                  <td>
+                    <span className={entry.current_streak > 0 ? styles.positive : entry.current_streak < 0 ? styles.negative : ''}>
+                      {entry.current_streak > 0 ? '🔥' : entry.current_streak < 0 ? '❄️' : '➖'}
+                      {Math.abs(entry.current_streak)}
                     </span>
-                  </div>
-                </td>
-                <td className={entry.win_rate >= 50 ? 'positive' : 'neutral'}>
-                  {entry.win_rate.toFixed(1)}%
-                </td>
-                <td className={entry.net_energy >= 0 ? 'positive' : 'negative'}>
-                  {entry.net_energy >= 0 ? '+' : ''}
-                  {entry.net_energy.toFixed(1)}
-                </td>
-                <td>
-                  <span className={entry.current_streak > 0 ? 'positive' : entry.current_streak < 0 ? 'negative' : ''}>
-                    {entry.current_streak > 0 ? '🔥' : entry.current_streak < 0 ? '❄️' : '➖'}
-                    {Math.abs(entry.current_streak)}
-                  </span>
-                </td>
-                <td className="best-hand">
-                  {getHandEmoji(entry.best_hand_rank)} {entry.best_hand}
-                </td>
-              </tr>
-            ))}
+                  </td>
+                  <td className={styles.bestHand}>
+                    {getHandEmoji(entry.best_hand_rank)} {entry.best_hand}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
-      <style jsx>{`
-        .poker-leaderboard {
-          background: rgba(0, 0, 0, 0.8);
-          border: 2px solid #4a9eff;
-          border-radius: 8px;
-          padding: 15px;
-          color: white;
-          font-family: 'Courier New', monospace;
-          max-width: 800px;
-          margin: 10px;
-        }
-
-        h3 {
-          margin: 0 0 15px 0;
-          font-size: 18px;
-          color: #ffd700;
-          text-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
-        }
-
-        .leaderboard-table {
-          overflow-x: auto;
-        }
-
-        table {
-          width: 100%;
-          border-collapse: collapse;
-          font-size: 13px;
-        }
-
-        th {
-          background: rgba(74, 158, 255, 0.3);
-          padding: 8px 6px;
-          text-align: left;
-          font-weight: bold;
-          border-bottom: 2px solid #4a9eff;
-          font-size: 12px;
-          text-transform: uppercase;
-        }
-
-        td {
-          padding: 8px 6px;
-          border-bottom: 1px solid rgba(74, 158, 255, 0.2);
-        }
-
-        tr:hover {
-          background: rgba(74, 158, 255, 0.1);
-        }
-
-        .rank-1 {
-          background: rgba(255, 215, 0, 0.15);
-        }
-
-        .rank-2 {
-          background: rgba(192, 192, 192, 0.15);
-        }
-
-        .rank-3 {
-          background: rgba(205, 127, 50, 0.15);
-        }
-
-        .rank-cell {
-          font-size: 18px;
-          text-align: center;
-          width: 40px;
-        }
-
-        .fish-cell {
-          min-width: 100px;
-        }
-
-        .fish-info {
-          display: flex;
-          flex-direction: column;
-          gap: 2px;
-        }
-
-        .fish-id {
-          font-weight: bold;
-          color: #4a9eff;
-        }
-
-        .fish-gen {
-          font-size: 10px;
-          color: #888;
-        }
-
-        .games-info {
-          display: flex;
-          flex-direction: column;
-          gap: 2px;
-        }
-
-        .total-games {
-          font-weight: bold;
-        }
-
-        .win-loss {
-          font-size: 10px;
-          color: #aaa;
-        }
-
-        .positive {
-          color: #4ade80;
-          font-weight: bold;
-        }
-
-        .negative {
-          color: #f87171;
-          font-weight: bold;
-        }
-
-        .neutral {
-          color: #fbbf24;
-        }
-
-        .best-hand {
-          font-size: 11px;
-          color: #a78bfa;
-        }
-
-        @media (max-width: 768px) {
-          table {
-            font-size: 11px;
-          }
-
-          th, td {
-            padding: 6px 4px;
-          }
-
-          .fish-gen, .win-loss {
-            display: none;
-          }
-        }
-      `}</style>
     </div>
   );
 };


### PR DESCRIPTION
The PokerLeaderboard component was using <style jsx> syntax which is specific to Next.js and not supported in Vite + React. This caused the entire app to crash with a blank screen.

Changes:
- Created PokerLeaderboard.module.css with all styles converted to standard CSS module format
- Updated PokerLeaderboard.tsx to import and use the CSS module
- Replaced all className strings with CSS module references
- Fixed type import to use 'import type' for PokerLeaderboardEntry

The app now builds successfully without syntax errors.

Fixes the issue introduced in commit ed45425