### PR TITLE
Fix fish movement when low on energy

### DIFF
--- a/core/entities.py
+++ b/core/entities.py
@@ -924,12 +924,8 @@ class Fish(Agent):
 
         previous_direction = self.last_direction
 
-        # Movement (only if not starving)
-        if not self.is_starving():
-            self.movement_strategy.move(self)
-        else:
-            # Slow down when starving
-            self.vel *= 0.5
+        # Movement (algorithms handle critical energy internally)
+        self.movement_strategy.move(self)
 
         self._apply_turn_energy_cost(previous_direction)
 


### PR DESCRIPTION
Previously, fish with energy below the starvation threshold (< 15.0) were prevented from executing their movement strategy. This meant they couldn't seek food when they needed it most, leading to death even with food nearby.

The movement algorithms already have sophisticated critical-energy handling built in:
- StarvationPreventer uses 1.3-1.5x speed multipliers
- EnergyAwareFoodSeeker ignores predators when desperate
- CircularHunter goes straight for food at low energy
- All algorithms expand pursuit distances when critical

By removing the starvation check, fish can now use these emergency behaviors to survive. The algorithms handle critical energy states internally, making the external check both redundant and harmful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)