### PR TITLE
Sort auto-evaluation stats by final energy

### DIFF
--- a/frontend/src/components/AutoEvaluateDisplay.tsx
+++ b/frontend/src/components/AutoEvaluateDisplay.tsx
@@ -65,6 +65,8 @@ export function AutoEvaluateDisplay({ stats, onClose, loading }: AutoEvaluateDis
     ? ((totalFishWins / stats.hands_played) * 100).toFixed(1)
     : '0.0';
 
+  const sortedPlayers = [...stats.players].sort((a, b) => b.energy - a.energy);
+
   return (
     <div style={styles.container}>
       <div style={styles.header}>
@@ -108,8 +110,8 @@ export function AutoEvaluateDisplay({ stats, onClose, loading }: AutoEvaluateDis
       <div style={styles.detailsSection}>
         <h3 style={styles.sectionTitle}>Detailed Statistics</h3>
 
-        {/* Display all players */}
-        {stats.players.map((player) => (
+        {/* Display all players sorted by final energy */}
+        {sortedPlayers.map((player) => (
           <div key={player.player_id} style={styles.playerSection}>
             <h4 style={styles.playerName}>
               {player.is_standard ? '🤖' : '🐟'} {player.name}


### PR DESCRIPTION
## Summary
- add sorting for auto-evaluation detailed statistics by final energy

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eba72a54c83319b5b7de5a7ca26b9)