### PR TITLE
Fix string subtraction error in parameter mutation test

### DIFF
--- a/tests/test_algorithmic_evolution.py
+++ b/tests/test_algorithmic_evolution.py
@@ -131,10 +131,16 @@ def test_parameter_mutation():
     mutations_found = 0
     for key in original_params:
         if key in mutated_algo.parameters:
-            if abs(original_params[key] - mutated_algo.parameters[key]) > 0.01:
+            if isinstance(original_params[key], (int, float)) and isinstance(mutated_algo.parameters[key], (int, float)):
+                if abs(original_params[key] - mutated_algo.parameters[key]) > 0.01:
+                    mutations_found += 1
+                    print(
+                        f"  ✓ Parameter '{key}': {original_params[key]:.3f} → {mutated_algo.parameters[key]:.3f}"
+                    )
+            elif original_params[key] != mutated_algo.parameters[key]:
                 mutations_found += 1
                 print(
-                    f"  ✓ Parameter '{key}': {original_params[key]:.3f} → {mutated_algo.parameters[key]:.3f}"
+                    f"  ✓ Parameter '{key}': {original_params[key]} → {mutated_algo.parameters[key]}"
                 )
 
     if mutations_found > 0:


### PR DESCRIPTION
The test_parameter_mutation function was attempting to perform arithmetic subtraction on all parameter values, which caused a TypeError when encountering string parameters (e.g., 'border_preference': 'left').

Fixed by adding type checking before subtraction:
- For numeric parameters (int, float): use abs() comparison with threshold
- For non-numeric parameters: use direct equality comparison

This allows the test to properly handle both numeric and string parameter mutations without raising a TypeError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)