### PR TITLE
Debug simulation not running in headless mode

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -112,9 +112,12 @@ class TestFish:
         """Test that fish initializes correctly."""
         env, _ = simulation_env
         strategy = AlgorithmicMovement()
-        fish = Fish(env, strategy, ["george1.png"], 100, 100, 3)
+        # Create a genome with size_modifier=1.0 for deterministic testing
+        from core.genetics import Genome
+        genome = Genome(size_modifier=1.0)
+        fish = Fish(env, strategy, ["george1.png"], 100, 100, 3, genome=genome)
 
-        # Fish start as babies with size 0.5
+        # Fish start as babies with size 0.5 (when genetic size_modifier is 1.0)
         assert fish.size == 0.5
         assert fish.movement_strategy == strategy
 


### PR DESCRIPTION
The test was failing because Fish initialization with a random genome results in a random genetic size_modifier (0.7-1.3), causing the initial size to vary. Fixed by creating a Fish with a specific genome that has size_modifier=1.0, ensuring the size is exactly 0.5 (FISH_BABY_SIZE).

This makes the test deterministic and properly validates the fish initialization behavior without relying on random genetics.