### PR TITLE
Improve poker game with energy system

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -703,6 +703,16 @@ class SimulationRunner:
                 result = self.human_poker_game.handle_action("human", action, amount)
                 return result
 
+            elif command == "poker_new_round":
+                # Start a new hand in the current poker session
+                if not self.human_poker_game:
+                    logger.warning("New round requested but no game active")
+                    return self._create_error_response("No poker game active")
+
+                logger.info("Starting new poker hand...")
+                result = self.human_poker_game.start_new_hand()
+                return result
+
             elif command == "standard_poker_series":
                 # Run standard benchmark poker series with top 3 fish vs static player
                 logger.info("Starting standard poker benchmark series...")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,6 +73,25 @@ function App() {
         setPokerGameState(null);
     };
 
+    const handleNewRound = async () => {
+        try {
+            setPokerLoading(true);
+            const response = await sendCommandWithResponse({
+                command: 'poker_new_round',
+                data: {},
+            });
+            if (response.success === false) {
+                alert(response.error || 'Failed to start new round');
+            } else if (response.state) {
+                setPokerGameState(response.state);
+            }
+        } catch {
+            alert('Failed to start new round. Please try again.');
+        } finally {
+            setPokerLoading(false);
+        }
+    };
+
     const pokerStats = state?.stats?.poker_stats;
     const minutesElapsed = state ? state.frame / 30 / 60 : 0;
     const gamesPerMinute = minutesElapsed > 0 && pokerStats
@@ -138,6 +157,7 @@ function App() {
                         <PokerGame
                             onClose={handleClosePoker}
                             onAction={handlePokerAction}
+                            onNewRound={handleNewRound}
                             gameState={pokerGameState}
                             loading={pokerLoading}
                         />

--- a/frontend/src/components/PokerGame.module.css
+++ b/frontend/src/components/PokerGame.module.css
@@ -20,6 +20,15 @@
     margin: 0;
     font-size: 20px;
     color: #3b82f6;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.handCounter {
+    font-size: 14px;
+    color: #94a3b8;
+    font-weight: normal;
 }
 
 .closeButton {
@@ -51,6 +60,7 @@
 .humanSection {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 16px;
     margin-bottom: 8px;
     flex-wrap: wrap;
@@ -86,7 +96,50 @@
     font-size: 14px;
 }
 
-.newGameButton {
+.standings {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 16px;
+    padding: 12px;
+    background-color: #0f172a;
+    border-radius: 6px;
+}
+
+.standingRow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 13px;
+}
+
+.standingRank {
+    color: #64748b;
+    width: 24px;
+}
+
+.standingName {
+    flex: 1;
+    color: #e2e8f0;
+}
+
+.standingEnergy {
+    color: #fbbf24;
+    font-weight: bold;
+}
+
+.gameOverButtons {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+}
+
+.newRoundButton {
+    padding: 10px 24px;
+    font-size: 14px;
+}
+
+.quitButton {
     padding: 10px 24px;
     font-size: 14px;
 }

--- a/frontend/src/components/PokerGame.tsx
+++ b/frontend/src/components/PokerGame.tsx
@@ -10,11 +10,12 @@ import styles from './PokerGame.module.css';
 interface PokerGameProps {
     onClose: () => void;
     onAction: (action: string, amount?: number) => void;
+    onNewRound: () => void;
     gameState: PokerGameState | null;
     loading: boolean;
 }
 
-export function PokerGame({ onClose, onAction, gameState, loading }: PokerGameProps) {
+export function PokerGame({ onClose, onAction, onNewRound, gameState, loading }: PokerGameProps) {
     if (!gameState) {
         return (
             <div className={styles.container}>
@@ -55,7 +56,10 @@ export function PokerGame({ onClose, onAction, gameState, loading }: PokerGamePr
     return (
         <div className={styles.container}>
             <div className={styles.header}>
-                <h2 className={styles.title}>Poker Game</h2>
+                <h2 className={styles.title}>
+                    Poker Game
+                    <span className={styles.handCounter}>Hand #{gameState.hands_played}</span>
+                </h2>
                 <button onClick={onClose} className={styles.closeButton}>×</button>
             </div>
 
@@ -118,19 +122,41 @@ export function PokerGame({ onClose, onAction, gameState, loading }: PokerGamePr
                 <div className={styles.message}>{gameState.message}</div>
             )}
 
-            {/* Game Over */}
+            {/* Game Over - Show after hand ends */}
             {gameState.game_over && (
                 <div className={styles.gameOver}>
-                    <h3 className={styles.gameOverTitle}>Game Over!</h3>
+                    <h3 className={styles.gameOverTitle}>
+                        {gameState.session_over ? 'Session Over!' : 'Hand Complete!'}
+                    </h3>
                     <p className={styles.gameOverMessage}>
                         {gameState.winner === 'You'
                             ? `Congratulations! You won ${gameState.pot.toFixed(1)} energy!`
                             : `${gameState.winner} won the pot of ${gameState.pot.toFixed(1)} energy.`
                         }
                     </p>
-                    <Button onClick={onClose} variant="success" className={styles.newGameButton}>
-                        Close
-                    </Button>
+                    {/* Show player standings */}
+                    <div className={styles.standings}>
+                        {gameState.players
+                            .sort((a, b) => b.energy - a.energy)
+                            .map((player, i) => (
+                                <div key={player.player_id} className={styles.standingRow}>
+                                    <span className={styles.standingRank}>#{i + 1}</span>
+                                    <span className={styles.standingName}>{player.name}</span>
+                                    <span className={styles.standingEnergy}>{player.energy.toFixed(0)} energy</span>
+                                </div>
+                            ))
+                        }
+                    </div>
+                    <div className={styles.gameOverButtons}>
+                        {!gameState.session_over && (
+                            <Button onClick={onNewRound} variant="success" className={styles.newRoundButton} disabled={loading}>
+                                {loading ? 'Starting...' : 'Next Hand'}
+                            </Button>
+                        )}
+                        <Button onClick={onClose} variant="secondary" className={styles.quitButton}>
+                            {gameState.session_over ? 'Close' : 'Quit Session'}
+                        </Button>
+                    </div>
                 </div>
             )}
         </div>

--- a/frontend/src/components/poker/PokerActions.module.css
+++ b/frontend/src/components/poker/PokerActions.module.css
@@ -2,7 +2,10 @@
     display: flex;
     gap: 8px;
     justify-content: center;
+    align-items: center;
     flex-wrap: wrap;
+    min-height: 44px;
+    min-width: 340px;
 }
 
 .actionButton {

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -140,7 +140,7 @@ export interface SimulationUpdate {
 }
 
 export interface Command {
-  command: 'add_food' | 'spawn_fish' | 'pause' | 'resume' | 'reset' | 'start_poker' | 'poker_action' | 'standard_poker_series';
+  command: 'add_food' | 'spawn_fish' | 'pause' | 'resume' | 'reset' | 'start_poker' | 'poker_action' | 'poker_new_round' | 'standard_poker_series';
   data?: Record<string, unknown>;
 }
 
@@ -188,6 +188,8 @@ export interface PokerGameState {
   current_player: string;
   is_your_turn: boolean;
   game_over: boolean;
+  session_over: boolean;
+  hands_played: number;
   message: string;
   winner: string | null;
   players: PokerGamePlayer[];


### PR DESCRIPTION
- Start all players with 100 energy instead of variable amounts
- Allow multiple rounds until user quits or only 1 player has energy
- Add session_over tracking to detect when game session ends
- Add hands_played counter displayed in the header
- Add new_round backend command for starting next hand
- Show player standings after each hand with Next Hand / Quit buttons
- Fix PokerActions CSS with min-height/min-width for consistent button location
- Update TypeScript types for new game state fields

Players can now play a full poker session with multiple hands, with the session ending when one player accumulates all the energy or the user decides to quit.