### PR TITLE
Add time-of-day visuals and adjust spawning rates

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -40,8 +40,8 @@ export function Canvas({ state, width = 800, height = 600 }: CanvasProps) {
 
     const renderer = rendererRef.current;
 
-    // Clear canvas
-    renderer.clear(width, height);
+    // Clear canvas with time-of-day effects
+    renderer.clear(width, height, state.stats?.time);
 
     // Render all entities
     state.entities.forEach((entity) => {


### PR DESCRIPTION
## Summary
- add time-of-day-aware palettes to the renderer and feed canvas clears with the current cycle
- emphasize dawn/dusk live food spawning while softening daytime live food frequency
- bias plant nectar production toward daytime frames for more rewarding daylight harvests

## Testing
- python -m compileall core

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9d8c52e08331bec46e8dff3749c3)