### PR TITLE
Fix missing poker_strategy attribute in Genome

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -548,7 +548,7 @@ class SimulationRunner:
                         fish = fish_list[0]
                         fish_name = f"{fish.genome.behavior_algorithm.algorithm_id} (Gen {fish.generation})"
                         fish_energy = fish.energy
-                        fish_poker_strategy = fish.genome.poker_strategy
+                        fish_poker_strategy = fish.genome.poker_strategy_algorithm
                     else:
                         # Find the actual fish object
                         fish = next(
@@ -557,7 +557,7 @@ class SimulationRunner:
                         )
                         fish_name = f"{top_fish_entry['algorithm'][:20]} (Gen {top_fish_entry['generation']})"
                         fish_energy = fish.energy
-                        fish_poker_strategy = fish.genome.poker_strategy
+                        fish_poker_strategy = fish.genome.poker_strategy_algorithm
 
                     # Create auto-evaluation game
                     game_id = str(uuid.uuid4())


### PR DESCRIPTION
…bute

The auto-evaluation feature was failing with 'Genome' object has no attribute 'poker_strategy'. Fixed by using the correct attribute name 'poker_strategy_algorithm' which is defined in the Genome class.

Changes:
- backend/simulation_runner.py: Changed fish.genome.poker_strategy to fish.genome.poker_strategy_algorithm (lines 551, 560)