### PR TITLE
Fix poker game UI layout and positioning

### DIFF
--- a/frontend/src/components/PokerGame.module.css
+++ b/frontend/src/components/PokerGame.module.css
@@ -48,6 +48,14 @@
     margin-bottom: 12px;
 }
 
+.humanSection {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+}
+
 .message {
     padding: 8px;
     background-color: #1e293b;

--- a/frontend/src/components/PokerGame.tsx
+++ b/frontend/src/components/PokerGame.tsx
@@ -78,38 +78,40 @@ export function PokerGame({ onClose, onAction, gameState, loading }: PokerGamePr
                 ))}
             </div>
 
-            {/* Human Player */}
+            {/* Human Player Section - Cards, Chips, and Actions side by side */}
             {humanPlayer && (
-                <PokerPlayer
-                    name="You"
-                    energy={humanPlayer.energy}
-                    currentBet={humanPlayer.current_bet}
-                    folded={humanPlayer.folded}
-                    isActive={false}
-                    isHuman={true}
-                    cards={gameState.your_cards}
-                />
+                <div className={styles.humanSection}>
+                    <PokerPlayer
+                        name="You"
+                        energy={humanPlayer.energy}
+                        currentBet={humanPlayer.current_bet}
+                        folded={humanPlayer.folded}
+                        isActive={false}
+                        isHuman={true}
+                        cards={gameState.your_cards}
+                    />
+
+                    {/* Action Buttons */}
+                    {!gameState.game_over && (
+                        <PokerActions
+                            isYourTurn={gameState.is_your_turn}
+                            callAmount={gameState.call_amount}
+                            minRaise={gameState.min_raise}
+                            maxRaise={humanPlayer?.energy || 0}
+                            loading={loading}
+                            currentPlayer={gameState.current_player}
+                            onFold={handleFold}
+                            onCheck={handleCheck}
+                            onCall={handleCall}
+                            onRaise={handleRaise}
+                        />
+                    )}
+                </div>
             )}
 
             {/* Game Message */}
             {gameState.message && (
                 <div className={styles.message}>{gameState.message}</div>
-            )}
-
-            {/* Action Buttons */}
-            {!gameState.game_over && (
-                <PokerActions
-                    isYourTurn={gameState.is_your_turn}
-                    callAmount={gameState.call_amount}
-                    minRaise={gameState.min_raise}
-                    maxRaise={humanPlayer?.energy || 0}
-                    loading={loading}
-                    currentPlayer={gameState.current_player}
-                    onFold={handleFold}
-                    onCheck={handleCheck}
-                    onCall={handleCall}
-                    onRaise={handleRaise}
-                />
             )}
 
             {/* Game Over */}

--- a/frontend/src/components/poker/PokerPlayer.module.css
+++ b/frontend/src/components/poker/PokerPlayer.module.css
@@ -58,24 +58,13 @@
 }
 
 .humanPlayer {
-    padding: 8px;
-    background-color: #0f172a;
-    border-radius: 8px;
-    margin-bottom: 8px;
-    border: 2px solid #3b82f6;
-}
-
-.playerInfo {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    margin-bottom: 6px;
-}
-
-.playerName {
-    font-size: 14px;
-    font-weight: bold;
-    color: #3b82f6;
+    gap: 12px;
+    padding: 8px 12px;
+    background-color: #1e293b;
+    border-radius: 8px;
+    border: 2px solid #3b82f6;
 }
 
 .playerStats {
@@ -105,12 +94,6 @@
 .yourCards {
     display: flex;
     align-items: center;
-    gap: 8px;
-}
-
-.cardsLabel {
-    font-size: 11px;
-    color: #94a3b8;
 }
 
 .cardsContainer {

--- a/frontend/src/components/poker/PokerPlayer.tsx
+++ b/frontend/src/components/poker/PokerPlayer.tsx
@@ -30,24 +30,22 @@ export function PokerPlayer({
     if (isHuman) {
         return (
             <div className={styles.humanPlayer}>
-                <div className={styles.playerInfo}>
-                    <div className={styles.playerName}>You</div>
-                    <div className={styles.playerStats}>
-                        <div className={styles.chipStackContainer}>
-                            <ChipStack totalValue={Math.floor(energy)} size="medium" />
-                        </div>
-                        <div className={styles.energyText}>{energy.toFixed(1)} ⚡</div>
-                        {currentBet > 0 && <div className={styles.currentBet}>Bet: {currentBet.toFixed(1)}</div>}
-                    </div>
-                </div>
-
+                {/* Cards on the left */}
                 <div className={styles.yourCards}>
-                    <div className={styles.cardsLabel}>Your Cards:</div>
                     <div className={styles.cardsContainer}>
                         {cards.map((card, idx) => (
                             <PlayingCard key={idx} card={card} size="small" />
                         ))}
                     </div>
+                </div>
+
+                {/* Chips and stats to the right of cards */}
+                <div className={styles.playerStats}>
+                    <div className={styles.chipStackContainer}>
+                        <ChipStack totalValue={Math.floor(energy)} size="medium" />
+                    </div>
+                    <div className={styles.energyText}>{energy.toFixed(1)} ⚡</div>
+                    {currentBet > 0 && <div className={styles.currentBet}>Bet: {currentBet.toFixed(1)}</div>}
                 </div>
             </div>
         );


### PR DESCRIPTION
Reorganize the poker game UI so the human player's cards, chips/stats, and action buttons are displayed side-by-side in a horizontal row instead of vertically stacked. This creates a more compact and intuitive layout.