### PR TITLE
Fix tuple type hint for Python 3.8 compatibility

### DIFF
--- a/core/fish/reproduction_component.py
+++ b/core/fish/reproduction_component.py
@@ -6,7 +6,7 @@ Separating reproduction logic into its own component improves code organization 
 """
 
 import random
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 if TYPE_CHECKING:
     from core.entities import LifeStage
@@ -169,7 +169,7 @@ class ReproductionComponent:
 
     def give_birth(
         self, own_genome: "Genome", population_stress: float = 0.0
-    ) -> tuple["Genome", float]:
+    ) -> Tuple["Genome", float]:
         """Generate offspring genome from mating.
 
         Args:


### PR DESCRIPTION
Changed type hint from tuple["Genome", float] to Tuple["Genome", float] in the give_birth method to ensure compatibility with Python versions earlier than 3.9, where built-in types don't support subscripting.

Added Tuple to typing imports.

Fixes TypeError: 'type' object is not subscriptable