### PR TITLE
Fix JSX closing tag error in App.tsx

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -153,43 +153,42 @@ function App() {
               </div>
             <Canvas state={state} width={800} height={600} />
             <div className="canvas-glow" aria-hidden />
-          </div>
-          <EcosystemStats stats={state?.stats ?? null} />
-          <PokerEvents
-            events={state?.poker_events ?? []}
-            currentFrame={state?.frame ?? 0}
-          />
-          <PokerLeaderboard leaderboard={state?.poker_leaderboard ?? []} />
-          <div style={{ marginTop: '20px' }}>
-            <h2 style={{ color: '#00ff00', marginBottom: '10px', fontSize: '20px' }}>
-              Phylogenetic Tree
-            </h2>
-            <PhylogeneticTree />
-          </div>
-
-          {/* Poker Game */}
-          {showPokerGame && (
-            <div style={{ marginTop: '20px', width: '100%', maxWidth: '820px' }}>
-              <PokerGame
-                onClose={handleClosePoker}
-                onAction={handlePokerAction}
-                gameState={pokerGameState}
-                loading={pokerLoading}
-              />
+            <EcosystemStats stats={state?.stats ?? null} />
+            <PokerEvents
+              events={state?.poker_events ?? []}
+              currentFrame={state?.frame ?? 0}
+            />
+            <PokerLeaderboard leaderboard={state?.poker_leaderboard ?? []} />
+            <div style={{ marginTop: '20px' }}>
+              <h2 style={{ color: '#00ff00', marginBottom: '10px', fontSize: '20px' }}>
+                Phylogenetic Tree
+              </h2>
+              <PhylogeneticTree />
             </div>
-          )}
 
-          {/* Auto-Evaluation Display */}
-          {showAutoEvaluate && (
-            <div style={{ marginTop: '20px', width: '100%', maxWidth: '820px' }}>
-              <AutoEvaluateDisplay
-                stats={autoEvaluateStats}
-                onClose={handleCloseAutoEvaluate}
-                loading={autoEvaluateLoading}
-              />
-            </div>
-          )}
-        </div>
+            {/* Poker Game */}
+            {showPokerGame && (
+              <div style={{ marginTop: '20px', width: '100%', maxWidth: '820px' }}>
+                <PokerGame
+                  onClose={handleClosePoker}
+                  onAction={handlePokerAction}
+                  gameState={pokerGameState}
+                  loading={pokerLoading}
+                />
+              </div>
+            )}
+
+            {/* Auto-Evaluation Display */}
+            {showAutoEvaluate && (
+              <div style={{ marginTop: '20px', width: '100%', maxWidth: '820px' }}>
+                <AutoEvaluateDisplay
+                  stats={autoEvaluateStats}
+                  onClose={handleCloseAutoEvaluate}
+                  loading={autoEvaluateLoading}
+                />
+              </div>
+            )}
+          </div>
 
         <div className="sidebar">
           <ControlPanel


### PR DESCRIPTION
Previously, there was an extra closing div tag at line 156 that was prematurely closing the .app container, causing a JSX parsing error. This resulted in components like EcosystemStats, PokerEvents, and PokerLeaderboard being placed outside the app div incorrectly.

Fixed by removing the extra closing tag and ensuring all app components are properly nested within the main .app container div.

🤖 Generated with [Claude Code](https://claude.com/claude-code)