### PR TITLE
Debug simulation broken by recent fix

### DIFF
--- a/core/jellyfish_poker.py
+++ b/core/jellyfish_poker.py
@@ -153,8 +153,8 @@ class JellyfishPokerInteraction:
             initial_bet=bet_amount,
             player1_energy=self.fish.energy,
             player2_energy=self.jellyfish.energy,
-            player1_aggression=fish_aggression if button_position == 1 else jellyfish_aggression,
-            player2_aggression=jellyfish_aggression if button_position == 1 else fish_aggression,
+            player1_aggression=fish_aggression,
+            player2_aggression=jellyfish_aggression,
             button_position=button_position
         )
 


### PR DESCRIPTION
Fixed bug in jellyfish_poker.py where aggression parameters were being incorrectly swapped based on button position. This caused the fish and jellyfish to play with each other's strategies.

The issue was introduced in commit a30dc3f when converting to use the static PokerEngine.simulate_multi_round_game() method.

Changes:
- player1_aggression now always uses fish_aggression (not swapped)
- player2_aggression now always uses jellyfish_aggression (not swapped)
- This matches the pattern used in fish_poker.py where player roles are consistent regardless of button position