### PR TITLE
Fix phylogenetic tree build failure

### DIFF
--- a/core/fish_poker.py
+++ b/core/fish_poker.py
@@ -335,6 +335,7 @@ class PokerInteraction:
             screen_width=winner_fish.screen_width,
             screen_height=winner_fish.screen_height,
             initial_energy=total_baby_energy,
+            parent_id=winner_fish.fish_id,  # Track lineage for phylogenetic tree
         )
 
         # Record reproduction in ecosystem for both parents

--- a/frontend/src/utils/lineageUtils.ts
+++ b/frontend/src/utils/lineageUtils.ts
@@ -36,6 +36,14 @@ export const transformLineageData = (flatData: FishRecord[]): TreeNodeData | nul
       }
     }
 
+    // Log orphans if found
+    if (orphans.length > 0) {
+      console.error('Phylogenetic tree error: Found orphaned records:', orphans);
+      console.error('Available IDs:', Array.from(idSet));
+      console.error('Full data:', flatData);
+      return null;
+    }
+
     // D3 Stratify converts flat list -> nested tree
     const strategy = stratify<FishRecord>()
       .id((d) => d.id)
@@ -62,6 +70,8 @@ export const transformLineageData = (flatData: FishRecord[]): TreeNodeData | nul
     const result = mapper(tree);
     return result;
   } catch (error) {
+    console.error('Phylogenetic tree error:', error);
+    console.error('Data that caused error:', flatData);
     return null;
   }
 };


### PR DESCRIPTION
The phylogenetic tree was failing to build because baby fish created through poker reproduction were missing the parent_id parameter. This caused them to be recorded as root nodes instead of being properly linked to their parents, resulting in an invalid tree structure.

Changes:
- Add parent_id parameter to Fish creation in fish_poker.py
- Add better error logging in lineageUtils.ts to diagnose tree issues