### PR TITLE
Enhance live food visuals and night spawning

### DIFF
--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -365,7 +365,13 @@ class SimulationEngine(BaseSimulator):
 
             # Decide whether to spawn live food or regular food
             live_food_roll = self.rng.random()
-            if live_food_roll < LIVE_FOOD_SPAWN_CHANCE:
+            live_food_chance = LIVE_FOOD_SPAWN_CHANCE
+
+            # Live food becomes more common at night to mimic nocturnal plankton swarms
+            if self.time_system.is_night():
+                live_food_chance = min(0.9, LIVE_FOOD_SPAWN_CHANCE * 1.75)
+
+            if live_food_roll < live_food_chance:
                 # Spawn live food at random position (not from pool - LiveFood is special)
                 food_x = self.rng.randint(0, SCREEN_WIDTH)
                 food_y = self.rng.randint(0, SCREEN_HEIGHT)

--- a/frontend/src/utils/renderer.ts
+++ b/frontend/src/utils/renderer.ts
@@ -502,61 +502,78 @@ export class Renderer {
     if (isLiveFood) {
       // Pulsing animation for live food
       const pulse = Math.sin(elapsedTime * 0.005) * 0.3 + 0.7;
+      const cx = x + width / 2;
+      const cy = y + height / 2;
+      const planktonSeed = (x + y) * 0.01;
 
-      // Bright pulsing outer glow (cyan/green to indicate "alive")
+      // Soft bioluminescent outer glow for zooplankton look
       this.ctx.save();
-      this.ctx.globalAlpha = 0.6 * pulse;
-      const outerGlow = this.ctx.createRadialGradient(
-        x + width / 2,
-        y + height / 2,
-        0,
-        x + width / 2,
-        y + height / 2,
-        scaledWidth * 1.2
-      );
-      outerGlow.addColorStop(0, '#00ffff');
-      outerGlow.addColorStop(0.5, '#00ff88');
-      outerGlow.addColorStop(1, 'rgba(0, 255, 136, 0)');
+      this.ctx.globalAlpha = 0.55 * pulse;
+      const outerGlow = this.ctx.createRadialGradient(cx, cy, 0, cx, cy, scaledWidth * 1.3);
+      outerGlow.addColorStop(0, '#66f7ff');
+      outerGlow.addColorStop(0.5, '#4ad8b8');
+      outerGlow.addColorStop(1, 'rgba(74, 216, 184, 0)');
       this.ctx.fillStyle = outerGlow;
       this.ctx.beginPath();
-      this.ctx.arc(x + width / 2, y + height / 2, scaledWidth * 1.2, 0, Math.PI * 2);
+      this.ctx.arc(cx, cy, scaledWidth * 1.3, 0, Math.PI * 2);
       this.ctx.fill();
       this.ctx.restore();
 
-      // Inner bright glow
+      // Inner nucleus glow
       this.ctx.save();
-      this.ctx.globalAlpha = 0.8 * pulse;
-      const innerGlow = this.ctx.createRadialGradient(
-        x + width / 2,
-        y + height / 2,
-        0,
-        x + width / 2,
-        y + height / 2,
-        scaledWidth * 0.8
-      );
-      innerGlow.addColorStop(0, '#ffffff');
-      innerGlow.addColorStop(0.4, '#00ffcc');
-      innerGlow.addColorStop(1, 'rgba(0, 255, 204, 0)');
+      this.ctx.globalAlpha = 0.85 * pulse;
+      const innerGlow = this.ctx.createRadialGradient(cx, cy, 0, cx, cy, scaledWidth * 0.7);
+      innerGlow.addColorStop(0, '#eaffff');
+      innerGlow.addColorStop(0.45, '#7cffe4');
+      innerGlow.addColorStop(1, 'rgba(124, 255, 228, 0)');
       this.ctx.fillStyle = innerGlow;
       this.ctx.beginPath();
-      this.ctx.arc(x + width / 2, y + height / 2, scaledWidth * 0.8, 0, Math.PI * 2);
+      this.ctx.arc(cx, cy, scaledWidth * 0.7, 0, Math.PI * 2);
       this.ctx.fill();
+      this.ctx.restore();
+
+      // Thin appendages to mimic plankton cilia
+      this.ctx.save();
+      this.ctx.lineWidth = 1.2;
+      this.ctx.strokeStyle = `rgba(180, 240, 255, ${0.5 * pulse})`;
+      for (let i = 0; i < 6; i++) {
+        const angle = (Math.PI * 2 * i) / 6 + pulse * 0.4;
+        const sway = Math.sin(elapsedTime * 0.003 + planktonSeed + i) * 4;
+        const length = scaledWidth * (0.6 + 0.2 * Math.sin(elapsedTime * 0.002 + i));
+        const startX = cx + Math.cos(angle) * (scaledWidth * 0.2);
+        const startY = cy + Math.sin(angle) * (scaledWidth * 0.2);
+        const ctrlX = cx + Math.cos(angle) * (length * 0.5) + sway;
+        const ctrlY = cy + Math.sin(angle) * (length * 0.5) - sway;
+        const endX = cx + Math.cos(angle) * length;
+        const endY = cy + Math.sin(angle) * length;
+
+        this.ctx.beginPath();
+        this.ctx.moveTo(startX, startY);
+        this.ctx.quadraticCurveTo(ctrlX, ctrlY, endX, endY);
+        this.ctx.stroke();
+      }
+      this.ctx.restore();
+
+      // Speckled body highlights
+      this.ctx.save();
+      this.ctx.fillStyle = `rgba(255, 255, 255, ${0.5 * pulse})`;
+      for (let i = 0; i < 5; i++) {
+        const jitterX = Math.sin(planktonSeed + i * 1.7 + elapsedTime * 0.004) * 2;
+        const jitterY = Math.cos(planktonSeed + i * 1.3 + elapsedTime * 0.003) * 2;
+        this.ctx.beginPath();
+        this.ctx.arc(cx + jitterX, cy + jitterY, scaledWidth * 0.1, 0, Math.PI * 2);
+        this.ctx.fill();
+      }
       this.ctx.restore();
 
       // Draw motion trail effect for live food
       this.ctx.save();
-      this.ctx.globalAlpha = 0.3;
-      this.ctx.fillStyle = '#00ffaa';
+      this.ctx.globalAlpha = 0.25;
+      this.ctx.fillStyle = '#5fffd6';
       for (let i = 0; i < 3; i++) {
         const trailOffset = -i * 3;
         this.ctx.beginPath();
-        this.ctx.arc(
-          x + width / 2 + trailOffset,
-          y + height / 2,
-          (scaledWidth * 0.4) * (1 - i * 0.2),
-          0,
-          Math.PI * 2
-        );
+        this.ctx.arc(cx + trailOffset, cy, scaledWidth * 0.3 * (1 - i * 0.2), 0, Math.PI * 2);
         this.ctx.fill();
       }
       this.ctx.restore();


### PR DESCRIPTION
## Summary
- adjust live food rendering to resemble glowing zooplankton with cilia-like details
- increase live food spawn likelihood during night cycles for nocturnal swarms

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f76fa39d88331b4c9f7f25cffe1c9)