### PR TITLE
Inject shared RNG into simulation engine

### DIFF
--- a/CODE_QUALITY_ANALYSIS.md
+++ b/CODE_QUALITY_ANALYSIS.md
@@ -265,26 +265,14 @@ if (treeError) {
 
 ---
 
-### 5. TODO/FIXME COMMENTS - 1 Total
+### 5. RNG SEEDING FOR DETERMINISM ✓ ADDRESSED
 
-**Impact: LOW** | **Effort to Fix: 0.5-1 hour** | **Benefit: MEDIUM**
+**Impact: LOW** | **Effort to Fix: Completed** | **Benefit: MEDIUM**
 
-#### Location
-**File: tank_world.py, Line 131**
-
-```python
-# TODO: Refactor all random.* calls to use self.engine._tank_world_rng
-```
-
-#### Context
-- RNG refactoring for deterministic behavior
-- Would enable reproducible simulations
-- Should be seeded for testing
-
-#### Recommendation
-1. Create GitHub issue with priority
-2. Link to random number generation refactoring work
-3. Estimate effort: 1-2 hours to replace all `random.*` calls
+#### Summary
+- `TankWorld` now injects a shared `random.Random` instance into `SimulationEngine` rather than monkey-patching.
+- Initial population creation and emergency spawning now use the shared RNG for reproducible runs when a seed is provided.
+- Follow-up work can extend RNG plumbing to remaining modules that still use the global `random` module.
 
 ---
 

--- a/core/algorithms/__init__.py
+++ b/core/algorithms/__init__.py
@@ -205,9 +205,10 @@ def get_algorithm_name(algorithm_index: int) -> str:
     return "Unknown"
 
 
-def get_random_algorithm() -> BehaviorAlgorithm:
+def get_random_algorithm(rng: Optional[random.Random] = None) -> BehaviorAlgorithm:
     """Get a random behavior algorithm instance."""
-    algorithm_class = random.choice(ALL_ALGORITHMS)
+    rng = rng or random
+    algorithm_class = rng.choice(ALL_ALGORITHMS)
     return algorithm_class.random_instance()
 
 

--- a/core/entity_factory.py
+++ b/core/entity_factory.py
@@ -5,7 +5,7 @@ used by the web UI backend and headless simulation mode.
 """
 
 import random
-from typing import List
+from typing import List, Optional
 
 from core import entities, environment, movement_strategy
 from core.constants import FILES, INIT_POS, NUM_SCHOOLING_FISH, SCREEN_HEIGHT, SCREEN_WIDTH
@@ -18,6 +18,7 @@ def create_initial_population(
     ecosystem: EcosystemManager,
     screen_width: int = SCREEN_WIDTH,
     screen_height: int = SCREEN_HEIGHT,
+    rng: Optional[random.Random] = None,
 ) -> List[entities.Agent]:
     """Create initial population for simulation.
 
@@ -37,16 +38,17 @@ def create_initial_population(
         List of Entity objects representing the initial population
     """
     population = []
+    rng = rng or random
 
     # Create algorithmic fish with parametrizable behavior algorithms
     # These fish use the algorithmic evolution system with diverse genomes
     for _i in range(
         NUM_SCHOOLING_FISH
     ):  # Start with NUM_SCHOOLING_FISH algorithmic fish for better evolution and sustainability
-        x = INIT_POS["school"][0] + random.randint(-100, 100)
-        y = INIT_POS["school"][1] + random.randint(-60, 60)
+        x = INIT_POS["school"][0] + rng.randint(-100, 100)
+        y = INIT_POS["school"][1] + rng.randint(-60, 60)
         # Create genome with behavior algorithm
-        genome = Genome.random(use_algorithm=True)
+        genome = Genome.random(use_algorithm=True, rng=rng)
         fish = entities.Fish(
             env,
             movement_strategy.AlgorithmicMovement(),

--- a/core/genetics.py
+++ b/core/genetics.py
@@ -110,15 +110,17 @@ class Genome:
     )
 
     @classmethod
-    def random(cls, use_algorithm: bool = True) -> "Genome":
+    def random(cls, use_algorithm: bool = True, rng: Optional[random.Random] = None) -> "Genome":
         """Create a random genome with traits within normal ranges.
 
         Args:
             use_algorithm: Whether to include behavior algorithms
+            rng: Random number generator (defaults to global random module)
 
         Returns:
             New random genome
         """
+        rng = rng or random
         # Create random behavior algorithms
         algorithm = None
         poker_algorithm = None
@@ -127,30 +129,30 @@ class Genome:
             from core.algorithms import get_random_algorithm
             from core.poker_strategy_algorithms import get_random_poker_strategy
 
-            algorithm = get_random_algorithm()
+            algorithm = get_random_algorithm(rng=rng)
             # Also create a random poker algorithm for mix-and-match evolution
-            poker_algorithm = get_random_algorithm()
+            poker_algorithm = get_random_algorithm(rng=rng)
             # Create random poker strategy for betting decisions
-            poker_strategy_algorithm = get_random_poker_strategy()
+            poker_strategy_algorithm = get_random_poker_strategy(rng=rng)
 
         return cls(
-            speed_modifier=random.uniform(0.7, 1.3),
-            size_modifier=random.uniform(0.7, 1.3),
-            vision_range=random.uniform(0.7, 1.3),
-            metabolism_rate=random.uniform(0.7, 1.3),
-            max_energy=random.uniform(0.7, 1.5),
-            fertility=random.uniform(0.6, 1.4),
-            aggression=random.uniform(0.0, 1.0),
-            social_tendency=random.uniform(0.0, 1.0),
-            color_hue=random.random(),
+            speed_modifier=rng.uniform(0.7, 1.3),
+            size_modifier=rng.uniform(0.7, 1.3),
+            vision_range=rng.uniform(0.7, 1.3),
+            metabolism_rate=rng.uniform(0.7, 1.3),
+            max_energy=rng.uniform(0.7, 1.5),
+            fertility=rng.uniform(0.6, 1.4),
+            aggression=rng.uniform(0.0, 1.0),
+            social_tendency=rng.uniform(0.0, 1.0),
+            color_hue=rng.random(),
             # Visual traits for parametric fish templates
-            template_id=random.randint(0, FISH_TEMPLATE_COUNT - 1),
-            fin_size=random.uniform(0.6, 1.4),
-            tail_size=random.uniform(0.6, 1.4),
-            body_aspect=random.uniform(0.7, 1.3),
-            eye_size=random.uniform(0.7, 1.3),
-            pattern_intensity=random.random(),
-            pattern_type=random.randint(0, FISH_PATTERN_COUNT - 1),
+            template_id=rng.randint(0, FISH_TEMPLATE_COUNT - 1),
+            fin_size=rng.uniform(0.6, 1.4),
+            tail_size=rng.uniform(0.6, 1.4),
+            body_aspect=rng.uniform(0.7, 1.3),
+            eye_size=rng.uniform(0.7, 1.3),
+            pattern_intensity=rng.random(),
+            pattern_type=rng.randint(0, FISH_PATTERN_COUNT - 1),
             behavior_algorithm=algorithm,
             poker_algorithm=poker_algorithm,
             poker_strategy_algorithm=poker_strategy_algorithm,

--- a/core/poker_strategy_algorithms.py
+++ b/core/poker_strategy_algorithms.py
@@ -415,9 +415,10 @@ ALL_POKER_STRATEGIES = [
 ]
 
 
-def get_random_poker_strategy() -> PokerStrategyAlgorithm:
+def get_random_poker_strategy(rng: Optional[random.Random] = None) -> PokerStrategyAlgorithm:
     """Get random poker strategy."""
-    return random.choice(ALL_POKER_STRATEGIES).random_instance()
+    rng = rng or random
+    return rng.choice(ALL_POKER_STRATEGIES).random_instance()
 
 
 def crossover_poker_strategies(

--- a/core/tank_world.py
+++ b/core/tank_world.py
@@ -111,28 +111,7 @@ class TankWorld:
         # Create the simulation engine
         # For now, we pass headless flag to engine
         # Later we can refactor engine to use config directly
-        self.engine = SimulationEngine(headless=self.config.headless)
-
-        # Monkey-patch the engine to use our RNG
-        # This is a temporary solution - ideally engine would accept RNG in constructor
-        self._patch_engine_rng()
-
-    def _patch_engine_rng(self):
-        """Temporarily patch the engine to use our RNG.
-
-        This is a transitional approach. Eventually, the engine should
-        accept and use the RNG instance directly.
-        """
-        # Store reference to our RNG in the engine
-        self.engine._tank_world_rng = self.rng
-
-        # NOTE: For full deterministic simulation, all random.* calls need to be refactored
-        # to use self.engine._tank_world_rng instead of the global random module.
-        # This is tracked as technical debt and requires:
-        #   1. Grep for all 'import random' and 'random.' calls
-        #   2. Pass RNG instance through module constructors
-        #   3. Update all random.* calls to use instance methods
-        # Estimated effort: 2-3 hours across ~15 modules
+        self.engine = SimulationEngine(headless=self.config.headless, rng=self.rng)
 
     def setup(self) -> None:
         """Setup the simulation.


### PR DESCRIPTION
## Summary
- pass a shared random generator from TankWorld into SimulationEngine instead of monkey patching
- allow initial population creation and genome/strategy selection to consume the injected RNG for reproducible seeding
- update cleanup notes to reflect improved RNG plumbing

## Testing
- python -m pytest tests/test_fish_pause_fix.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eb5c07af483319c88e6acc9adf9fe)