### PR TITLE
Adjust canvas stats layout to single row

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -92,8 +92,8 @@ body {
 
 .canvas-meta {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 16px;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 14px;
     margin-bottom: 20px;
 }
 


### PR DESCRIPTION
## Summary
- update the canvas stats grid to use five columns so all metrics stay on one row
- slightly reduce spacing to keep the layout compact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb7a5a580833191e5cf681d574290)