### PR TITLE
Clean up UI layout and remove redundant stats

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { useWebSocket } from './hooks/useWebSocket';
 import { Canvas } from './components/Canvas';
 import { ControlPanel } from './components/ControlPanel';
 import { StatsPanel } from './components/StatsPanel';
+import { EcosystemStats } from './components/EcosystemStats';
 import PokerEvents from './components/PokerEvents';
 import { PokerLeaderboard } from './components/PokerLeaderboard';
 import { PhylogeneticTree } from './components/PhylogeneticTree';
@@ -127,6 +128,12 @@ function App() {
                 </p>
               </div>
               <div>
+                <p className="canvas-label">Generation</p>
+                <p className="canvas-value">
+                  {state?.stats?.generation ?? 0}
+                </p>
+              </div>
+              <div>
                 <p className="canvas-label">Population</p>
                 <p className="canvas-value">
                   {state?.stats?.fish_count ?? 0}
@@ -144,6 +151,12 @@ function App() {
                 </p>
               </div>
               <div>
+                <p className="canvas-label">Age</p>
+                <p className="canvas-value">
+                  {state?.stats?.time ?? '—'}
+                </p>
+              </div>
+              <div>
                 <p className="canvas-label">Status</p>
                 <p className={`canvas-status ${isConnected ? 'online' : 'offline'}`}>
                   {isConnected ? 'Connected' : 'Waiting'}
@@ -153,6 +166,7 @@ function App() {
             <Canvas state={state} width={800} height={600} />
             <div className="canvas-glow" aria-hidden />
           </div>
+          <EcosystemStats stats={state?.stats ?? null} />
           <PokerEvents
             events={state?.poker_events ?? []}
             currentFrame={state?.frame ?? 0}

--- a/frontend/src/components/EcosystemStats.module.css
+++ b/frontend/src/components/EcosystemStats.module.css
@@ -1,0 +1,49 @@
+.container {
+  display: flex;
+  gap: 24px;
+  padding: 16px 20px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(71, 85, 105, 0.3);
+  border-radius: 8px;
+  margin-top: 16px;
+  backdrop-filter: blur(10px);
+}
+
+.section {
+  flex: 1;
+  min-width: 0;
+}
+
+.sectionTitle {
+  font-size: 12px;
+  font-weight: 600;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.statsGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.statItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.label {
+  color: #cbd5e1;
+  font-weight: 400;
+}
+
+.value {
+  color: #f1f5f9;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/components/EcosystemStats.tsx
+++ b/frontend/src/components/EcosystemStats.tsx
@@ -1,0 +1,65 @@
+/**
+ * Ecosystem statistics component
+ * Displays non-poker stats below the tank simulation
+ */
+
+import type { StatsData } from '../types/simulation';
+import styles from './EcosystemStats.module.css';
+
+interface EcosystemStatsProps {
+  stats: StatsData | null;
+}
+
+export function EcosystemStats({ stats }: EcosystemStatsProps) {
+  if (!stats) {
+    return null;
+  }
+
+  const deathCauseEntries = Object.entries(stats.death_causes);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.section}>
+        <div className={styles.sectionTitle}>Ecosystem</div>
+        <div className={styles.statsGrid}>
+          <div className={styles.statItem}>
+            <span className={styles.label}>Food:</span>
+            <span className={styles.value}>{stats.food_count}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.section}>
+        <div className={styles.sectionTitle}>Population</div>
+        <div className={styles.statsGrid}>
+          <div className={styles.statItem}>
+            <span className={styles.label}>Fish Alive:</span>
+            <span className={styles.value}>{stats.fish_count}</span>
+          </div>
+          <div className={styles.statItem}>
+            <span className={styles.label}>Total Births:</span>
+            <span className={styles.value}>{stats.births}</span>
+          </div>
+          <div className={styles.statItem}>
+            <span className={styles.label}>Total Deaths:</span>
+            <span className={styles.value}>{stats.deaths}</span>
+          </div>
+        </div>
+      </div>
+
+      {deathCauseEntries.length > 0 && (
+        <div className={styles.section}>
+          <div className={styles.sectionTitle}>Death Causes</div>
+          <div className={styles.statsGrid}>
+            {deathCauseEntries.map(([cause, count]) => (
+              <div key={cause} className={styles.statItem}>
+                <span className={styles.label}>{cause}:</span>
+                <span className={styles.value}>{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -1,10 +1,9 @@
 /**
- * Stats panel component showing ecosystem statistics
+ * Stats panel component showing poker statistics
  */
 
 import type { StatsData } from '../types/simulation';
-import { Panel, CollapsibleSection, StatRow } from './ui';
-import { getEnergyColor } from '../utils/energy';
+import { Panel, StatRow } from './ui';
 import styles from './StatsPanel.module.css';
 
 interface StatsPanelProps {
@@ -14,116 +13,55 @@ interface StatsPanelProps {
 export function StatsPanel({ stats }: StatsPanelProps) {
   if (!stats) {
     return (
-      <Panel title="Statistics">
+      <Panel title="Poker Stats">
         <p className={styles.noData}>Waiting for data...</p>
       </Panel>
     );
   }
 
-  const deathCauseEntries = Object.entries(stats.death_causes);
   const winRate = stats.poker_stats ? (stats.poker_stats.win_rate || 0) * 100 : 0;
-  const avgEnergy = stats.fish_count > 0 ? stats.total_energy / stats.fish_count : 0;
 
   return (
-    <Panel title="Statistics">
-      <div className={styles.highlightGrid}>
-        <div className={styles.highlightCard}>
-          <p className={styles.highlightLabel}>Generation</p>
-          <p className={styles.highlightValue}>{stats.generation}</p>
+    <Panel title={`Poker Stats ${stats.poker_stats && stats.poker_stats.total_games > 0 ? `(${winRate.toFixed(0)}% WR)` : ''}`}>
+      {!stats.poker_stats || stats.poker_stats.total_games === 0 ? (
+        <div className={styles.noPokerGames}>
+          No poker games yet (fish need 10+ energy & to collide)
         </div>
-        <div className={styles.highlightCard}>
-          <p className={styles.highlightLabel}>Avg Energy</p>
-          <p
-            className={styles.highlightValue}
-            style={{ color: getEnergyColor(avgEnergy) }}
-          >
-            {avgEnergy.toFixed(1)}
-          </p>
-        </div>
-        <div className={styles.highlightCard}>
-          <p className={styles.highlightLabel}>Time</p>
-          <p className={styles.highlightValue}>{stats.time}</p>
-        </div>
-      </div>
-
-      {/* Ecosystem */}
-      <CollapsibleSection title="Ecosystem" defaultExpanded>
-        <div className={styles.gridRow}>
-          <StatRow label="Capacity:" value={stats.capacity} />
-          <StatRow label="Energy Reserve:" value={Math.round(stats.total_energy).toLocaleString()} />
-        </div>
-        <div className={styles.gridRow}>
-          <StatRow label="Food:" value={stats.food_count} />
-          <StatRow label="Plants:" value={stats.plant_count} />
-        </div>
-      </CollapsibleSection>
-
-      {/* Population */}
-      <CollapsibleSection title="Population" defaultExpanded={false}>
-        <div className={styles.gridRow}>
-          <StatRow label="Fish Alive:" value={stats.fish_count} />
-          <StatRow label="Total Births:" value={stats.births} />
-        </div>
-        <div className={styles.gridRow}>
-          <StatRow label="Total Deaths:" value={stats.deaths} />
-        </div>
-      </CollapsibleSection>
-
-      {/* Death Causes */}
-      {deathCauseEntries.length > 0 && (
-        <CollapsibleSection title="Death Causes" defaultExpanded={false}>
-          {deathCauseEntries.map(([cause, count]) => (
-            <div key={cause} className={styles.statRow}>
-              <StatRow label={`${cause}:`} value={count} />
-            </div>
-          ))}
-        </CollapsibleSection>
-      )}
-
-      {/* Poker Stats */}
-      {stats.poker_stats && (
-        <CollapsibleSection title={`Poker Stats ${stats.poker_stats.total_games > 0 ? `(${winRate.toFixed(0)}% WR)` : ''}`}>
-          {stats.poker_stats.total_games === 0 ? (
-            <div className={styles.noPokerGames}>
-              No poker games yet (fish need 10+ energy & to collide)
-            </div>
-          ) : (
-            <>
-              <div className={styles.gridRow}>
-                <StatRow label="Games:" value={stats.poker_stats.total_games} />
-                <StatRow
-                  label="Win Rate:"
-                  value={stats.poker_stats.win_rate_pct || '0.0%'}
-                  valueColor={(stats.poker_stats.win_rate || 0) > 0.5 ? '#4ade80' : '#94a3b8'}
-                />
-              </div>
-              <div className={styles.gridRow}>
-                <StatRow
-                  label="Net Energy:"
-                  value={`${stats.poker_stats.net_energy >= 0 ? '+' : ''}${stats.poker_stats.net_energy.toFixed(1)}`}
-                  valueColor={stats.poker_stats.net_energy >= 0 ? '#4ade80' : '#f87171'}
-                  valueStyle={{ fontWeight: 600 }}
-                />
-                <StatRow
-                  label="ROI:"
-                  value={stats.poker_stats.roi !== undefined ? (stats.poker_stats.roi >= 0 ? '+' : '') + stats.poker_stats.roi.toFixed(2) : '0.00'}
-                  valueColor={(stats.poker_stats.roi || 0) >= 0 ? '#4ade80' : '#f87171'}
-                />
-              </div>
-              <div className={styles.gridRow}>
-                <StatRow label="Showdown:" value={stats.poker_stats.showdown_win_rate || '0.0%'} />
-                <StatRow
-                  label="Aggression:"
-                  value={stats.poker_stats.aggression_factor !== undefined ? stats.poker_stats.aggression_factor.toFixed(2) : '0.00'}
-                />
-              </div>
-              <div className={styles.gridRow}>
-                <StatRow label="VPIP:" value={stats.poker_stats.vpip_pct || '0.0%'} />
-                <StatRow label="Best Hand:" value={stats.poker_stats.best_hand_name} />
-              </div>
-            </>
-          )}
-        </CollapsibleSection>
+      ) : (
+        <>
+          <div className={styles.gridRow}>
+            <StatRow label="Games:" value={stats.poker_stats.total_games} />
+            <StatRow
+              label="Win Rate:"
+              value={stats.poker_stats.win_rate_pct || '0.0%'}
+              valueColor={(stats.poker_stats.win_rate || 0) > 0.5 ? '#4ade80' : '#94a3b8'}
+            />
+          </div>
+          <div className={styles.gridRow}>
+            <StatRow
+              label="Net Energy:"
+              value={`${stats.poker_stats.net_energy >= 0 ? '+' : ''}${stats.poker_stats.net_energy.toFixed(1)}`}
+              valueColor={stats.poker_stats.net_energy >= 0 ? '#4ade80' : '#f87171'}
+              valueStyle={{ fontWeight: 600 }}
+            />
+            <StatRow
+              label="ROI:"
+              value={stats.poker_stats.roi !== undefined ? (stats.poker_stats.roi >= 0 ? '+' : '') + stats.poker_stats.roi.toFixed(2) : '0.00'}
+              valueColor={(stats.poker_stats.roi || 0) >= 0 ? '#4ade80' : '#f87171'}
+            />
+          </div>
+          <div className={styles.gridRow}>
+            <StatRow label="Showdown:" value={stats.poker_stats.showdown_win_rate || '0.0%'} />
+            <StatRow
+              label="Aggression:"
+              value={stats.poker_stats.aggression_factor !== undefined ? stats.poker_stats.aggression_factor.toFixed(2) : '0.00'}
+            />
+          </div>
+          <div className={styles.gridRow}>
+            <StatRow label="VPIP:" value={stats.poker_stats.vpip_pct || '0.0%'} />
+            <StatRow label="Best Hand:" value={stats.poker_stats.best_hand_name} />
+          </div>
+        </>
       )}
     </Panel>
   );


### PR DESCRIPTION
Cleaned up the UI by reorganizing statistics display:

**Above the tank:**
- Added Generation and Age to canvas-meta section
- Kept existing Simulation, Population, Energy, Status

**Below the tank:**
- Created new EcosystemStats component displaying:
  - Ecosystem: Food count
  - Population: Fish Alive, Total Births, Total Deaths
  - Death Causes: breakdown of starvation, old_age, predation

**Right sidebar (StatsPanel):**
- Now shows only Poker Stats
- Removed redundant sections (Ecosystem, Population, Death Causes)
- Removed highlight cards at top

**Removed stats:**
- Plants count (less useful)
- Energy Reserve (redundant with Energy total)
- Capacity percentage (not informative)
- Duplicate Generation, Time, Avg Energy from highlight cards

This provides a cleaner layout with poker stats separated from general ecosystem stats, and eliminates redundant information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)