### PR TITLE
Improve game controls and user interface

### DIFF
--- a/frontend/src/components/PokerGame.module.css
+++ b/frontend/src/components/PokerGame.module.css
@@ -61,9 +61,34 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 16px;
+    gap: 12px;
     margin-bottom: 8px;
-    flex-wrap: wrap;
+}
+
+.playerAndControls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: 1;
+}
+
+.quitGameButton {
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
+    border: 1px solid #4b5563;
+    border-radius: 6px;
+    color: #9ca3af;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.quitGameButton:hover {
+    background: linear-gradient(135deg, #4b5563 0%, #374151 100%);
+    color: #f3f4f6;
+    border-color: #6b7280;
 }
 
 .message {
@@ -79,31 +104,91 @@
 
 .gameOver {
     padding: 16px;
-    background-color: #1e293b;
-    border-radius: 8px;
+    background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+    border-radius: 12px;
     text-align: center;
     border: 2px solid #3b82f6;
+    animation: slideIn 0.3s ease-out;
 }
 
-.gameOverTitle {
-    margin: 0 0 8px 0;
-    font-size: 20px;
-    color: #3b82f6;
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
-.gameOverMessage {
-    margin: 0 0 16px 0;
+.winnerGlow {
+    border-color: #fbbf24;
+    box-shadow: 0 0 20px rgba(251, 191, 36, 0.3), inset 0 0 30px rgba(251, 191, 36, 0.05);
+}
+
+.resultBanner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.winEmoji {
+    font-size: 24px;
+    animation: bounce 0.6s ease infinite alternate;
+}
+
+@keyframes bounce {
+    from { transform: translateY(0); }
+    to { transform: translateY(-4px); }
+}
+
+.winTitle {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 800;
+    background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 50%, #fbbf24 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-shadow: 0 0 20px rgba(251, 191, 36, 0.5);
+}
+
+.loseTitle {
+    margin: 0;
+    font-size: 18px;
+    color: #94a3b8;
+}
+
+.potWon {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 6px;
+    margin-bottom: 12px;
+}
+
+.potAmount {
+    font-size: 28px;
+    font-weight: 800;
+    color: #22c55e;
+}
+
+.potLabel {
     font-size: 14px;
+    color: #64748b;
 }
 
 .standings {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
     margin-bottom: 16px;
-    padding: 12px;
+    padding: 10px;
     background-color: #0f172a;
-    border-radius: 6px;
+    border-radius: 8px;
 }
 
 .standingRow {
@@ -111,35 +196,90 @@
     align-items: center;
     gap: 12px;
     font-size: 13px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+
+.standingRow:hover {
+    background-color: rgba(59, 130, 246, 0.1);
+}
+
+.humanStanding {
+    background-color: rgba(59, 130, 246, 0.15);
+    border: 1px solid rgba(59, 130, 246, 0.3);
 }
 
 .standingRank {
     color: #64748b;
-    width: 24px;
+    width: 28px;
+    font-size: 14px;
 }
 
 .standingName {
     flex: 1;
     color: #e2e8f0;
+    font-weight: 500;
 }
 
 .standingEnergy {
     color: #fbbf24;
     font-weight: bold;
+    min-width: 40px;
+    text-align: right;
 }
 
 .gameOverButtons {
     display: flex;
     gap: 12px;
     justify-content: center;
+    align-items: center;
 }
 
-.newRoundButton {
-    padding: 10px 24px;
-    font-size: 14px;
+.playAgainButton {
+    padding: 12px 32px;
+    font-size: 16px;
+    font-weight: 700;
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    border: none;
+    border-radius: 8px;
+    color: white;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
 }
 
-.quitButton {
-    padding: 10px 24px;
+.playAgainButton:hover:not(:disabled) {
+    background: linear-gradient(135deg, #16a34a 0%, #15803d 100%);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(34, 197, 94, 0.4);
+}
+
+.playAgainButton:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.exitButton {
+    padding: 10px 20px;
     font-size: 14px;
+    font-weight: 600;
+    background: transparent;
+    border: 1px solid #4b5563;
+    border-radius: 6px;
+    color: #9ca3af;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.exitButton:hover {
+    border-color: #6b7280;
+    color: #e5e7eb;
+    background-color: rgba(75, 85, 99, 0.2);
+}
+
+.sessionOverMessage {
+    font-size: 14px;
+    color: #94a3b8;
+    padding: 8px 16px;
 }

--- a/frontend/src/components/PokerGame.tsx
+++ b/frontend/src/components/PokerGame.tsx
@@ -2,7 +2,6 @@
  * Interactive poker game component
  */
 
-import { Button } from './ui';
 import { PokerTable, PokerPlayer, PokerActions } from './poker';
 import type { PokerGameState } from '../types/simulation';
 import styles from './PokerGame.module.css';
@@ -86,33 +85,42 @@ export function PokerGame({ onClose, onAction, onNewRound, gameState, loading }:
                 ))}
             </div>
 
-            {/* Human Player Section - Cards, Chips, and Actions side by side */}
+            {/* Human Player Section - Cards | Controls | Quit Button */}
             {humanPlayer && (
                 <div className={styles.humanSection}>
-                    <PokerPlayer
-                        name="You"
-                        energy={humanPlayer.energy}
-                        currentBet={humanPlayer.current_bet}
-                        folded={humanPlayer.folded}
-                        isActive={false}
-                        isHuman={true}
-                        cards={gameState.your_cards}
-                    />
-
-                    {/* Action Buttons */}
-                    {!gameState.game_over && (
-                        <PokerActions
-                            isYourTurn={gameState.is_your_turn}
-                            callAmount={gameState.call_amount}
-                            minRaise={gameState.min_raise}
-                            maxRaise={humanPlayer?.energy || 0}
-                            loading={loading}
-                            currentPlayer={gameState.current_player}
-                            onFold={handleFold}
-                            onCheck={handleCheck}
-                            onCall={handleCall}
-                            onRaise={handleRaise}
+                    <div className={styles.playerAndControls}>
+                        <PokerPlayer
+                            name="You"
+                            energy={humanPlayer.energy}
+                            currentBet={humanPlayer.current_bet}
+                            folded={humanPlayer.folded}
+                            isActive={gameState.is_your_turn}
+                            isHuman={true}
+                            cards={gameState.your_cards}
                         />
+
+                        {/* Action Buttons - Right next to cards */}
+                        {!gameState.game_over && (
+                            <PokerActions
+                                isYourTurn={gameState.is_your_turn}
+                                callAmount={gameState.call_amount}
+                                minRaise={gameState.min_raise}
+                                maxRaise={humanPlayer?.energy || 0}
+                                loading={loading}
+                                currentPlayer={gameState.current_player}
+                                onFold={handleFold}
+                                onCheck={handleCheck}
+                                onCall={handleCall}
+                                onRaise={handleRaise}
+                            />
+                        )}
+                    </div>
+
+                    {/* Quit Button - Far right */}
+                    {!gameState.game_over && (
+                        <button onClick={onClose} className={styles.quitGameButton}>
+                            Quit
+                        </button>
                     )}
                 </div>
             )}
@@ -124,38 +132,50 @@ export function PokerGame({ onClose, onAction, onNewRound, gameState, loading }:
 
             {/* Game Over - Show after hand ends */}
             {gameState.game_over && (
-                <div className={styles.gameOver}>
-                    <h3 className={styles.gameOverTitle}>
-                        {gameState.session_over ? 'Session Over!' : 'Hand Complete!'}
-                    </h3>
-                    <p className={styles.gameOverMessage}>
-                        {gameState.winner === 'You'
-                            ? `Congratulations! You won ${gameState.pot.toFixed(1)} energy!`
-                            : `${gameState.winner} won the pot of ${gameState.pot.toFixed(1)} energy.`
-                        }
-                    </p>
+                <div className={`${styles.gameOver} ${gameState.winner === 'You' ? styles.winnerGlow : ''}`}>
+                    <div className={styles.resultBanner}>
+                        {gameState.winner === 'You' ? (
+                            <>
+                                <span className={styles.winEmoji}>&#127881;</span>
+                                <h3 className={styles.winTitle}>YOU WIN!</h3>
+                                <span className={styles.winEmoji}>&#127881;</span>
+                            </>
+                        ) : (
+                            <h3 className={styles.loseTitle}>{gameState.winner} wins</h3>
+                        )}
+                    </div>
+                    <div className={styles.potWon}>
+                        <span className={styles.potAmount}>+{gameState.pot.toFixed(0)}</span>
+                        <span className={styles.potLabel}>energy</span>
+                    </div>
                     {/* Show player standings */}
                     <div className={styles.standings}>
                         {gameState.players
                             .sort((a, b) => b.energy - a.energy)
                             .map((player, i) => (
-                                <div key={player.player_id} className={styles.standingRow}>
-                                    <span className={styles.standingRank}>#{i + 1}</span>
-                                    <span className={styles.standingName}>{player.name}</span>
-                                    <span className={styles.standingEnergy}>{player.energy.toFixed(0)} energy</span>
+                                <div key={player.player_id} className={`${styles.standingRow} ${player.is_human ? styles.humanStanding : ''}`}>
+                                    <span className={styles.standingRank}>
+                                        {i === 0 ? '&#128081;' : `#${i + 1}`}
+                                    </span>
+                                    <span className={styles.standingName}>{player.is_human ? 'You' : player.name}</span>
+                                    <span className={styles.standingEnergy}>{player.energy.toFixed(0)}</span>
                                 </div>
                             ))
                         }
                     </div>
                     <div className={styles.gameOverButtons}>
-                        {!gameState.session_over && (
-                            <Button onClick={onNewRound} variant="success" className={styles.newRoundButton} disabled={loading}>
-                                {loading ? 'Starting...' : 'Next Hand'}
-                            </Button>
+                        {!gameState.session_over ? (
+                            <button onClick={onNewRound} className={styles.playAgainButton} disabled={loading}>
+                                {loading ? 'Dealing...' : 'Play Again'}
+                            </button>
+                        ) : (
+                            <div className={styles.sessionOverMessage}>
+                                {humanPlayer && humanPlayer.energy > 100 ? 'Great session! You made profit!' : 'Better luck next time!'}
+                            </div>
                         )}
-                        <Button onClick={onClose} variant="secondary" className={styles.quitButton}>
-                            {gameState.session_over ? 'Close' : 'Quit Session'}
-                        </Button>
+                        <button onClick={onClose} className={styles.exitButton}>
+                            {gameState.session_over ? 'Exit' : 'Cash Out'}
+                        </button>
                     </div>
                 </div>
             )}

--- a/frontend/src/components/poker/PokerActions.module.css
+++ b/frontend/src/components/poker/PokerActions.module.css
@@ -1,40 +1,162 @@
 .actions {
     display: flex;
     gap: 8px;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
-    flex-wrap: wrap;
     min-height: 44px;
-    min-width: 340px;
+    padding: 8px 12px;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.8) 0%, rgba(15, 23, 42, 0.9) 100%);
+    border-radius: 8px;
+    border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.actionsActive {
+    border-color: rgba(251, 191, 36, 0.5);
+    box-shadow: 0 0 12px rgba(251, 191, 36, 0.15);
+    animation: pulseGlow 2s ease-in-out infinite;
+}
+
+@keyframes pulseGlow {
+    0%, 100% { box-shadow: 0 0 12px rgba(251, 191, 36, 0.15); }
+    50% { box-shadow: 0 0 20px rgba(251, 191, 36, 0.25); }
 }
 
 .actionButton {
-    padding: 8px 16px;
+    padding: 10px 18px;
     font-size: 14px;
-    font-weight: bold;
-    min-width: 100px;
+    font-weight: 700;
+    min-width: 90px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.foldButton {
+    background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+    border: none;
+    color: white;
+    box-shadow: 0 2px 8px rgba(220, 38, 38, 0.3);
+}
+
+.foldButton:hover:not(:disabled) {
+    background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+    transform: translateY(-1px);
+}
+
+.checkButton {
+    background: linear-gradient(135deg, #475569 0%, #334155 100%);
+    border: none;
+    color: white;
+    box-shadow: 0 2px 8px rgba(71, 85, 105, 0.3);
+}
+
+.checkButton:hover:not(:disabled) {
+    background: linear-gradient(135deg, #64748b 0%, #475569 100%);
+    transform: translateY(-1px);
+}
+
+.callButton {
+    background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+    border: none;
+    color: white;
+    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
+}
+
+.callButton:hover:not(:disabled) {
+    background: linear-gradient(135deg, #60a5fa 0%, #3b82f6 100%);
+    transform: translateY(-1px);
+}
+
+.raiseButton {
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    border: none;
+    color: white;
+    box-shadow: 0 2px 8px rgba(34, 197, 94, 0.3);
+}
+
+.raiseButton:hover:not(:disabled) {
+    background: linear-gradient(135deg, #4ade80 0%, #22c55e 100%);
+    transform: translateY(-1px);
+}
+
+.actionButton:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none !important;
 }
 
 .raiseInputContainer {
     display: flex;
     gap: 8px;
     align-items: center;
-    flex-wrap: wrap;
 }
 
 .raiseInput {
-    padding: 8px;
-    font-size: 14px;
+    padding: 10px 12px;
+    font-size: 16px;
+    font-weight: 600;
     border-radius: 6px;
-    border: 2px solid rgba(148, 163, 184, 0.18);
+    border: 2px solid rgba(34, 197, 94, 0.5);
     background-color: #0f172a;
-    color: #e2e8f0;
-    width: 100px;
+    color: #22c55e;
+    width: 90px;
+    text-align: center;
+}
+
+.raiseInput:focus {
+    outline: none;
+    border-color: #22c55e;
+    box-shadow: 0 0 8px rgba(34, 197, 94, 0.3);
+}
+
+.confirmButton {
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    border: none;
+    color: white;
+    padding: 10px 16px;
+    font-size: 13px;
+    font-weight: 700;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.confirmButton:hover:not(:disabled) {
+    background: linear-gradient(135deg, #4ade80 0%, #22c55e 100%);
+}
+
+.cancelButton {
+    background: transparent;
+    border: 1px solid #4b5563;
+    color: #9ca3af;
+    padding: 10px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.cancelButton:hover {
+    border-color: #6b7280;
+    color: #e5e7eb;
 }
 
 .waitingMessage {
-    padding: 8px;
+    padding: 10px 16px;
     font-size: 14px;
-    color: #fbbf24;
+    color: #94a3b8;
     text-align: center;
+    font-style: italic;
+}
+
+.waitingDots {
+    animation: blink 1.4s infinite;
+}
+
+@keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
 }

--- a/frontend/src/components/poker/PokerActions.tsx
+++ b/frontend/src/components/poker/PokerActions.tsx
@@ -3,7 +3,6 @@
  */
 
 import { useState } from 'react';
-import { Button } from '../ui';
 import styles from './PokerActions.module.css';
 
 interface PokerActionsProps {
@@ -47,11 +46,13 @@ export function PokerActions({
     setRaiseAmount(minRaise);
   };
 
+  const actionsClass = `${styles.actions} ${isYourTurn ? styles.actionsActive : ''}`;
+
   if (!isYourTurn) {
     return (
       <div className={styles.actions}>
         <div className={styles.waitingMessage}>
-          Waiting for {currentPlayer}...
+          Waiting for <strong>{currentPlayer}</strong><span className={styles.waitingDots}>...</span>
         </div>
       </div>
     );
@@ -59,7 +60,7 @@ export function PokerActions({
 
   if (showRaiseInput) {
     return (
-      <div className={styles.actions}>
+      <div className={actionsClass}>
         <div className={styles.raiseInputContainer}>
           <input
             type="number"
@@ -67,68 +68,62 @@ export function PokerActions({
             onChange={(e) => setRaiseAmount(Number(e.target.value))}
             min={minRaise}
             max={maxRaise}
-            step={minRaise}
+            step={1}
             className={styles.raiseInput}
           />
-          <Button
+          <button
             onClick={handleRaise}
             disabled={loading || raiseAmount < minRaise}
-            variant="success"
-            className={styles.actionButton}
+            className={styles.confirmButton}
           >
-            Confirm {raiseAmount.toFixed(1)}
-          </Button>
-          <Button
+            Bet {raiseAmount.toFixed(0)}
+          </button>
+          <button
             onClick={() => setShowRaiseInput(false)}
-            variant="secondary"
-            className={styles.actionButton}
+            className={styles.cancelButton}
           >
             Cancel
-          </Button>
+          </button>
         </div>
       </div>
     );
   }
 
   return (
-    <div className={styles.actions}>
-      <Button
+    <div className={actionsClass}>
+      <button
         onClick={onFold}
         disabled={loading}
-        variant="danger"
-        className={styles.actionButton}
+        className={`${styles.actionButton} ${styles.foldButton}`}
       >
         Fold
-      </Button>
+      </button>
 
       {callAmount === 0 ? (
-        <Button
+        <button
           onClick={onCheck}
           disabled={loading}
-          variant="secondary"
-          className={styles.actionButton}
+          className={`${styles.actionButton} ${styles.checkButton}`}
         >
           Check
-        </Button>
+        </button>
       ) : (
-        <Button
+        <button
           onClick={onCall}
           disabled={loading}
-          variant="primary"
-          className={styles.actionButton}
+          className={`${styles.actionButton} ${styles.callButton}`}
         >
-          Call {callAmount.toFixed(1)}
-        </Button>
+          Call {callAmount.toFixed(0)}
+        </button>
       )}
 
-      <Button
+      <button
         onClick={handleShowRaise}
         disabled={loading}
-        variant="success"
-        className={styles.actionButton}
+        className={`${styles.actionButton} ${styles.raiseButton}`}
       >
         {callAmount > 0 ? 'Raise' : 'Bet'}
-      </Button>
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/poker/PokerPlayer.module.css
+++ b/frontend/src/components/poker/PokerPlayer.module.css
@@ -62,9 +62,21 @@
     align-items: center;
     gap: 12px;
     padding: 8px 12px;
-    background-color: #1e293b;
+    background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
     border-radius: 8px;
     border: 2px solid #3b82f6;
+    transition: all 0.3s ease;
+}
+
+.humanPlayer.humanActive {
+    border-color: #fbbf24;
+    box-shadow: 0 0 16px rgba(251, 191, 36, 0.3), inset 0 0 20px rgba(251, 191, 36, 0.05);
+    animation: yourTurnPulse 2s ease-in-out infinite;
+}
+
+@keyframes yourTurnPulse {
+    0%, 100% { box-shadow: 0 0 16px rgba(251, 191, 36, 0.3), inset 0 0 20px rgba(251, 191, 36, 0.05); }
+    50% { box-shadow: 0 0 24px rgba(251, 191, 36, 0.4), inset 0 0 30px rgba(251, 191, 36, 0.08); }
 }
 
 .playerStats {

--- a/frontend/src/components/poker/PokerPlayer.tsx
+++ b/frontend/src/components/poker/PokerPlayer.tsx
@@ -28,8 +28,9 @@ export function PokerPlayer({
     const playerClass = `${styles.player} ${folded ? styles.folded : ''} ${isActive ? styles.active : ''}`;
 
     if (isHuman) {
+        const humanClass = `${styles.humanPlayer} ${isActive ? styles.humanActive : ''}`;
         return (
-            <div className={styles.humanPlayer}>
+            <div className={humanClass}>
                 {/* Cards on the left */}
                 <div className={styles.yourCards}>
                     <div className={styles.cardsContainer}>


### PR DESCRIPTION
- Move game controls right next to user's cards for better flow
- Add quit button on the right side during gameplay
- Replace "Next Hand" with engaging "Play Again" button at results
- Add celebratory win animation with golden glow effect
- Style action buttons with gradients and hover effects
- Add pulsing glow when it's your turn to act
- Animate game over screen with slide-in effect
- Show session profit/loss message when game ends