### PR TITLE
Make Phylogenetic Tree more compact horizontally

### DIFF
--- a/frontend/src/components/PhylogeneticTree.tsx
+++ b/frontend/src/components/PhylogeneticTree.tsx
@@ -173,8 +173,8 @@ export const PhylogeneticTree: React.FC = () => {
                 translate={translate} // Start in top center
                 zoomable={true}
                 collapsible={true}
-                nodeSize={{ x: 280, y: 160 }}
-                separation={{ siblings: 1.8, nonSiblings: 2.4 }}
+                nodeSize={{ x: 240, y: 160 }}
+                separation={{ siblings: 1.2, nonSiblings: 1.5 }}
                 scaleExtent={{ min: 0.25, max: 2.5 }}
             />
         </div>


### PR DESCRIPTION
Reduced horizontal spacing between nodes by adjusting:
- nodeSize.x: 280 → 240 (14% reduction)
- separation.siblings: 1.8 → 1.2 (33% reduction)
- separation.nonSiblings: 2.4 → 1.5 (37.5% reduction)

This makes better use of horizontal space while maintaining readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)