### PR TITLE
Fix Python 3.13 compatibility and add Windows setup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,32 @@ Built with **React + FastAPI + WebSocket**:
 
 ### Installation
 
+#### Windows (PowerShell)
+
+```powershell
+# Create and activate virtual environment (recommended)
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+
+# Run the setup script
+.\setup-windows.ps1
+
+# Or manually install dependencies
+python -m pip install --upgrade pip
+python -m pip install -e .
+
+# Install frontend dependencies (in frontend\ directory)
+cd frontend
+npm install
+```
+
+#### Linux/Mac
+
 ```bash
+# Create and activate virtual environment (recommended)
+python3 -m venv .venv
+source .venv/bin/activate
+
 # Install Python dependencies
 pip install -e .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [
@@ -33,7 +35,7 @@ dependencies = [
     "fastapi>=0.109.0",
     "uvicorn[standard]>=0.27.0",
     "websockets>=12.0",
-    "pydantic>=2.5.0",
+    "pydantic>=2.6.0",  # Required for Python 3.13 compatibility
 ]
 
 [project.optional-dependencies]

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1,0 +1,59 @@
+# Fish Tank Simulation - Windows Setup Script
+# This script sets up the Python environment and installs dependencies
+
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host "Fish Tank Simulation - Setup" -ForegroundColor Cyan
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Check if we're in a virtual environment
+if ($env:VIRTUAL_ENV) {
+    Write-Host "Virtual environment detected: $env:VIRTUAL_ENV" -ForegroundColor Green
+} else {
+    Write-Host "WARNING: No virtual environment detected!" -ForegroundColor Yellow
+    Write-Host "It's recommended to use a virtual environment." -ForegroundColor Yellow
+    Write-Host "Activate your .venv with:" -ForegroundColor Yellow
+    Write-Host "  .\.venv\Scripts\Activate.ps1" -ForegroundColor White
+    Write-Host ""
+
+    $response = Read-Host "Continue anyway? (y/N)"
+    if ($response -ne 'y' -and $response -ne 'Y') {
+        Write-Host "Setup cancelled." -ForegroundColor Red
+        exit 1
+    }
+}
+
+# Check Python version
+Write-Host "Checking Python version..." -ForegroundColor Cyan
+$pythonVersion = python --version 2>&1
+Write-Host "Found: $pythonVersion" -ForegroundColor Green
+
+# Upgrade pip
+Write-Host ""
+Write-Host "Upgrading pip..." -ForegroundColor Cyan
+python -m pip install --upgrade pip
+
+# Install the package in development mode
+Write-Host ""
+Write-Host "Installing fish tank simulation and dependencies..." -ForegroundColor Cyan
+python -m pip install -e .
+
+# Install development dependencies (optional)
+Write-Host ""
+$installDev = Read-Host "Install development dependencies (pytest, mypy, black, ruff)? (Y/n)"
+if ($installDev -ne 'n' -and $installDev -ne 'N') {
+    Write-Host "Installing development dependencies..." -ForegroundColor Cyan
+    python -m pip install -e ".[dev]"
+}
+
+Write-Host ""
+Write-Host "======================================" -ForegroundColor Green
+Write-Host "Setup Complete!" -ForegroundColor Green
+Write-Host "======================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "To run the web server:" -ForegroundColor Cyan
+Write-Host "  python main.py" -ForegroundColor White
+Write-Host ""
+Write-Host "To run in headless mode:" -ForegroundColor Cyan
+Write-Host "  python main.py --headless --max-frames 1000" -ForegroundColor White
+Write-Host ""


### PR DESCRIPTION
- Updated pydantic requirement from >=2.5.0 to >=2.6.0 for Python 3.13 compatibility
- Added Python 3.12 and 3.13 to supported versions in classifiers
- Created setup-windows.ps1 PowerShell script for easy Windows installation
- Added Windows-specific installation instructions to README.md

This fixes the ImportError when running main.py on Windows with Python 3.13,
which was caused by incompatibility between Python 3.13 and pydantic <2.6.0.