### PR TITLE
Prevent stats bar wrapping and prioritize status

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -91,10 +91,17 @@ body {
 }
 
 .canvas-meta {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 16px;
+    display: flex;
+    gap: 10px;
     margin-bottom: 20px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 4px;
+}
+
+.canvas-meta > div {
+    flex: 1;
+    min-width: 0;
 }
 
 .canvas-label {
@@ -183,7 +190,7 @@ body {
     }
 
     .canvas-meta {
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 8px;
     }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -124,6 +124,12 @@ function App() {
                     <div className="canvas-wrapper">
                         <div className="canvas-meta">
                             <div>
+                                <p className="canvas-label">Status</p>
+                                <p className={`canvas-status ${isConnected ? 'online' : 'offline'}`}>
+                                    {isConnected ? 'Connected' : 'Waiting'}
+                                </p>
+                            </div>
+                            <div>
                                 <p className="canvas-label">Simulation</p>
                                 <p className="canvas-value">
                                     {state?.stats?.frame ? state.stats.frame.toLocaleString() : '—'}{' '}
@@ -154,12 +160,6 @@ function App() {
                                 <p className="canvas-label">Time</p>
                                 <p className="canvas-value">
                                     {state?.stats?.time ?? '—'}
-                                </p>
-                            </div>
-                            <div>
-                                <p className="canvas-label">Status</p>
-                                <p className={`canvas-status ${isConnected ? 'online' : 'offline'}`}>
-                                    {isConnected ? 'Connected' : 'Waiting'}
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- switch the canvas stats bar to a no-wrap flex layout so metrics stay on one row even when space is tight
- move the connection status indicator to the first position in the stats bar

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb7a5a580833191e5cf681d574290)