### PR TITLE
Fix missing simulation_engine module import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Run headless simulation test
       run: |
-        python -c "from simulation_engine import HeadlessSimulator; sim = HeadlessSimulator(max_frames=100); sim.run(); print('Headless test passed')"
+        python -c "from core.simulation_engine import HeadlessSimulator; sim = HeadlessSimulator(max_frames=100); sim.run(); print('Headless test passed')"
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The test-headless job was failing with ModuleNotFoundError because it was trying to import simulation_engine directly. Since the module is located in the core/ package (as defined in pyproject.toml), the correct import is 'from core.simulation_engine import HeadlessSimulator'.

This fixes the import path in .github/workflows/ci.yml:66 to use the correct package structure.

Fixes: ModuleNotFoundError: No module named 'simulation_engine'