### PR TITLE
Fix syntax error in auto evaluate poker module

### DIFF
--- a/core/auto_evaluate_poker.py
+++ b/core/auto_evaluate_poker.py
@@ -1,4 +1,3 @@
-"""
 """Auto-evaluation poker game for testing fish poker skills.
 
 This module manages automated poker games where multiple fish play against


### PR DESCRIPTION
## Summary
- remove the extra opening triple quote in `core/auto_evaluate_poker.py` to fix the module docstring and syntax error

## Testing
- python -m compileall core/auto_evaluate_poker.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbe3ab1e8833197c54ecc716596e5)