### PR TITLE
Fix duplicate fish in poker evaluation

### DIFF
--- a/frontend/src/components/AutoEvaluateDisplay.tsx
+++ b/frontend/src/components/AutoEvaluateDisplay.tsx
@@ -113,7 +113,6 @@ export function AutoEvaluateDisplay({ stats, onClose, loading }: AutoEvaluateDis
           <div key={player.player_id} style={styles.playerSection}>
             <h4 style={styles.playerName}>
               {player.is_standard ? '🤖' : '🐟'} {player.name}
-              {!player.is_standard && player.fish_id ? ` #${player.fish_id}` : ''}
             </h4>
             <div style={styles.statsGrid}>
               <div style={styles.statRow}>


### PR DESCRIPTION
The backend already includes the fish ID in the player name field (e.g., "FoodMemorySeeker (Gen 0) #3"), so removed the redundant frontend code that was appending the fish_id again, which was causing the display to show "#3 #3".