### PR TITLE
Add fish poker skill detection system

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -36,12 +36,13 @@ class PokerEventData(BaseModel):
     """A single poker game event."""
 
     frame: int
-    winner_id: int  # -1 for tie
-    loser_id: int
+    winner_id: int  # -1 for tie, -2 for jellyfish
+    loser_id: int  # -2 for jellyfish
     winner_hand: str
     loser_hand: str
     energy_transferred: float
     message: str
+    is_jellyfish: bool = False
 
 
 class PokerLeaderboardEntry(BaseModel):
@@ -67,6 +68,8 @@ class PokerLeaderboardEntry(BaseModel):
     showdown_win_rate: float  # Percentage (0-100)
     fold_rate: float  # Percentage (0-100)
     positional_advantage: float  # Percentage (0-100)
+    recent_win_rate: float = 0.0  # Recent win rate (0-100)
+    skill_trend: str = "stable"  # "improving", "declining", or "stable"
 
 
 class PokerStatsData(BaseModel):

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -180,6 +180,7 @@ class SimulationRunner:
                         loser_hand=event["loser_hand"],
                         energy_transferred=event["energy_transferred"],
                         message=event["message"],
+                        is_jellyfish=event.get("is_jellyfish", False),
                     )
                 )
 

--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -1054,6 +1054,8 @@ class EcosystemManager:
                     "showdown_win_rate": round(stats.get_showdown_win_rate() * 100, 1),
                     "fold_rate": round(stats.get_fold_rate() * 100, 1),
                     "positional_advantage": round(stats.get_positional_advantage() * 100, 1),
+                    "recent_win_rate": round(stats.get_recent_win_rate() * 100, 1),
+                    "skill_trend": stats.get_skill_trend(),
                 }
             )
 

--- a/core/simulators/base_simulator.py
+++ b/core/simulators/base_simulator.py
@@ -198,6 +198,15 @@ class BaseSimulator(ABC):
         # Fish-to-jellyfish poker interaction
         poker = JellyfishPokerInteraction(fish, jellyfish)
         if poker.play_poker():
+            # Add jellyfish poker event if available
+            if hasattr(self, 'add_jellyfish_poker_event') and poker.result is not None:
+                self.add_jellyfish_poker_event(
+                    fish_id=poker.result.fish_id,
+                    fish_won=poker.result.fish_won,
+                    fish_hand=poker.result.fish_hand.description,
+                    jellyfish_hand=poker.result.jellyfish_hand.description,
+                    energy_transferred=abs(poker.result.energy_transferred)
+                )
             # Check if fish died from poker
             if fish.is_dead() and fish in self.get_all_entities():
                 self.record_fish_death(fish)

--- a/frontend/src/components/PokerEvents.css
+++ b/frontend/src/components/PokerEvents.css
@@ -63,6 +63,17 @@
   color: #fef9c3;
 }
 
+.poker-events__item.jellyfish {
+  border-color: rgba(147, 51, 234, 0.5);
+  background: rgba(107, 33, 168, 0.15);
+  color: #e9d5ff;
+}
+
+.poker-events__jellyfish-icon {
+  font-size: 16px;
+  margin-right: 4px;
+}
+
 .poker-events__energy-loss {
   color: #ff4444;
   font-weight: 600;

--- a/frontend/src/components/PokerEvents.tsx
+++ b/frontend/src/components/PokerEvents.tsx
@@ -9,6 +9,7 @@ interface PokerEvent {
   loser_hand: string;
   energy_transferred: number;
   message: string;
+  is_jellyfish?: boolean;
 }
 
 interface PokerEventsProps {
@@ -21,7 +22,7 @@ const PokerEvents: React.FC<PokerEventsProps> = ({ events, currentFrame }) => {
     <section className="poker-events" aria-label="Recent poker activity">
       <div className="poker-events__header">
         <h2>Poker Activity</h2>
-        <span>Latest clashes between fish</span>
+        <span>Latest clashes between fish and jellyfish</span>
       </div>
       {events.length === 0 ? (
         <p className="poker-events__empty">No poker activity yet.</p>
@@ -33,14 +34,16 @@ const PokerEvents: React.FC<PokerEventsProps> = ({ events, currentFrame }) => {
             .map((event, index) => {
               const age = currentFrame - event.frame;
               const isTie = event.winner_id === -1;
+              const isJellyfish = event.is_jellyfish ?? false;
               const fading = Math.max(0.35, 1 - Math.max(0, age - 90) / 90);
 
               return (
                 <div
                   key={`${event.frame}-${index}`}
-                  className={`poker-events__item ${isTie ? 'tie' : ''}`}
+                  className={`poker-events__item ${isTie ? 'tie' : ''} ${isJellyfish ? 'jellyfish' : ''}`}
                   style={{ opacity: fading }}
                 >
+                  {isJellyfish && <span className="poker-events__jellyfish-icon">🪼 </span>}
                   {event.message}
                   {!isTie && event.energy_transferred > 0 && (
                     <span className="poker-events__energy-loss">

--- a/frontend/src/components/PokerLeaderboard.module.css
+++ b/frontend/src/components/PokerLeaderboard.module.css
@@ -117,6 +117,28 @@
   color: #a78bfa;
 }
 
+.trendCell {
+  text-align: center;
+  font-size: 14px;
+}
+
+.improving {
+  color: #4ade80;
+  font-weight: bold;
+  cursor: help;
+}
+
+.declining {
+  color: #f87171;
+  font-weight: bold;
+  cursor: help;
+}
+
+.stable {
+  color: #94a3b8;
+  cursor: help;
+}
+
 @media (max-width: 768px) {
   .pokerLeaderboard table {
     font-size: 11px;

--- a/frontend/src/components/PokerLeaderboard.tsx
+++ b/frontend/src/components/PokerLeaderboard.tsx
@@ -23,6 +23,7 @@ export const PokerLeaderboard: React.FC<PokerLeaderboardProps> = ({ leaderboard 
               <th>Fish</th>
               <th>Games</th>
               <th>Win%</th>
+              <th>Trend</th>
               <th>Net Energy</th>
               <th>Streak</th>
               <th>Best Hand</th>
@@ -55,6 +56,9 @@ export const PokerLeaderboard: React.FC<PokerLeaderboardProps> = ({ leaderboard 
                   </td>
                   <td className={entry.win_rate >= 50 ? styles.positive : styles.neutral}>
                     {entry.win_rate.toFixed(1)}%
+                  </td>
+                  <td className={styles.trendCell}>
+                    {getTrendIndicator(entry.skill_trend, entry.recent_win_rate)}
                   </td>
                   <td className={entry.net_energy >= 0 ? styles.positive : styles.negative}>
                     {entry.net_energy >= 0 ? '+' : ''}
@@ -94,4 +98,27 @@ function getHandEmoji(rank: number): string {
     '👑', // Royal Flush
   ];
   return emojis[rank] || '🃏';
+}
+
+// Helper function to get trend indicator
+function getTrendIndicator(trend: string, recentWinRate: number): React.ReactNode {
+  if (trend === 'improving') {
+    return (
+      <span className={styles.improving} title={`Recent: ${recentWinRate.toFixed(1)}%`}>
+        📈 ↗
+      </span>
+    );
+  } else if (trend === 'declining') {
+    return (
+      <span className={styles.declining} title={`Recent: ${recentWinRate.toFixed(1)}%`}>
+        📉 ↘
+      </span>
+    );
+  } else {
+    return (
+      <span className={styles.stable} title={`Recent: ${recentWinRate.toFixed(1)}%`}>
+        ➡ ─
+      </span>
+    );
+  }
 }

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -45,12 +45,13 @@ export interface EntityData {
 
 export interface PokerEventData {
   frame: number;
-  winner_id: number;  // -1 for tie
-  loser_id: number;
+  winner_id: number;  // -1 for tie, -2 for jellyfish
+  loser_id: number;  // -2 for jellyfish
   winner_hand: string;
   loser_hand: string;
   energy_transferred: number;
   message: string;
+  is_jellyfish?: boolean;
 }
 
 export interface PokerLeaderboardEntry {
@@ -74,6 +75,8 @@ export interface PokerLeaderboardEntry {
   showdown_win_rate: number;  // Percentage (0-100)
   fold_rate: number;  // Percentage (0-100)
   positional_advantage: number;  // Percentage (0-100)
+  recent_win_rate: number;  // Recent win rate (0-100)
+  skill_trend: string;  // "improving", "declining", or "stable"
 }
 
 export interface PokerStatsData {

--- a/simulation_engine.py
+++ b/simulation_engine.py
@@ -346,6 +346,43 @@ class SimulationEngine(BaseSimulator):
             "loser_hand": loser_hand_obj.description if loser_hand_obj is not None else "Unknown",
             "energy_transferred": result.energy_transferred,
             "message": message,
+            "is_jellyfish": False,
+        }
+
+        self.poker_events.append(event)
+
+        # Keep only last MAX_POKER_EVENTS
+        if len(self.poker_events) > MAX_POKER_EVENTS:
+            self.poker_events.pop(0)
+
+    def add_jellyfish_poker_event(self, fish_id: int, fish_won: bool,
+                                   fish_hand: str, jellyfish_hand: str,
+                                   energy_transferred: float) -> None:
+        """Add a jellyfish poker event to the recent events list.
+
+        Args:
+            fish_id: ID of the fish that played
+            fish_won: Whether the fish won
+            fish_hand: Description of the fish's hand
+            jellyfish_hand: Description of the jellyfish's hand
+            energy_transferred: Amount of energy transferred
+        """
+        # Create event message with jellyfish emoji indicator
+        if fish_won:
+            message = f"Fish #{fish_id} beats Jellyfish with {fish_hand}! (+{energy_transferred:.1f} energy)"
+        else:
+            message = f"Jellyfish beats Fish #{fish_id} with {jellyfish_hand}! (-{energy_transferred:.1f} energy)"
+
+        # Create event data
+        event = {
+            "frame": self.frame_count,
+            "winner_id": fish_id if fish_won else -2,  # -2 indicates jellyfish won
+            "loser_id": -2 if fish_won else fish_id,  # -2 indicates jellyfish lost
+            "winner_hand": fish_hand if fish_won else jellyfish_hand,
+            "loser_hand": jellyfish_hand if fish_won else fish_hand,
+            "energy_transferred": energy_transferred,
+            "message": message,
+            "is_jellyfish": True,
         }
 
         self.poker_events.append(event)


### PR DESCRIPTION
This commit makes it easy to tell when fish are playing poker with the jellyfish and whether fish are improving at poker over time.

Changes:
- Add jellyfish poker games to poker events feed with distinct styling
  - Jellyfish games show with 🪼 emoji and purple background
  - Events clearly indicate "Fish vs Jellyfish" matchups
- Add skill progression tracking for fish poker performance
  - Track recent win rate (last 10 games) vs overall win rate
  - Calculate skill trends: improving, declining, or stable
  - Use 10% threshold to filter out noise
- Add skill trend visualization to poker leaderboard
  - New "Trend" column with visual indicators:
    - 📈 ↗ for improving players (green)
    - 📉 ↘ for declining players (red)
    - ➡ ─ for stable players (gray)
  - Hover tooltip shows recent win rate percentage
- Backend changes:
  - Add is_jellyfish flag to poker events
  - Track recent game results in deque (maxlen=10)
  - Add recent_win_rate and skill_trend to leaderboard data
- Frontend changes:
  - Update TypeScript interfaces for new fields
  - Style jellyfish events distinctly in poker feed
  - Display skill trends with emojis in leaderboard

Now users can easily see:
1. When fish play poker against the jellyfish benchmark
2. Which fish are improving their poker skills over time
3. Recent performance trends for each fish