### PR TITLE
Code cleanup and remove unused pygame

### DIFF
--- a/core/algorithms/base.py
+++ b/core/algorithms/base.py
@@ -3,7 +3,6 @@
 This module contains:
 - BehaviorAlgorithm base class
 - ALGORITHM_PARAMETER_BOUNDS configuration
-- Vector2 implementation (if pygame not available)
 - Helper functions for algorithm execution
 """
 

--- a/core/entities.py
+++ b/core/entities.py
@@ -1,7 +1,7 @@
-"""Pure entity classes without pygame dependencies.
+"""Pure entity classes for the simulation.
 
 This module contains the core simulation logic for all entities in the fish tank.
-No pygame-specific code is included - all rendering is handled separately.
+All rendering is handled separately by the frontend.
 """
 
 import random
@@ -37,7 +37,6 @@ from core.constants import (
     TARGET_POPULATION,
 )
 
-# Use a simple Vector2 class or import from pygame.math (we'll create a pure version)
 from core.math_utils import Vector2
 
 if TYPE_CHECKING:
@@ -57,7 +56,7 @@ class LifeStage(Enum):
 
 
 class Rect:
-    """Simple rectangle class for test compatibility (pygame.Rect replacement)."""
+    """Simple rectangle class for collision detection and positioning."""
 
     def __init__(self, x: float = 0, y: float = 0, width: float = 32, height: float = 32):
         self.x = x
@@ -258,12 +257,12 @@ class Agent:
             self.vel += difference.normalize() * 0.1  # ALIGNMENT_SPEED_CHANGE
 
     def add_internal(self, group) -> None:
-        """Track sprite group for kill() method (pygame compatibility)."""
+        """Track group for kill() method."""
         if group not in self._groups:
             self._groups.append(group)
 
     def kill(self) -> None:
-        """Remove this agent from all groups (pygame compatibility)."""
+        """Remove this agent from all groups."""
         for group in self._groups[:]:  # Copy list to avoid modification during iteration
             if hasattr(group, "remove"):
                 group.remove(self)

--- a/core/math_utils.py
+++ b/core/math_utils.py
@@ -1,69 +1,66 @@
 """Centralized math utilities for the simulation.
 
-This module provides a single source of truth for mathematical utilities,
-including Vector2 implementation that works with or without pygame.
+This module provides pure Python mathematical utilities for the simulation,
+including a Vector2 implementation for 2D vector operations.
 """
 
 import math
 
-try:
-    from pygame.math import Vector2
-except ImportError:
-    # Fallback for environments without pygame
-    class Vector2:
-        """A 2D vector class compatible with pygame.math.Vector2 interface."""
 
-        def __init__(self, x=0, y=0):
-            self.x = float(x)
-            self.y = float(y)
+class Vector2:
+    """A 2D vector class for mathematical operations."""
 
-        def __add__(self, other):
-            return Vector2(self.x + other.x, self.y + other.y)
+    def __init__(self, x=0, y=0):
+        self.x = float(x)
+        self.y = float(y)
 
-        def __sub__(self, other):
-            return Vector2(self.x - other.x, self.y - other.y)
+    def __add__(self, other):
+        return Vector2(self.x + other.x, self.y + other.y)
 
-        def __mul__(self, scalar):
-            return Vector2(self.x * scalar, self.y * scalar)
+    def __sub__(self, other):
+        return Vector2(self.x - other.x, self.y - other.y)
 
-        def __truediv__(self, scalar):
-            return Vector2(self.x / scalar, self.y / scalar)
+    def __mul__(self, scalar):
+        return Vector2(self.x * scalar, self.y * scalar)
 
-        def length(self):
-            return math.sqrt(self.x**2 + self.y**2)
+    def __truediv__(self, scalar):
+        return Vector2(self.x / scalar, self.y / scalar)
 
-        def length_squared(self):
-            return self.x**2 + self.y**2
+    def length(self):
+        return math.sqrt(self.x**2 + self.y**2)
 
-        def normalize(self):
-            length = self.length()
-            if length == 0:
-                return Vector2(0, 0)
-            return Vector2(self.x / length, self.y / length)
+    def length_squared(self):
+        return self.x**2 + self.y**2
 
-        def dot(self, other):
-            return self.x * other.x + self.y * other.y
+    def normalize(self):
+        length = self.length()
+        if length == 0:
+            return Vector2(0, 0)
+        return Vector2(self.x / length, self.y / length)
 
-        def update(self, x, y):
-            self.x = float(x)
-            self.y = float(y)
+    def dot(self, other):
+        return self.x * other.x + self.y * other.y
 
-        def copy(self):
-            """Return a copy of this vector."""
-            return Vector2(self.x, self.y)
+    def update(self, x, y):
+        self.x = float(x)
+        self.y = float(y)
 
-        def __eq__(self, other):
-            """Check if two vectors are equal."""
-            if not isinstance(other, Vector2):
-                return False
-            return abs(self.x - other.x) < 1e-9 and abs(self.y - other.y) < 1e-9
+    def copy(self):
+        """Return a copy of this vector."""
+        return Vector2(self.x, self.y)
 
-        def __ne__(self, other):
-            """Check if two vectors are not equal."""
-            return not self.__eq__(other)
+    def __eq__(self, other):
+        """Check if two vectors are equal."""
+        if not isinstance(other, Vector2):
+            return False
+        return abs(self.x - other.x) < 1e-9 and abs(self.y - other.y) < 1e-9
 
-        def __repr__(self):
-            return f"Vector2({self.x}, {self.y})"
+    def __ne__(self, other):
+        """Check if two vectors are not equal."""
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return f"Vector2({self.x}, {self.y})"
 
 
 __all__ = ["Vector2"]

--- a/tests/test_headless_equivalence.py
+++ b/tests/test_headless_equivalence.py
@@ -118,8 +118,7 @@ def test_statistical_equivalence():
 def test_mode_independence():
     """Verify that headless=True parameter is consistently used.
 
-    This ensures no pygame or visualization dependencies leak into the
-    simulation logic.
+    This ensures no visualization dependencies leak into the simulation logic.
     """
     print("=" * 80)
     print("TESTING: Mode Independence")


### PR DESCRIPTION
- Remove optional pygame import fallback in math_utils.py
- Use pure Python Vector2 class directly (no try/except needed)
- Update docstrings to remove pygame references
- Clean up comments mentioning pygame compatibility
- All functionality remains the same, just cleaner code

The codebase is now fully pygame-free with a clean pure Python implementation for all mathematical operations.