### PR TITLE
Fix initial fish size in population

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -133,6 +133,12 @@ app.add_middleware(
 async def broadcast_updates():
     """Broadcast simulation updates to all connected clients."""
     logger.info("broadcast_updates: Task started")
+
+    # Unpause simulation now that broadcast task is ready
+    # This prevents initial fish from aging before the frontend sees them
+    simulation.world.paused = False
+    logger.info("broadcast_updates: Simulation unpaused")
+
     frame_count = 0
     try:
         while True:

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -31,6 +31,10 @@ class SimulationRunner:
         self.world = TankWorld(config=config, seed=seed)
         self.world.setup()
 
+        # Start paused to prevent initial fish from aging before frontend sees them
+        # This ensures all fish (initial and spawned) appear at baby size when first created
+        self.world.paused = True
+
         self.running = False
         self.thread: Optional[threading.Thread] = None
         self.lock = threading.Lock()


### PR DESCRIPTION
Fixed a race condition where initial fish appeared larger than baby size on first render, while spawned fish correctly appeared as babies.

**Root Cause:**
- Backend initialization created fish at age=0 with baby size (0.5)
- Simulation background thread started immediately and began updating fish
- By the time frontend connected, initial fish had aged 5-15+ frames
- Size grows from 0.5 to 1.0 over 300 frames, so aged fish appeared larger
- Spawned fish were added after update cycles, so appeared at age=0

**Solution:**
- Initialize simulation in paused state (paused=True)
- Unpause when broadcast task starts
- Ensures initial fish remain at age=0 until frontend is ready
- All fish (initial and spawned) now appear at baby size when created

Files changed:
- backend/simulation_runner.py: Start paused during initialization
- backend/main.py: Unpause when broadcast task begins