### PR TITLE
Add evasive live food that spawns randomly

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -52,6 +52,7 @@ AUTO_FOOD_HIGH_ENERGY_THRESHOLD_1 = 4500  # Reduce spawn rate above this total e
 AUTO_FOOD_HIGH_ENERGY_THRESHOLD_2 = 6500  # Further reduce spawn rate above this total energy
 AUTO_FOOD_HIGH_POP_THRESHOLD_1 = 15  # Reduce spawn rate above this fish count
 AUTO_FOOD_HIGH_POP_THRESHOLD_2 = 20  # Further reduce spawn rate above this fish count
+LIVE_FOOD_SPAWN_CHANCE = 0.2  # 20% of auto-spawned food will be live/active
 
 # Food type definitions with nutrient properties
 FOOD_TYPES = {
@@ -102,6 +103,14 @@ FOOD_TYPES = {
         "rarity": 0.15,  # Used for plant-only spawn weighting
         "sink_multiplier": 0.0,  # Remains in place
         "stationary": True,
+    },
+    "live": {
+        "name": "Live Treat",
+        "files": ["food_energy1.png", "food_energy2.png"],
+        "energy": 80.0,  # Moderate reward but harder to catch
+        "rarity": 0.12,  # Appears occasionally
+        "sink_multiplier": 0.0,  # Self-propelled, so no sinking
+        "stationary": False,
     },
 }
 

--- a/core/simulators/base_simulator.py
+++ b/core/simulators/base_simulator.py
@@ -19,6 +19,7 @@ from core.constants import (
     AUTO_FOOD_SPAWN_RATE,
     AUTO_FOOD_ULTRA_LOW_ENERGY_THRESHOLD,
     COLLISION_QUERY_RADIUS,
+    LIVE_FOOD_SPAWN_CHANCE,
     MATING_QUERY_RADIUS,
     SCREEN_HEIGHT,
     SCREEN_WIDTH,
@@ -486,19 +487,31 @@ class BaseSimulator(ABC):
         self.auto_food_timer += 1
         if self.auto_food_timer >= spawn_rate:
             self.auto_food_timer = 0
-            # Spawn food from the top at random x position
-            x = random.randint(0, SCREEN_WIDTH)
-            food = entities.Food(
-                environment,
-                x,
-                0,
-                source_plant=None,
-                allow_stationary_types=False,
-                screen_width=SCREEN_WIDTH,
-                screen_height=SCREEN_HEIGHT,
-            )
-            # Ensure the food starts exactly at the top edge before falling
-            food.pos.y = 0
+            live_food_roll = random.random()
+            if live_food_roll < LIVE_FOOD_SPAWN_CHANCE:
+                food_x = random.randint(0, SCREEN_WIDTH)
+                food_y = random.randint(0, SCREEN_HEIGHT)
+                food = entities.LiveFood(
+                    environment,
+                    food_x,
+                    food_y,
+                    screen_width=SCREEN_WIDTH,
+                    screen_height=SCREEN_HEIGHT,
+                )
+            else:
+                # Spawn food from the top at random x position
+                x = random.randint(0, SCREEN_WIDTH)
+                food = entities.Food(
+                    environment,
+                    x,
+                    0,
+                    source_plant=None,
+                    allow_stationary_types=False,
+                    screen_width=SCREEN_WIDTH,
+                    screen_height=SCREEN_HEIGHT,
+                )
+                # Ensure the food starts exactly at the top edge before falling
+                food.pos.y = 0
             self.add_entity(food)
 
     def keep_entity_on_screen(


### PR DESCRIPTION
## Summary
- add a mobile live food type that wanders and avoids nearby fish
- introduce a chance for auto-spawned food to use the live type and appear anywhere in the tank
- extend food type configuration to support the new live food option

## Testing
- python -m pytest tests/core/test_entities.py -q *(fails: file or directory not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6b69fa048331aed421b7452982a0)