### PR TITLE
Fix evaluation hand count to 100

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,7 +84,7 @@ function App() {
 
       const response = await sendCommandWithResponse({
         command: 'auto_evaluate_poker',
-        data: { standard_energy: 500, max_hands: 100 },
+        data: { standard_energy: 500, max_hands: 1000 },
       });
 
       if (response.success === false) {


### PR DESCRIPTION
The frontend was hardcoding max_hands: 100 when calling auto_evaluate_poker, overriding the backend's default of 1000 hands. Updated to 1000 hands.