### PR TITLE
Clean up imports and document code quality tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,12 @@ python tests/test_simulation.py
 
 # Test determinism
 python tests/test_parity.py
+
+# Run static analysis (import order, safety, style)
+ruff check
+
+# Format code
+black .
 ```
 
 ## 🎓 Educational Value

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from backend.models import Command
 from backend.simulation_runner import SimulationRunner
-
 from core.constants import DEFAULT_API_PORT, FRAME_RATE
 
 # Global simulation runner

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -3,8 +3,8 @@
 import logging
 import threading
 import time
-from typing import Any, Dict, Optional
 import uuid
+from typing import Any, Dict, Optional
 
 from backend.models import (
     EntityData,
@@ -15,11 +15,11 @@ from backend.models import (
     StatsData,
 )
 from core import entities, movement_strategy
-from core.constants import FRAME_RATE, FILES, SCREEN_HEIGHT, SCREEN_WIDTH, SPAWN_MARGIN_PIXELS
+from core.auto_evaluate_poker import AutoEvaluatePokerGame
+from core.constants import FILES, FRAME_RATE, SCREEN_HEIGHT, SCREEN_WIDTH, SPAWN_MARGIN_PIXELS
 from core.entities import Fish
 from core.genetics import Genome
 from core.human_poker_game import HumanPokerGame
-from core.auto_evaluate_poker import AutoEvaluatePokerGame
 
 # Use absolute imports assuming tank/ is in PYTHONPATH
 from core.tank_world import TankWorld, TankWorldConfig

--- a/core/poker/core/engine.py
+++ b/core/poker/core/engine.py
@@ -7,7 +7,7 @@ This module contains the core game engine, game state tracking, and AI decision 
 import logging
 import random
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import IntEnum
 from itertools import combinations
 from typing import TYPE_CHECKING, List, Optional, Tuple
@@ -31,7 +31,7 @@ from core.constants import (
     POKER_WEAK_ENERGY_FRACTION,
     POKER_WEAK_POT_MULTIPLIER,
 )
-from core.poker.core.cards import Card, Deck, Rank
+from core.poker.core.cards import Card, Deck
 from core.poker.core.hand import HandRank, PokerHand
 
 if TYPE_CHECKING:

--- a/update_poker_imports.py
+++ b/update_poker_imports.py
@@ -5,10 +5,7 @@ This script updates all imports from the old scattered poker modules to the new
 organized poker package structure.
 """
 
-import os
-import re
 from pathlib import Path
-
 
 # Mapping of old imports to new imports
 IMPORT_MAPPINGS = {
@@ -45,7 +42,7 @@ IMPORT_MAPPINGS = {
 def update_file_imports(file_path: Path) -> bool:
     """Update imports in a single file. Returns True if file was modified."""
     try:
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, encoding='utf-8') as f:
             content = f.read()
 
         original_content = content


### PR DESCRIPTION
## Summary
- tidy backend and poker engine imports to match lint expectations
- simplify the poker import migration helper by removing unused dependencies and redundant arguments
- document linting and formatting commands alongside existing test instructions in the README

## Testing
- ruff check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed32c44608331baf7b66b7cf550a7)