### PR TITLE
Fix poker card flipping and betting rounds

### DIFF
--- a/frontend/src/components/PokerGame.tsx
+++ b/frontend/src/components/PokerGame.tsx
@@ -60,7 +60,11 @@ export function PokerGame({ onClose, onAction, gameState, loading }: PokerGamePr
             </div>
 
             {/* Pot and Community Cards */}
-            <PokerTable pot={gameState.pot} communityCards={gameState.community_cards} />
+            <PokerTable
+                pot={gameState.pot}
+                communityCards={gameState.community_cards}
+                currentRound={gameState.current_round}
+            />
 
             {/* AI Players */}
             <div className={styles.opponentsSection}>

--- a/frontend/src/components/poker/PokerPlayer.tsx
+++ b/frontend/src/components/poker/PokerPlayer.tsx
@@ -51,13 +51,26 @@ export function PokerPlayer({
         );
     }
 
+    // Check if we should show actual cards (showdown) or card backs
+    const showActualCards = cards.length > 0 && cards[0] !== '??';
+
     return (
         <div className={playerClass}>
             <div className={styles.opponentName}>{name}</div>
             <div className={styles.opponentInfo}>
                 <div className={styles.opponentCards}>
-                    <PlayingCard card="BACK" size="small" faceDown={true} />
-                    <PlayingCard card="BACK" size="small" faceDown={true} />
+                    {showActualCards ? (
+                        // Show actual cards during showdown
+                        cards.map((card, idx) => (
+                            <PlayingCard key={idx} card={card} size="small" />
+                        ))
+                    ) : (
+                        // Show card backs during normal play
+                        <>
+                            <PlayingCard card="BACK" size="small" faceDown={true} />
+                            <PlayingCard card="BACK" size="small" faceDown={true} />
+                        </>
+                    )}
                 </div>
                 <div className={styles.opponentStats}>
                     <div className={styles.chipStackContainer}>

--- a/frontend/src/components/poker/PokerTable.module.css
+++ b/frontend/src/components/poker/PokerTable.module.css
@@ -5,6 +5,34 @@
     border-radius: 8px;
 }
 
+.roundIndicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    padding: 4px 12px;
+    background: linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%);
+    border: 1px solid #3b82f6;
+    border-radius: 16px;
+    width: fit-content;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.roundName {
+    font-size: 14px;
+    font-weight: bold;
+    color: #60a5fa;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.roundCards {
+    font-size: 11px;
+    color: #94a3b8;
+}
+
 .topRow {
     display: flex;
     align-items: center;

--- a/frontend/src/components/poker/PokerTable.tsx
+++ b/frontend/src/components/poker/PokerTable.tsx
@@ -9,11 +9,38 @@ import styles from './PokerTable.module.css';
 interface PokerTableProps {
     pot: number;
     communityCards: string[];
+    currentRound?: string;
 }
 
-export function PokerTable({ pot, communityCards }: PokerTableProps) {
+// Helper to get round display name
+function getRoundDisplay(round?: string): { name: string; cards: string } {
+    switch (round) {
+        case 'PRE_FLOP':
+            return { name: 'Pre-Flop', cards: '0 cards' };
+        case 'FLOP':
+            return { name: 'Flop', cards: '3 cards' };
+        case 'TURN':
+            return { name: 'Turn', cards: '4 cards' };
+        case 'RIVER':
+            return { name: 'River', cards: '5 cards' };
+        case 'SHOWDOWN':
+            return { name: 'Showdown', cards: 'All cards revealed' };
+        default:
+            return { name: round || 'Starting', cards: '' };
+    }
+}
+
+export function PokerTable({ pot, communityCards, currentRound }: PokerTableProps) {
+    const roundInfo = getRoundDisplay(currentRound);
+
     return (
         <div className={styles.table}>
+            {/* Round indicator */}
+            <div className={styles.roundIndicator}>
+                <span className={styles.roundName}>{roundInfo.name}</span>
+                <span className={styles.roundCards}>{roundInfo.cards}</span>
+            </div>
+
             {/* Pot and Community Cards side by side */}
             <div className={styles.topRow}>
                 {/* Pot display */}


### PR DESCRIPTION
- Show AI fish cards during showdown (PokerPlayer now uses cards prop)
- Add round indicator showing current phase (Pre-Flop/Flop/Turn/River/Showdown)
- Fix betting round completion logic that was skipping rounds (betting_history accumulated across rounds, now using per-round counter)
- Reset action counter on raises so other players must respond

The game now properly progresses through all betting rounds with community cards revealed progressively as in real poker.