### PR TITLE
Fix game stopping after 18 hands instead of 100

### DIFF
--- a/core/auto_evaluate_poker.py
+++ b/core/auto_evaluate_poker.py
@@ -1,7 +1,7 @@
 """
 Auto-evaluation poker game for testing fish poker skills.
 
-This module manages automated poker games where a fish plays against
+This module manages automated poker games where multiple fish play against
 a standard poker evaluation algorithm for 100 hands or until one player
 runs out of money.
 """
@@ -34,8 +34,11 @@ class EvalPlayerState:
     current_bet: float = 0.0
     total_bet: float = 0.0
     folded: bool = False
+    is_standard: bool = False  # True if this is the standard algorithm player
     # For fish player
     poker_strategy: Optional[PokerStrategyAlgorithm] = None
+    fish_id: Optional[int] = None
+    fish_generation: Optional[int] = None
     # Stats tracking
     hands_won: int = 0
     hands_lost: int = 0
@@ -49,28 +52,19 @@ class AutoEvaluateStats:
 
     hands_played: int = 0
     hands_remaining: int = 100
-    fish_energy: float = 0.0
-    standard_energy: float = 0.0
-    fish_wins: int = 0
-    standard_wins: int = 0
-    fish_total_won: float = 0.0
-    fish_total_lost: float = 0.0
-    standard_total_won: float = 0.0
-    standard_total_lost: float = 0.0
+    players: List[Dict[str, Any]] = field(default_factory=list)  # List of player stats
     game_over: bool = False
     winner: Optional[str] = None
     reason: str = ""
 
 
 class AutoEvaluatePokerGame:
-    """Manages an automated poker evaluation game between a fish and standard algorithm."""
+    """Manages an automated poker evaluation game between multiple fish and standard algorithm."""
 
     def __init__(
         self,
         game_id: str,
-        fish_name: str,
-        fish_energy: float,
-        fish_poker_strategy: PokerStrategyAlgorithm,
+        fish_players: List[Dict[str, Any]],
         standard_energy: float = 500.0,
         max_hands: int = 100,
         small_blind: float = 5.0,
@@ -80,9 +74,7 @@ class AutoEvaluatePokerGame:
 
         Args:
             game_id: Unique identifier for this game
-            fish_name: Name of the fish being evaluated
-            fish_energy: Starting energy for fish player
-            fish_poker_strategy: The fish's poker strategy algorithm
+            fish_players: List of dicts with keys: name, fish_id, generation, poker_strategy
             standard_energy: Starting energy for standard algorithm player
             max_hands: Maximum number of hands to play (default 100)
             small_blind: Small blind amount
@@ -94,18 +86,36 @@ class AutoEvaluatePokerGame:
         self.max_hands = max_hands
         self.hands_played = 0
 
-        # Create players
-        self.fish_player = EvalPlayerState(
-            player_id="fish",
-            name=fish_name,
-            energy=fish_energy,
-            poker_strategy=fish_poker_strategy,
-        )
+        # Create players list
+        self.players: List[EvalPlayerState] = []
 
-        self.standard_player = EvalPlayerState(
-            player_id="standard",
-            name="Standard Algorithm",
-            energy=standard_energy,
+        # Add fish players - ensure they have enough energy to play 100 hands
+        # With 4 players, blinds rotate, so each player posts SB+BB every 4 hands
+        # Minimum energy needed: (SB + BB) * (max_hands / 4) * 2 = (5+10) * (100/4) * 2 = 750
+        min_energy_for_100_hands = (small_blind + big_blind) * (max_hands / len(fish_players) + 1) * 2
+        starting_energy = max(500.0, min_energy_for_100_hands)
+
+        for i, fish_data in enumerate(fish_players):
+            self.players.append(
+                EvalPlayerState(
+                    player_id=f"fish_{i}",
+                    name=fish_data["name"],
+                    energy=starting_energy,
+                    poker_strategy=fish_data["poker_strategy"],
+                    fish_id=fish_data.get("fish_id"),
+                    fish_generation=fish_data.get("generation"),
+                    is_standard=False,
+                )
+            )
+
+        # Add standard algorithm player
+        self.players.append(
+            EvalPlayerState(
+                player_id="standard",
+                name="Standard Algorithm",
+                energy=starting_energy,
+                is_standard=True,
+            )
         )
 
         # Game state
@@ -113,25 +123,22 @@ class AutoEvaluatePokerGame:
         self.community_cards: List[Card] = []
         self.pot = 0.0
         self.current_round = BettingRound.PRE_FLOP
-        self.button_position = 0  # 0 = fish, 1 = standard
-        self.current_player = 0  # 0 = fish, 1 = standard
+        self.button_position = 0  # Dealer button position
+        self.current_player_index = 0
         self.game_over = False
         self.winner: Optional[str] = None
         self.last_hand_message = ""
 
     def get_players(self) -> List[EvalPlayerState]:
         """Get list of players."""
-        return [self.fish_player, self.standard_player]
+        return self.players
 
     def _start_hand(self):
         """Start a new hand: deal cards and post blinds."""
         # Reset deck and deal hole cards
         self.deck.reset()
-        self.fish_player.hole_cards = self.deck.deal(2)
-        self.standard_player.hole_cards = self.deck.deal(2)
-
-        # Reset hand state
-        for player in self.get_players():
+        for player in self.players:
+            player.hole_cards = self.deck.deal(2)
             player.current_bet = 0.0
             player.total_bet = 0.0
             player.folded = False
@@ -141,23 +148,23 @@ class AutoEvaluatePokerGame:
         self.current_round = BettingRound.PRE_FLOP
 
         # Rotate button
-        self.button_position = (self.button_position + 1) % 2
+        num_players = len(self.players)
+        self.button_position = (self.button_position + 1) % num_players
 
-        # Post blinds
-        small_blind_index = (self.button_position + 1) % 2
-        big_blind_index = self.button_position
+        # Post blinds (small blind is player after button, big blind is next player)
+        small_blind_index = (self.button_position + 1) % num_players
+        big_blind_index = (self.button_position + 2) % num_players
 
-        players = self.get_players()
         self._player_bet(small_blind_index, self.small_blind)
         self._player_bet(big_blind_index, self.big_blind)
 
-        # First to act pre-flop is player after big blind (button)
-        self.current_player = (self.button_position + 1) % 2
+        # First to act pre-flop is player after big blind
+        self.current_player_index = (big_blind_index + 1) % num_players
 
         self.hands_played += 1
         logger.info(
             f"Auto-eval {self.game_id}: Started hand {self.hands_played}. "
-            f"Button at {players[self.button_position].name}"
+            f"Button at {self.players[self.button_position].name}"
         )
 
     def _player_bet(self, player_index: int, amount: float):
@@ -173,10 +180,9 @@ class AutoEvaluatePokerGame:
 
     def _get_call_amount(self, player_index: int) -> float:
         """Get the amount a player needs to call."""
-        players = self.get_players()
-        player = players[player_index]
-        other_player = players[1 - player_index]
-        return other_player.current_bet - player.current_bet
+        player = self.players[player_index]
+        max_bet = max(p.current_bet for p in self.players if not p.folded)
+        return max_bet - player.current_bet
 
     def _advance_round(self):
         """Move to the next betting round and deal community cards."""
@@ -198,73 +204,79 @@ class AutoEvaluatePokerGame:
             return
 
         # Reset current bets for new round
-        for player in self.get_players():
+        for player in self.players:
             player.current_bet = 0.0
 
-        # First to act post-flop is player not on button
-        self.current_player = (self.button_position + 1) % 2
+        # First to act post-flop is player after button
+        num_players = len(self.players)
+        self.current_player_index = (self.button_position + 1) % num_players
+        # Skip folded players
+        while self.players[self.current_player_index].folded:
+            self.current_player_index = (self.current_player_index + 1) % num_players
 
     def _showdown(self):
         """Determine winner at showdown."""
-        players = self.get_players()
+        active_players = [i for i, p in enumerate(self.players) if not p.folded]
 
-        # If one player folded, other wins
-        if self.fish_player.folded:
-            self._award_pot(1)  # Standard wins
-            return
-        if self.standard_player.folded:
-            self._award_pot(0)  # Fish wins
+        # If only one player left, they win
+        if len(active_players) == 1:
+            self._award_pot(active_players[0])
             return
 
-        # Evaluate hands
-        fish_hand = PokerEngine.evaluate_hand(self.fish_player.hole_cards, self.community_cards)
-        standard_hand = PokerEngine.evaluate_hand(
-            self.standard_player.hole_cards, self.community_cards
-        )
+        # Evaluate hands for all active players
+        best_hand: Optional[PokerHand] = None
+        best_player_index: Optional[int] = None
+        tied_players: List[int] = []
 
-        logger.info(
-            f"Auto-eval {self.game_id}: Showdown - Fish: {fish_hand}, Standard: {standard_hand}"
-        )
+        for i in active_players:
+            player = self.players[i]
+            hand = PokerEngine.evaluate_hand(player.hole_cards, self.community_cards)
+            logger.info(f"Auto-eval {self.game_id}: {player.name}: {hand}")
 
-        if fish_hand.beats(standard_hand):
-            self._award_pot(0)  # Fish wins
-            self.last_hand_message = f"Fish wins with {fish_hand}!"
-        elif standard_hand.beats(fish_hand):
-            self._award_pot(1)  # Standard wins
-            self.last_hand_message = f"Standard wins with {standard_hand}!"
-        else:
-            # Tie - split pot
-            self._split_pot()
-            self.last_hand_message = "Tie! Pot split."
+            if best_hand is None or hand.beats(best_hand):
+                best_hand = hand
+                best_player_index = i
+                tied_players = [i]
+            elif hand.ties(best_hand):
+                tied_players.append(i)
+
+        # Award pot to winner(s)
+        if len(tied_players) > 1:
+            self._split_pot(tied_players)
+            self.last_hand_message = f"Tie! Pot split among {len(tied_players)} players."
+        elif best_player_index is not None:
+            self._award_pot(best_player_index)
+            winner = self.players[best_player_index]
+            self.last_hand_message = f"{winner.name} wins with {best_hand}!"
 
     def _award_pot(self, winner_index: int):
         """Award the pot to the winner."""
-        players = self.get_players()
-        winner = players[winner_index]
-        loser = players[1 - winner_index]
+        winner = self.players[winner_index]
 
         winner.energy += self.pot
         winner.hands_won += 1
         winner.total_energy_won += self.pot
 
-        loser.hands_lost += 1
-        loser.total_energy_lost += loser.total_bet
+        # Track losses for non-winners who didn't fold
+        for i, player in enumerate(self.players):
+            if i != winner_index and player.total_bet > 0:
+                player.hands_lost += 1
+                player.total_energy_lost += player.total_bet
 
         logger.info(
-            f"Auto-eval {self.game_id}: {winner.name} wins {self.pot:.1f} energy. "
-            f"Fish: {self.fish_player.energy:.1f}, Standard: {self.standard_player.energy:.1f}"
+            f"Auto-eval {self.game_id}: {winner.name} wins {self.pot:.1f} energy"
         )
 
-    def _split_pot(self):
-        """Split the pot in case of a tie."""
-        half_pot = self.pot / 2.0
-        self.fish_player.energy += half_pot
-        self.standard_player.energy += half_pot
+    def _split_pot(self, tied_player_indices: List[int]):
+        """Split the pot among tied players."""
+        split_amount = self.pot / len(tied_player_indices)
+        for i in tied_player_indices:
+            self.players[i].energy += split_amount
+            self.players[i].total_energy_won += split_amount
 
     def _process_player_action(self, player_index: int):
         """Process a player's action."""
-        players = self.get_players()
-        player = players[player_index]
+        player = self.players[player_index]
 
         if player.folded:
             return
@@ -278,33 +290,35 @@ class AutoEvaluatePokerGame:
             return
 
         # Determine action based on player type
-        if player_index == 0:  # Fish player
-            # Use fish's poker strategy
-            hand = PokerEngine.evaluate_hand(player.hole_cards, self.community_cards)
-            hand_strength = hand.rank_value / 10.0  # Normalize to 0-1
-
-            action, amount = player.poker_strategy.decide_action(
-                hand_strength=hand_strength,
-                current_bet=player.current_bet,
-                opponent_bet=players[1 - player_index].current_bet,
-                pot=self.pot,
-                player_energy=player.energy,
-                position_on_button=(player_index == self.button_position),
-            )
-
-        else:  # Standard player
+        if player.is_standard:  # Standard player
             # Use PokerEngine.decide_action (standard algorithm)
             hand = PokerEngine.evaluate_hand(player.hole_cards, self.community_cards)
+            max_opponent_bet = max(p.current_bet for p in self.players if not p.folded)
 
             action, amount = PokerEngine.decide_action(
                 hand=hand,
                 current_bet=player.current_bet,
-                opponent_bet=players[1 - player_index].current_bet,
+                opponent_bet=max_opponent_bet,
                 pot=self.pot,
                 player_energy=player.energy,
                 aggression=0.5,  # Medium aggression
                 hole_cards=player.hole_cards,
                 community_cards=self.community_cards if self.community_cards else None,
+                position_on_button=(player_index == self.button_position),
+            )
+
+        else:  # Fish player
+            # Use fish's poker strategy
+            hand = PokerEngine.evaluate_hand(player.hole_cards, self.community_cards)
+            hand_strength = hand.rank_value / 10.0  # Normalize to 0-1
+            max_opponent_bet = max(p.current_bet for p in self.players if not p.folded)
+
+            action, amount = player.poker_strategy.decide_action(
+                hand_strength=hand_strength,
+                current_bet=player.current_bet,
+                opponent_bet=max_opponent_bet,
+                pot=self.pot,
+                player_energy=player.energy,
                 position_on_button=(player_index == self.button_position),
             )
 
@@ -333,43 +347,52 @@ class AutoEvaluatePokerGame:
 
     def _play_betting_round(self):
         """Play one betting round."""
-        max_actions = 20  # Prevent infinite loops
+        max_actions = 100  # Prevent infinite loops (increased for multi-player)
         actions_taken = 0
+        num_players = len(self.players)
 
         while actions_taken < max_actions:
-            players = self.get_players()
-            current = players[self.current_player]
+            current = self.players[self.current_player_index]
 
-            # If current player folded, round is over
+            # If current player folded, skip to next
             if current.folded:
-                break
+                self.current_player_index = (self.current_player_index + 1) % num_players
+                actions_taken += 1
+                continue
 
             # Process action
-            self._process_player_action(self.current_player)
+            self._process_player_action(self.current_player_index)
 
-            # Check if someone folded
-            if self.fish_player.folded or self.standard_player.folded:
+            # Check if only one player left
+            active_players = [p for p in self.players if not p.folded]
+            if len(active_players) <= 1:
                 break
 
             # Check if betting is complete
             if self._is_betting_complete():
                 break
 
-            # Switch to other player
-            self.current_player = 1 - self.current_player
+            # Move to next player
+            self.current_player_index = (self.current_player_index + 1) % num_players
             actions_taken += 1
 
     def _is_betting_complete(self) -> bool:
         """Check if betting is complete for the current round."""
-        # If either player folded, betting is done
-        if self.fish_player.folded or self.standard_player.folded:
+        active_players = [p for p in self.players if not p.folded]
+
+        # If only one player left, betting is done
+        if len(active_players) <= 1:
             return True
 
-        # If bets match and both players have acted, betting is done
-        if self.fish_player.current_bet == self.standard_player.current_bet:
-            return True
+        # Get max bet
+        max_bet = max(p.current_bet for p in active_players)
 
-        return False
+        # Check if all active players have matched max bet
+        for player in active_players:
+            if player.current_bet < max_bet and player.energy > 0:
+                return False
+
+        return True
 
     def play_hand(self):
         """Play one complete hand of poker."""
@@ -378,12 +401,14 @@ class AutoEvaluatePokerGame:
         # Play pre-flop
         self._play_betting_round()
 
-        # Continue through remaining rounds if no one folded
-        while (
-            self.current_round != BettingRound.SHOWDOWN
-            and not self.fish_player.folded
-            and not self.standard_player.folded
-        ):
+        # Continue through remaining rounds if more than one player active
+        while self.current_round != BettingRound.SHOWDOWN:
+            active_players = [p for p in self.players if not p.folded]
+            if len(active_players) <= 1:
+                # Someone won by everyone else folding
+                self._showdown()
+                break
+
             self._advance_round()
             if self.current_round != BettingRound.SHOWDOWN:
                 self._play_betting_round()
@@ -393,32 +418,33 @@ class AutoEvaluatePokerGame:
             self._showdown()
 
     def run_evaluation(self) -> AutoEvaluateStats:
-        """Run the full evaluation (100 hands or until one player runs out of money).
+        """Run the full evaluation (100 hands or until only one player remains).
 
         Returns:
             Final evaluation statistics
         """
         logger.info(
-            f"Auto-eval {self.game_id}: Starting evaluation - "
-            f"Fish: {self.fish_player.energy:.1f}, Standard: {self.standard_player.energy:.1f}"
+            f"Auto-eval {self.game_id}: Starting evaluation with {len(self.players)} players"
         )
 
         while self.hands_played < self.max_hands:
-            # Check if either player ran out of money
-            if self.fish_player.energy < self.big_blind:
-                self.game_over = True
-                self.winner = "Standard Algorithm"
-                logger.info(
-                    f"Auto-eval {self.game_id}: Fish ran out of energy after {self.hands_played} hands"
-                )
-                break
+            # Check how many players can still play (have energy >= big blind)
+            active_players = [p for p in self.players if p.energy >= self.big_blind]
 
-            if self.standard_player.energy < self.big_blind:
+            if len(active_players) <= 1:
+                # Only one player left who can afford to play
                 self.game_over = True
-                self.winner = self.fish_player.name
-                logger.info(
-                    f"Auto-eval {self.game_id}: Standard ran out of energy after {self.hands_played} hands"
-                )
+                if len(active_players) == 1:
+                    self.winner = active_players[0].name
+                    logger.info(
+                        f"Auto-eval {self.game_id}: {self.winner} wins - "
+                        f"all other players out of energy after {self.hands_played} hands"
+                    )
+                else:
+                    # All players out of energy (shouldn't happen with proper starting energy)
+                    logger.info(
+                        f"Auto-eval {self.game_id}: All players out of energy after {self.hands_played} hands"
+                    )
                 break
 
             # Play one hand
@@ -427,10 +453,12 @@ class AutoEvaluatePokerGame:
         # If we completed all hands, determine winner by energy
         if not self.game_over:
             self.game_over = True
-            if self.fish_player.energy > self.standard_player.energy:
-                self.winner = self.fish_player.name
-            elif self.standard_player.energy > self.fish_player.energy:
-                self.winner = "Standard Algorithm"
+            # Find player with most energy
+            max_energy = max(p.energy for p in self.players)
+            winners = [p for p in self.players if p.energy == max_energy]
+
+            if len(winners) == 1:
+                self.winner = winners[0].name
             else:
                 self.winner = "Tie"
 
@@ -438,17 +466,27 @@ class AutoEvaluatePokerGame:
 
     def get_stats(self) -> AutoEvaluateStats:
         """Get current evaluation statistics."""
+        # Build player stats list
+        players_stats = []
+        for player in self.players:
+            players_stats.append({
+                "player_id": player.player_id,
+                "name": player.name,
+                "is_standard": player.is_standard,
+                "fish_id": player.fish_id,
+                "fish_generation": player.fish_generation,
+                "energy": round(player.energy, 1),
+                "hands_won": player.hands_won,
+                "hands_lost": player.hands_lost,
+                "total_energy_won": round(player.total_energy_won, 1),
+                "total_energy_lost": round(player.total_energy_lost, 1),
+                "net_energy": round(player.total_energy_won - player.total_energy_lost, 1),
+            })
+
         return AutoEvaluateStats(
             hands_played=self.hands_played,
             hands_remaining=max(0, self.max_hands - self.hands_played),
-            fish_energy=self.fish_player.energy,
-            standard_energy=self.standard_player.energy,
-            fish_wins=self.fish_player.hands_won,
-            standard_wins=self.standard_player.hands_won,
-            fish_total_won=self.fish_player.total_energy_won,
-            fish_total_lost=self.fish_player.total_energy_lost,
-            standard_total_won=self.standard_player.total_energy_won,
-            standard_total_lost=self.standard_player.total_energy_lost,
+            players=players_stats,
             game_over=self.game_over,
             winner=self.winner,
             reason=(


### PR DESCRIPTION
The poker auto-evaluation was ending early because:
1. It only supported 1v1 (fish vs standard)
2. Players were using current energy (which could be low)
3. Game ended when any player ran below big blind

Changes:
- Modified AutoEvaluatePokerGame to support 4 players (3 fish + 1 standard)
- Ensure all players start with sufficient energy to play 100 hands
- Game now only ends after 100 hands OR when only 1 player remains
- Updated simulation_runner to select top 3 fish for evaluation
- Updated frontend AutoEvaluateDisplay to show all 4 players dynamically

This matches the user's expectation to see "3 fish and the Standard Algorithm" playing for the full 100 hands.