### PR TITLE
Increase castle size and adjust background layer

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -101,6 +101,18 @@ class SimulationRunner:
                 if entity_data:
                     entities_data.append(entity_data)
 
+            # Sort entities by z-order (background to foreground)
+            # This ensures castles and plants are rendered first (background)
+            z_order = {
+                'castle': 0,
+                'plant': 1,
+                'food': 2,
+                'crab': 3,
+                'fish': 4,
+                'jellyfish': 5,
+            }
+            entities_data.sort(key=lambda e: z_order.get(e.type, 999))
+
             # Get ecosystem stats
             stats = self.world.get_stats()
 

--- a/core/entities.py
+++ b/core/entities.py
@@ -1255,6 +1255,9 @@ class Castle(Agent):
             screen_height: Height of simulation area
         """
         super().__init__(environment, x, y, 0, screen_width, screen_height)
+        # Make castle larger (3x default size)
+        self.width = 150.0
+        self.height = 150.0
 
 
 class Jellyfish(Agent):


### PR DESCRIPTION
- Increase castle size from 50x50 to 150x150 (3x larger)
- Add z-order sorting to ensure castle renders in background
- Sort entities: castle(0), plant(1), food(2), crab(3), fish(4), jellyfish(5)
- Castle now appears as a prominent background element