### PR TITLE
Fix poker auto evaluation and show fish numbers

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -599,6 +599,8 @@ class SimulationRunner:
                         "winner": final_stats.winner,
                         "reason": final_stats.reason,
                         "fish_name": fish_name,
+                        "fish_id": fish.fish_id,
+                        "fish_generation": fish.generation,
                         "fish_net_energy": round(final_stats.fish_total_won - final_stats.fish_total_lost, 1),
                         "fish_win_rate": round(final_stats.fish_wins / final_stats.hands_played * 100, 1) if final_stats.hands_played > 0 else 0.0,
                     }

--- a/frontend/src/components/AutoEvaluateDisplay.tsx
+++ b/frontend/src/components/AutoEvaluateDisplay.tsx
@@ -19,6 +19,8 @@ interface AutoEvaluateStats {
   winner: string | null;
   reason: string;
   fish_name: string;
+  fish_id: number;
+  fish_generation: number;
   fish_net_energy: number;
   fish_win_rate: number;
 }
@@ -99,7 +101,7 @@ export function AutoEvaluateDisplay({ stats, onClose, loading }: AutoEvaluateDis
         {/* Fish Stats */}
         <div style={styles.playerSection}>
           <h4 style={styles.playerName}>
-            🐟 {stats.fish_name}
+            🐟 {stats.fish_name} #{stats.fish_id}
           </h4>
           <div style={styles.statsGrid}>
             <div style={styles.statRow}>


### PR DESCRIPTION
- Include fish_id and generation in backend auto-evaluate response
- Update frontend AutoEvaluateStats interface to include fish_id and fish_generation
- Display fish number alongside fish name in auto-evaluate results (e.g., "🐟 Algorithm Name (Gen 5) #42")

This makes it easier to identify which specific fish was evaluated, matching the format used in the leaderboard.