### PR TITLE
Fix type annotations for Python compatibility

### DIFF
--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -4,7 +4,7 @@ This module manages population dynamics, statistics, and ecosystem health.
 """
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 from core.constants import MAX_ECOSYSTEM_EVENTS, TOTAL_ALGORITHM_COUNT
 from core.ecosystem_stats import (
@@ -1281,7 +1281,7 @@ class EcosystemManager:
         """
         return self.jellyfish_poker_stats.get(fish_id)
 
-    def get_lineage_data(self, alive_fish_ids: Optional[set[int]] = None) -> List[Dict[str, Any]]:
+    def get_lineage_data(self, alive_fish_ids: Optional[Set[int]] = None) -> List[Dict[str, Any]]:
         """Get complete lineage data for phylogenetic tree visualization.
 
         Args:

--- a/core/environment.py
+++ b/core/environment.py
@@ -163,8 +163,8 @@ class Environment:
 
         # Query cache to avoid redundant searches within the same frame
         # Cache is cleared when rebuild_spatial_grid() is called
-        self._query_cache: dict[Tuple, List[Agent]] = {}
-        self._type_cache: dict[Type[Agent], List[Agent]] = {}
+        self._query_cache: Dict[Tuple, List[Agent]] = {}
+        self._type_cache: Dict[Type[Agent], List[Agent]] = {}
 
         # NEW: Initialize communication system for fish
         from core.fish_communication import FishCommunicationSystem


### PR DESCRIPTION
Replace PEP 585-style built-in generics with typing module equivalents:
- core/ecosystem.py: Change set[int] to Set[int]
- core/environment.py: Change dict[...] to Dict[...]

This resolves TypeError: 'type' object is not subscriptable errors in CI environments running Python versions prior to 3.9.

Fixes #issue