### PR TITLE
Raise castle to show distance perspective

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -123,7 +123,7 @@ INIT_POS = {
     "plant2": (10, 510),
     "plant3": (500, 510),  # Add third plant
     "plant4": (700, 510),  # Add fourth plant
-    "castle": (100, 500),
+    "castle": (100, 420),
 }
 
 # UI Constants - Poker Notifications


### PR DESCRIPTION
Move castle from y=500 to y=420 to make it appear more distant in the scene. This creates better depth perception by positioning the castle higher in the viewport.