### PR TITLE
Add static poker benchmark series and graph

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,10 +26,10 @@ function App() {
         ? state.stats.max_generation ?? state.stats.generation ?? 0
         : 0;
 
-    // Auto-evaluation state
-    const [autoEvaluateStats, setAutoEvaluateStats] = useState<AutoEvaluateStats | null>(null);
-    const [showAutoEvaluate, setShowAutoEvaluate] = useState(false);
-    const [autoEvaluateLoading, setAutoEvaluateLoading] = useState(false);
+    // Benchmark series state
+    const [benchmarkStats, setBenchmarkStats] = useState<AutoEvaluateStats | null>(null);
+    const [showBenchmark, setShowBenchmark] = useState(false);
+    const [benchmarkLoading, setBenchmarkLoading] = useState(false);
 
     const handleStartPoker = async () => {
         try {
@@ -47,7 +47,7 @@ function App() {
             } else if (response.state) {
                 setPokerGameState(response.state);
             }
-        } catch (error) {
+        } catch {
             alert('Failed to start poker game. Please try again.');
             setShowPokerGame(false);
         } finally {
@@ -69,7 +69,7 @@ function App() {
             } else if (response.state) {
                 setPokerGameState(response.state);
             }
-        } catch (error) {
+        } catch {
             alert('Failed to send action. Please try again.');
         } finally {
             setPokerLoading(false);
@@ -81,33 +81,33 @@ function App() {
         setPokerGameState(null);
     };
 
-    const handleAutoEvaluatePoker = async () => {
+    const handleRunBenchmark = async () => {
         try {
-            setAutoEvaluateLoading(true);
-            setShowAutoEvaluate(true);
+            setBenchmarkLoading(true);
+            setShowBenchmark(true);
 
             const response = await sendCommandWithResponse({
-                command: 'auto_evaluate_poker',
+                command: 'standard_poker_series',
                 data: { standard_energy: 500, max_hands: 1000 },
             });
 
             if (response.success === false) {
-                alert(response.error || 'Failed to run auto-evaluation');
-                setShowAutoEvaluate(false);
+                alert(response.error || 'Failed to run benchmark series');
+                setShowBenchmark(false);
             } else if (response.stats) {
-                setAutoEvaluateStats(response.stats);
+                setBenchmarkStats(response.stats);
             }
-        } catch (error) {
-            alert('Failed to run auto-evaluation. Please try again.');
-            setShowAutoEvaluate(false);
+        } catch {
+            alert('Failed to run benchmark series. Please try again.');
+            setShowBenchmark(false);
         } finally {
-            setAutoEvaluateLoading(false);
+            setBenchmarkLoading(false);
         }
     };
 
-    const handleCloseAutoEvaluate = () => {
-        setShowAutoEvaluate(false);
-        setAutoEvaluateStats(null);
+    const handleCloseBenchmark = () => {
+        setShowBenchmark(false);
+        setBenchmarkStats(null);
     };
 
     return (
@@ -191,12 +191,12 @@ function App() {
                     )}
 
                     {/* Auto-Evaluation Display */}
-                    {showAutoEvaluate && (
+                    {showBenchmark && (
                         <div style={{ marginTop: '20px', width: '100%', maxWidth: '1140px' }}>
                             <AutoEvaluateDisplay
-                                stats={autoEvaluateStats}
-                                onClose={handleCloseAutoEvaluate}
-                                loading={autoEvaluateLoading}
+                                stats={benchmarkStats}
+                                onClose={handleCloseBenchmark}
+                                loading={benchmarkLoading}
                             />
                         </div>
                     )}
@@ -207,7 +207,7 @@ function App() {
                         onCommand={sendCommand}
                         isConnected={isConnected}
                         onPlayPoker={handleStartPoker}
-                        onAutoEvaluatePoker={handleAutoEvaluatePoker}
+                        onRunBenchmark={handleRunBenchmark}
                     />
                     <StatsPanel stats={state?.stats ?? null} />
                 </div>

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -11,10 +11,10 @@ interface ControlPanelProps {
   onCommand: (command: Command) => void;
   isConnected: boolean;
   onPlayPoker?: () => void;
-  onAutoEvaluatePoker?: () => void;
+  onRunBenchmark?: () => void;
 }
 
-export function ControlPanel({ onCommand, isConnected, onPlayPoker, onAutoEvaluatePoker }: ControlPanelProps) {
+export function ControlPanel({ onCommand, isConnected, onPlayPoker, onRunBenchmark }: ControlPanelProps) {
   const [isPaused, setIsPaused] = useState(false);
 
   const handleAddFood = () => {
@@ -40,19 +40,15 @@ export function ControlPanel({ onCommand, isConnected, onPlayPoker, onAutoEvalua
     setIsPaused(false);
   };
 
-  const handleSpawnJellyfish = () => {
-    onCommand({ command: 'spawn_jellyfish' });
-  };
-
   const handlePlayPoker = () => {
     if (onPlayPoker) {
       onPlayPoker();
     }
   };
 
-  const handleAutoEvaluatePoker = () => {
-    if (onAutoEvaluatePoker) {
-      onAutoEvaluatePoker();
+  const handleRunBenchmark = () => {
+    if (onRunBenchmark) {
+      onRunBenchmark();
     }
   };
 
@@ -80,11 +76,11 @@ export function ControlPanel({ onCommand, isConnected, onPlayPoker, onAutoEvalua
         </Button>
 
         <Button
-          onClick={handleAutoEvaluatePoker}
+          onClick={handleRunBenchmark}
           disabled={!isConnected}
           variant="evaluate"
         >
-          📊 Auto-Evaluate Skill
+          📊 Benchmark vs Static
         </Button>
 
         <Button
@@ -101,14 +97,6 @@ export function ControlPanel({ onCommand, isConnected, onPlayPoker, onAutoEvalua
           variant="success"
         >
           🐟 Spawn Fish
-        </Button>
-
-        <Button
-          onClick={handleSpawnJellyfish}
-          disabled={!isConnected}
-          variant="special"
-        >
-          🎰 Spawn Poker Jellyfish
         </Button>
 
         <Button
@@ -135,16 +123,13 @@ export function ControlPanel({ onCommand, isConnected, onPlayPoker, onAutoEvalua
             <strong>Play Poker:</strong> Play poker against the top 3 fish
           </li>
           <li>
-            <strong>Auto-Evaluate Skill:</strong> Test top fish against standard algorithm (1000 hands)
+            <strong>Benchmark vs Static:</strong> Runs a series between the top 3 fish and the static standard player
           </li>
           <li>
             <strong>Add Food:</strong> Drop food into the tank
           </li>
           <li>
             <strong>Spawn Fish:</strong> Add a new fish with random genetics
-          </li>
-          <li>
-            <strong>Spawn Poker Jellyfish:</strong> Add a static poker evaluator that plays fish
           </li>
           <li>
             <strong>Pause:</strong> Pause/resume the simulation

--- a/frontend/src/components/PokerEvents.css
+++ b/frontend/src/components/PokerEvents.css
@@ -63,17 +63,6 @@
   color: #fef9c3;
 }
 
-.poker-events__item.jellyfish {
-  border-color: rgba(147, 51, 234, 0.5);
-  background: rgba(107, 33, 168, 0.15);
-  color: #e9d5ff;
-}
-
-.poker-events__jellyfish-icon {
-  font-size: 16px;
-  margin-right: 4px;
-}
-
 .poker-events__energy-loss {
   color: #ff4444;
   font-weight: 600;

--- a/frontend/src/components/PokerEvents.tsx
+++ b/frontend/src/components/PokerEvents.tsx
@@ -9,7 +9,6 @@ interface PokerEvent {
   loser_hand: string;
   energy_transferred: number;
   message: string;
-  is_jellyfish?: boolean;
 }
 
 interface PokerEventsProps {
@@ -22,7 +21,7 @@ const PokerEvents: React.FC<PokerEventsProps> = ({ events, currentFrame }) => {
     <section className="poker-events" aria-label="Recent poker activity">
       <div className="poker-events__header">
         <h2>Poker Activity</h2>
-        <span>Latest clashes between fish and jellyfish</span>
+        <span>Latest clashes between top fish at the table</span>
       </div>
       {events.length === 0 ? (
         <p className="poker-events__empty">No poker activity yet.</p>
@@ -34,16 +33,14 @@ const PokerEvents: React.FC<PokerEventsProps> = ({ events, currentFrame }) => {
             .map((event, index) => {
               const age = currentFrame - event.frame;
               const isTie = event.winner_id === -1;
-              const isJellyfish = event.is_jellyfish ?? false;
               const fading = Math.max(0.35, 1 - Math.max(0, age - 90) / 90);
 
               return (
                 <div
                   key={`${event.frame}-${index}`}
-                  className={`poker-events__item ${isTie ? 'tie' : ''} ${isJellyfish ? 'jellyfish' : ''}`}
+                  className={`poker-events__item ${isTie ? 'tie' : ''}`}
                   style={{ opacity: fading }}
                 >
-                  {isJellyfish && <span className="poker-events__jellyfish-icon">🪼 </span>}
                   {event.message}
                   {!isTie && event.energy_transferred > 0 && (
                     <span className="poker-events__energy-loss">

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -36,7 +36,7 @@ export function useWebSocket() {
             responseCallbacksRef.current.forEach((callback) => callback(data));
             responseCallbacksRef.current.clear();
           }
-        } catch (error) {
+        } catch {
           // Silently ignore parse errors - malformed data
         }
       };
@@ -58,15 +58,19 @@ export function useWebSocket() {
       };
 
       wsRef.current = ws;
-    } catch (error) {
+    } catch {
       setIsConnected(false);
     }
   }, []);
 
-  // Store connect function in ref
-  connectRef.current = connect;
+  // Store connect function in ref without mutating during render
+  useEffect(() => {
+    connectRef.current = connect;
+  }, [connect]);
 
   useEffect(() => {
+    // WebSocket setup synchronizes with external server state
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     connect();
 
     return () => {

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -4,7 +4,7 @@
 
 export interface EntityData {
   id: number;
-  type: 'fish' | 'food' | 'plant' | 'crab' | 'castle' | 'jellyfish';
+  type: 'fish' | 'food' | 'plant' | 'crab' | 'castle';
   x: number;
   y: number;
   width: number;
@@ -39,8 +39,6 @@ export interface EntityData {
   // Plant-specific
   plant_type?: number;
 
-  // Jellyfish-specific
-  jellyfish_id?: number;
 }
 
 export interface PokerEventData {
@@ -141,7 +139,7 @@ export interface SimulationUpdate {
 }
 
 export interface Command {
-  command: 'add_food' | 'spawn_fish' | 'spawn_jellyfish' | 'pause' | 'resume' | 'reset' | 'start_poker' | 'poker_action' | 'auto_evaluate_poker';
+  command: 'add_food' | 'spawn_fish' | 'pause' | 'resume' | 'reset' | 'start_poker' | 'poker_action' | 'standard_poker_series';
   data?: Record<string, unknown>;
 }
 
@@ -213,6 +211,17 @@ export interface AutoEvaluatePlayerStats {
   win_rate: number;
 }
 
+export interface PokerPerformanceSnapshot {
+  hand: number;
+  players: {
+    player_id: string;
+    name: string;
+    is_standard: boolean;
+    energy: number;
+    net_energy: number;
+  }[];
+}
+
 export interface AutoEvaluateStats {
   hands_played: number;
   hands_remaining: number;
@@ -220,6 +229,7 @@ export interface AutoEvaluateStats {
   game_over: boolean;
   winner: string | null;
   reason: string;
+  performance_history?: PokerPerformanceSnapshot[];
 }
 
 // Command Response Types

--- a/frontend/src/utils/renderer.ts
+++ b/frontend/src/utils/renderer.ts
@@ -520,13 +520,14 @@ export class Renderer {
         });
         break;
 
-      case 2: // Solid (darker overlay)
+      case 2: { // Solid (darker overlay)
         const path = new Path2D(getFishPath(params, baseSize));
         ctx.globalAlpha = opacity * 0.5;
         ctx.fill(path);
         break;
+      }
 
-      case 3: // Gradient
+      case 3: { // Gradient
         const gradient = ctx.createLinearGradient(0, 0, width, 0);
         gradient.addColorStop(0, color);
         gradient.addColorStop(1, 'transparent');
@@ -534,6 +535,7 @@ export class Renderer {
         const gradPath = new Path2D(getFishPath(params, baseSize));
         ctx.fill(gradPath);
         break;
+      }
     }
 
     ctx.restore();


### PR DESCRIPTION
## Summary
- replace the jellyfish spawn/auto-evaluate controls with a static benchmark series for the leaderboard’s top fish against the standard player
- extend the backend poker evaluation to collect per-hand performance history for the benchmark series
- refresh the UI with the new benchmark display, performance graph, and supporting lint fixes

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbbb8a17c8331be5ea15772cc97aa)