### PR TITLE
Improve horizontal spacing and layout

### DIFF
--- a/frontend/src/components/PhylogeneticTree.tsx
+++ b/frontend/src/components/PhylogeneticTree.tsx
@@ -173,8 +173,8 @@ export const PhylogeneticTree: React.FC = () => {
                 translate={translate} // Start in top center
                 zoomable={true}
                 collapsible={true}
-                nodeSize={{ x: 200, y: 160 }}
-                separation={{ siblings: 0.8, nonSiblings: 1.0 }}
+                nodeSize={{ x: 250, y: 160 }}
+                separation={{ siblings: 1.2, nonSiblings: 1.3 }}
                 scaleExtent={{ min: 0.25, max: 2.5 }}
             />
         </div>


### PR DESCRIPTION
Expanded horizontal spacing to improve readability:
- Increased node width from 200 to 250 pixels
- Increased sibling separation from 0.8 to 1.2
- Increased non-sibling separation from 1.0 to 1.3

This gives the tree more breathing room and makes it easier to distinguish between individual nodes and their relationships.