### PR TITLE
Show hole cards at poker showdown

### DIFF
--- a/core/human_poker_game.py
+++ b/core/human_poker_game.py
@@ -538,9 +538,11 @@ class HumanPokerGame:
                     "folded": p.folded,
                     "is_human": p.is_human,
                     "algorithm": p.algorithm,
-                    # Only show hole cards for human player
+                    # Show hole cards for human player or during showdown
                     "hole_cards": (
-                        [str(card) for card in p.hole_cards] if p.is_human else ["??", "??"]
+                        [str(card) for card in p.hole_cards]
+                        if (p.is_human or self.current_round == BettingRound.SHOWDOWN)
+                        else ["??", "??"]
                     ),
                 }
                 for p in self.players


### PR DESCRIPTION
Previously, opponent hole cards were always hidden as "??" regardless of the game state. Now they are revealed when the game reaches the SHOWDOWN round, allowing players to see what cards opponents had.

The frontend was already configured to display cards, but the backend was always sending "??" for non-human players. This change updates the backend logic to reveal actual hole cards during showdown.

Changes:
- Modified human_poker_game.py to show hole cards when current_round == BettingRound.SHOWDOWN
- Updated comment to reflect new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)