### PR TITLE
Fix fish not recognizing live food

### DIFF
--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -275,7 +275,12 @@ class SimulationEngine(BaseSimulator):
 
             self.keep_entity_on_screen(entity)
 
-            if isinstance(entity, entities.Food) and entity.pos.y >= SCREEN_HEIGHT - entity.height:
+            # Remove regular food that sinks to bottom, but NOT live food (which swims freely)
+            if (
+                isinstance(entity, entities.Food)
+                and not isinstance(entity, entities.LiveFood)
+                and entity.pos.y >= SCREEN_HEIGHT - entity.height
+            ):
                 self.remove_entity(entity)
 
         for new_entity in new_entities:


### PR DESCRIPTION
Previously, LiveFood instances were being removed when they wandered to the bottom of the screen, just like regular sinking food. This caused fish to lose sight of live food randomly, making it appear that fish couldn't recognize live food as food.

LiveFood is meant to swim freely throughout the tank, not sink and be removed at the bottom. The fix excludes LiveFood from the bottom-of-screen removal check.

Changes:
- Modified entity update loop to check for LiveFood type before removing food at bottom of screen
- Added clarifying comment explaining the behavior difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)