### PR TITLE
Fix missing react-d3-tree import dependency

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -246,7 +246,7 @@ async def get_lineage():
     """
     try:
         # Get lineage data from ecosystem manager
-        lineage_data = simulation.simulation.ecosystem.get_lineage_data()
+        lineage_data = simulation.world.ecosystem.get_lineage_data()
         return JSONResponse(lineage_data)
     except Exception as e:
         logger.error(f"Error getting lineage data: {e}", exc_info=True)


### PR DESCRIPTION
The /api/lineage endpoint was failing with a 500 error because it was trying to access simulation.simulation.ecosystem, but SimulationRunner has a 'world' attribute (TankWorld instance), not 'simulation'.

Changed the path from:
  simulation.simulation.ecosystem.get_lineage_data()
to:
  simulation.world.ecosystem.get_lineage_data()

This fixes the AttributeError and allows the phylogenetic tree visualization to load properly.