### PR TITLE
Compute max generation from living population

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -119,6 +119,7 @@ class StatsData(BaseModel):
     frame: int
     population: int
     generation: int
+    max_generation: int
     births: int
     deaths: int
     capacity: str

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -264,6 +264,9 @@ class SimulationRunner:
                 frame=self.world.frame_count,
                 population=stats.get("total_population", 0),
                 generation=stats.get("current_generation", 0),
+                max_generation=stats.get(
+                    "max_generation", stats.get("current_generation", 0)
+                ),
                 births=stats.get("total_births", 0),
                 deaths=stats.get("total_deaths", 0),
                 capacity=stats.get("capacity_usage", "0%"),

--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -487,9 +487,12 @@ class EcosystemManager:
 
             total_energy = sum(e.energy for e in entities if isinstance(e, Fish))
 
+        alive_generations = [g for g, s in self.generation_stats.items() if s.population > 0]
+
         return {
             "total_population": total_pop,
             "current_generation": self.current_generation,
+            "max_generation": max(alive_generations) if alive_generations else 0,
             "total_births": self.total_births,
             "total_deaths": self.total_deaths,
             "carrying_capacity": self.max_population,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -118,6 +118,17 @@ body {
     margin-left: 6px;
 }
 
+.canvas-value .canvas-subvalue {
+    display: block;
+    margin-left: 0;
+    margin-top: 4px;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.85);
+}
+
 .canvas-status {
     font-weight: 600;
     font-size: 18px;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,10 @@ function App() {
     const [showPokerGame, setShowPokerGame] = useState(false);
     const [pokerLoading, setPokerLoading] = useState(false);
 
+    const maxGeneration = state?.stats
+        ? state.stats.max_generation ?? state.stats.generation ?? 0
+        : 0;
+
     // Auto-evaluation state
     const [autoEvaluateStats, setAutoEvaluateStats] = useState<AutoEvaluateStats | null>(null);
     const [showAutoEvaluate, setShowAutoEvaluate] = useState(false);
@@ -131,6 +135,9 @@ function App() {
                                 <p className="canvas-value">
                                     {state?.stats?.fish_count ?? 0}
                                     <span> fish</span>
+                                    {state?.stats && (
+                                        <span className="canvas-subvalue">Max Gen {maxGeneration}</span>
+                                    )}
                                 </p>
                             </div>
                             <div>
@@ -141,6 +148,12 @@ function App() {
                                 >
                                     {state?.stats?.total_energy ? Math.round(state.stats.total_energy).toLocaleString() : '—'}
                                     <span>total</span>
+                                </p>
+                            </div>
+                            <div>
+                                <p className="canvas-label">Time</p>
+                                <p className="canvas-value">
+                                    {state?.stats?.time ?? '—'}
                                 </p>
                             </div>
                             <div>

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -117,6 +117,7 @@ export interface StatsData {
   frame: number;
   population: number;
   generation: number;
+  max_generation: number;
   births: number;
   deaths: number;
   capacity: string;


### PR DESCRIPTION
## Summary
- derive the max_generation statistic from generations that still have living fish to avoid reporting extinct generations

## Testing
- python -m compileall backend core

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb5a08f008331b7945caade3370e6)