### PR TITLE
Allow greater zoom-out on phylogenetic tree

### DIFF
--- a/frontend/src/components/PhylogeneticTree.tsx
+++ b/frontend/src/components/PhylogeneticTree.tsx
@@ -175,7 +175,7 @@ export const PhylogeneticTree: React.FC = () => {
                 collapsible={true}
                 nodeSize={{ x: 280, y: 160 }}
                 separation={{ siblings: 1.8, nonSiblings: 2.4 }}
-                scaleExtent={{ min: 0.5, max: 2.5 }}
+                scaleExtent={{ min: 0.25, max: 2.5 }}
             />
         </div>
     );


### PR DESCRIPTION
## Summary
- allow further zooming out on the phylogenetic tree by lowering the minimum scale extent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f677c00748331ad65acc0f6011aa0)