### PR TITLE
Automate static poker benchmarking and update UI

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -113,6 +113,42 @@ class PokerStatsData(BaseModel):
     avg_fold_rate: str = "0.0%"
 
 
+class AutoEvaluatePlayerStats(BaseModel):
+    """Player statistics from an auto-evaluation poker series."""
+
+    player_id: str
+    name: str
+    is_standard: bool
+    fish_id: Optional[int] = None
+    fish_generation: Optional[int] = None
+    energy: float
+    hands_won: int
+    hands_lost: int
+    total_energy_won: float
+    total_energy_lost: float
+    net_energy: float
+    win_rate: Optional[float] = None
+
+
+class PokerPerformanceSnapshot(BaseModel):
+    """Net energy snapshot for all players after a hand."""
+
+    hand: int
+    players: List[Dict[str, Any]]
+
+
+class AutoEvaluateStats(BaseModel):
+    """Aggregate stats for a static benchmark run."""
+
+    hands_played: int
+    hands_remaining: int
+    players: List[AutoEvaluatePlayerStats]
+    game_over: bool
+    winner: Optional[str]
+    reason: str
+    performance_history: List[PokerPerformanceSnapshot] = []
+
+
 class StatsData(BaseModel):
     """Ecosystem statistics."""
 
@@ -142,6 +178,7 @@ class SimulationUpdate(BaseModel):
     stats: StatsData
     poker_events: List[PokerEventData] = []
     poker_leaderboard: List[PokerLeaderboardEntry] = []
+    auto_evaluation: Optional[AutoEvaluateStats] = None
 
 
 class Command(BaseModel):

--- a/frontend/src/components/AutoEvaluateDisplay.tsx
+++ b/frontend/src/components/AutoEvaluateDisplay.tsx
@@ -146,6 +146,32 @@ export function AutoEvaluateDisplay({
   const fishPlayers = stats.players.filter((p) => !p.is_standard);
   const standardWon = stats.winner === standardPlayer?.name;
 
+  const playerMap = new Map<string, AutoEvaluatePlayerStats>();
+  stats.players.forEach((player) => {
+    playerMap.set(player.player_id, player);
+  });
+
+  (stats.performance_history ?? []).forEach((snapshot) => {
+    snapshot.players.forEach((player) => {
+      if (!playerMap.has(player.player_id)) {
+          playerMap.set(player.player_id, {
+            player_id: player.player_id,
+            name: player.name,
+            is_standard: player.is_standard,
+            energy: player.energy,
+            hands_won: 0,
+            hands_lost: 0,
+            total_energy_won: 0,
+            total_energy_lost: 0,
+          net_energy: player.net_energy,
+          win_rate: 0,
+        });
+      }
+    });
+  });
+
+  const chartPlayers = Array.from(playerMap.values());
+
   // Calculate aggregate fish stats
   const totalFishWins = fishPlayers.reduce((sum, p) => sum + p.hands_won, 0);
   const totalFishEnergy = fishPlayers.reduce((sum, p) => sum + p.net_energy, 0);
@@ -163,6 +189,12 @@ export function AutoEvaluateDisplay({
           ×
         </button>
       </div>
+
+      <p style={styles.helperText}>
+        Top leaderboard fish are automatically benchmarked against the static evaluation
+        player every few minutes. The chart below shows how the current contenders compare
+        to the static baseline over time.
+      </p>
 
       {/* Winner Announcement */}
       <div
@@ -208,7 +240,7 @@ export function AutoEvaluateDisplay({
 
       <PerformanceChart
         history={stats.performance_history ?? []}
-        players={stats.players}
+        players={chartPlayers}
       />
 
       {/* Detailed Stats */}
@@ -299,6 +331,12 @@ const styles = {
     margin: 0,
     fontSize: '24px',
     color: colors.primary,
+  },
+  helperText: {
+    margin: '0 0 16px 0',
+    color: colors.textSecondary,
+    lineHeight: 1.5,
+    fontSize: '14px',
   },
   closeButton: {
     background: 'none',

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -11,10 +11,9 @@ interface ControlPanelProps {
   onCommand: (command: Command) => void;
   isConnected: boolean;
   onPlayPoker?: () => void;
-  onRunBenchmark?: () => void;
 }
 
-export function ControlPanel({ onCommand, isConnected, onPlayPoker, onRunBenchmark }: ControlPanelProps) {
+export function ControlPanel({ onCommand, isConnected, onPlayPoker }: ControlPanelProps) {
   const [isPaused, setIsPaused] = useState(false);
 
   const handleAddFood = () => {
@@ -46,12 +45,6 @@ export function ControlPanel({ onCommand, isConnected, onPlayPoker, onRunBenchma
     }
   };
 
-  const handleRunBenchmark = () => {
-    if (onRunBenchmark) {
-      onRunBenchmark();
-    }
-  };
-
   return (
     <Panel title="Controls">
       <div className={styles.status}>
@@ -73,14 +66,6 @@ export function ControlPanel({ onCommand, isConnected, onPlayPoker, onRunBenchma
           variant="poker"
         >
           🃏 Play Poker
-        </Button>
-
-        <Button
-          onClick={handleRunBenchmark}
-          disabled={!isConnected}
-          variant="evaluate"
-        >
-          📊 Benchmark vs Static
         </Button>
 
         <Button
@@ -121,9 +106,6 @@ export function ControlPanel({ onCommand, isConnected, onPlayPoker, onRunBenchma
         <ul className={styles.helpList}>
           <li>
             <strong>Play Poker:</strong> Play poker against the top 3 fish
-          </li>
-          <li>
-            <strong>Benchmark vs Static:</strong> Runs a series between the top 3 fish and the static standard player
           </li>
           <li>
             <strong>Add Food:</strong> Drop food into the tank

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -4,7 +4,7 @@
 
 export interface EntityData {
   id: number;
-  type: 'fish' | 'food' | 'plant' | 'crab' | 'castle';
+  type: 'fish' | 'food' | 'plant' | 'crab' | 'castle' | 'jellyfish';
   x: number;
   y: number;
   width: number;
@@ -136,6 +136,7 @@ export interface SimulationUpdate {
   stats: StatsData;
   poker_events: PokerEventData[];
   poker_leaderboard: PokerLeaderboardEntry[];
+  auto_evaluation?: AutoEvaluateStats;
 }
 
 export interface Command {


### PR DESCRIPTION
## Summary
- add backend auto-evaluation scheduling that regularly benchmarks leaderboard fish against the static player and streams results
auto
- expose aggregated benchmark stats over WebSocket updates for live display
- update frontend to remove manual benchmark trigger, auto-show benchmark panel, and improve performance chart legends

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fd7daf6f08331aca823c4ec3f34c5)