### PR TITLE
Add random fish spawning to tank

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -6,7 +6,7 @@ SCREEN_HEIGHT = 600
 FRAME_RATE = 30
 
 # The number of schooling fish to create at the start of the game
-NUM_SCHOOLING_FISH = 10  # Increased to create resource competition
+NUM_SCHOOLING_FISH = 0  # Start with empty tank, let random spawning populate
 
 # Target stable population for ecosystem balance
 TARGET_POPULATION = 15


### PR DESCRIPTION
Changed NUM_SCHOOLING_FISH from 10 to 0 to start with an empty tank. The emergency spawning mechanism will automatically populate the tank since the population starts below the critical threshold (10 fish).