### PR TITLE
Adjust physics for directional changes and size

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -153,6 +153,11 @@ MOVEMENT_ENERGY_COST = 0.015  # Movement-based energy consumption multiplier
 SHARP_TURN_ENERGY_COST = 0.05  # Additional cost for sharp turns
 SHARP_TURN_DOT_THRESHOLD = -0.85  # Dot product threshold for detecting sharp turns
 
+# Direction Change Energy Constants
+DIRECTION_CHANGE_ENERGY_BASE = 0.03  # Base energy cost for direction changes
+DIRECTION_CHANGE_SIZE_MULTIPLIER = 1.5  # Larger fish use more energy to turn (multiplied by size)
+MOVEMENT_SIZE_MULTIPLIER = 1.2  # Additional size-based movement cost multiplier
+
 # Energy Thresholds (centralized for consistency across the codebase)
 STARVATION_THRESHOLD = 15.0  # Below this, fish dies from starvation
 CRITICAL_ENERGY_THRESHOLD = 15.0  # Emergency survival mode (same as starvation threshold)

--- a/core/fish/energy_component.py
+++ b/core/fish/energy_component.py
@@ -91,8 +91,12 @@ class EnergyComponent:
         metabolism = self.base_metabolism * time_modifier
 
         # Additional cost for movement - scales with body size (larger fish use more energy to move)
+        # Size scaling is non-linear: larger fish use disproportionately more energy
         if velocity.length() > 0:
-            movement_cost = MOVEMENT_ENERGY_COST * velocity.length() / speed * size
+            from core.constants import MOVEMENT_SIZE_MULTIPLIER
+
+            size_factor = size**MOVEMENT_SIZE_MULTIPLIER
+            movement_cost = MOVEMENT_ENERGY_COST * velocity.length() / speed * size_factor
             metabolism += movement_cost
 
         # Apply life stage modifiers to metabolism (not existence cost)


### PR DESCRIPTION
This commit introduces more realistic physics where:
1. Direction changes cost energy proportional to turn angle
2. Larger fish use more energy to turn (scaled by size^1.5)
3. Larger fish use more energy to move (scaled by size^1.2)

Changes:
- Added DIRECTION_CHANGE_ENERGY_BASE, DIRECTION_CHANGE_SIZE_MULTIPLIER, and MOVEMENT_SIZE_MULTIPLIER constants
- Rewrote _apply_turn_energy_cost() to scale with turn angle and fish size
- Enhanced movement energy consumption with non-linear size scaling
- Direction changes now have granular costs (not just sharp turns)

The new physics makes larger fish more expensive to control while small fish are more agile and energy-efficient.