### PR TITLE
Fix poker game startup failure

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -480,6 +480,12 @@ class SimulationRunner:
 
                     logger.info(f"Created human poker game {game_id} with {len(ai_fish)} AI opponents")
 
+                    # Return the initial game state to the frontend
+                    return {
+                        "success": True,
+                        "state": self.human_poker_game.get_state(),
+                    }
+
                 except Exception as e:
                     logger.error(f"Error starting poker game: {e}", exc_info=True)
                     return {


### PR DESCRIPTION
The poker game was being created successfully but the backend wasn't returning the game state to the frontend, causing a timeout error.

Changes:
- Added return statement after successful game creation in start_poker command
- Returns success=True and initial game state to frontend
- Resolves "Failed to start poker game" error

The game creation logic was working correctly, but without the return statement, the frontend received no response and displayed an error.