### PR TITLE
Fix auto evaluation stopping at 100 hands

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -569,7 +569,7 @@ class SimulationRunner:
                     # Create auto-evaluation game with multiple fish
                     game_id = str(uuid.uuid4())
                     standard_energy = data.get("standard_energy", 500.0) if data else 500.0
-                    max_hands = data.get("max_hands", 100) if data else 100
+                    max_hands = data.get("max_hands", 1000) if data else 1000
 
                     self.auto_evaluate_game = AutoEvaluatePokerGame(
                         game_id=game_id,


### PR DESCRIPTION
The simulation_runner was defaulting max_hands to 100 when creating the AutoEvaluatePokerGame instance, overriding the class's default of 1000. Now correctly defaults to 1000 hands as intended.