### PR TITLE
Fix frame-based memory expiration

### DIFF
--- a/core/fish_memory.py
+++ b/core/fish_memory.py
@@ -7,7 +7,6 @@ This module provides advanced memory capabilities including:
 - Learning from experience
 """
 
-import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional
@@ -45,10 +44,14 @@ class Memory:
         """Reinforce memory (increase strength)."""
         self.strength = min(1.0, self.strength + amount)
 
-    def is_expired(self, max_age: int = 1800) -> bool:
-        """Check if memory is too old (default 60 seconds at 30fps)."""
+    def is_expired(self, current_frame: int, max_age: int = 1800) -> bool:
+        """Check if memory is too old based on simulation frames."""
+
+        if max_age <= 0:
+            return self.strength <= 0.0
+
         return self.strength <= 0.0 or (
-            max_age > 0 and self.timestamp > 0 and time.time() - self.timestamp > max_age
+            self.timestamp > 0 and current_frame - self.timestamp > max_age
         )
 
 
@@ -235,7 +238,9 @@ class FishMemorySystem:
 
             # Remove expired memories
             self.memories[memory_type] = [
-                m for m in memories if not m.is_expired(max_age=1800)  # 60 seconds at 30fps
+                m
+                for m in memories
+                if not m.is_expired(self.current_frame, max_age=1800)  # 60 seconds at 30fps
             ]
 
     def clear_memories(self, memory_type: Optional[MemoryType] = None):

--- a/tests/test_fish_memory.py
+++ b/tests/test_fish_memory.py
@@ -1,0 +1,18 @@
+from core.fish_memory import FishMemorySystem, MemoryType
+from core.math_utils import Vector2
+
+
+def test_memories_expire_based_on_frames():
+    system = FishMemorySystem()
+    system.current_frame = 100
+
+    system.add_memory(MemoryType.FOOD_LOCATION, Vector2(10, 10))
+    assert system.get_memory_count(MemoryType.FOOD_LOCATION) == 1
+
+    # Advance fewer frames than the max_age window to ensure memory persists
+    system.update(current_frame=150)
+    assert system.get_memory_count(MemoryType.FOOD_LOCATION) == 1
+
+    # Move well past the max_age window; memory should expire
+    system.update(current_frame=2000)
+    assert system.get_memory_count(MemoryType.FOOD_LOCATION) == 0


### PR DESCRIPTION
## Summary
- ensure fish memories expire based on simulation frames instead of wall clock time
- add regression test covering memory retention within and beyond the frame window

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f36a7b8b08331a31865ea28626244)