### PR TITLE
Fix poker button positioning and layout stability

### DIFF
--- a/frontend/src/components/PokerGame.module.css
+++ b/frontend/src/components/PokerGame.module.css
@@ -282,4 +282,63 @@
     font-size: 14px;
     color: #94a3b8;
     padding: 8px 16px;
+    text-align: center;
+}
+
+.inlineGameOverButtons {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 8px 12px;
+    min-width: 300px;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.8) 0%, rgba(15, 23, 42, 0.9) 100%);
+    border-radius: 8px;
+    border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.inlinePlayAgainButton {
+    padding: 10px 18px;
+    font-size: 14px;
+    font-weight: 700;
+    min-width: 110px;
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    border: none;
+    border-radius: 6px;
+    color: white;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    box-shadow: 0 2px 8px rgba(34, 197, 94, 0.3);
+}
+
+.inlinePlayAgainButton:hover:not(:disabled) {
+    background: linear-gradient(135deg, #4ade80 0%, #22c55e 100%);
+    transform: translateY(-1px);
+}
+
+.inlinePlayAgainButton:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.inlineCashOutButton {
+    padding: 10px 18px;
+    font-size: 14px;
+    font-weight: 600;
+    min-width: 90px;
+    background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
+    border: 1px solid #4b5563;
+    border-radius: 6px;
+    color: #9ca3af;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.inlineCashOutButton:hover {
+    background: linear-gradient(135deg, #4b5563 0%, #374151 100%);
+    color: #f3f4f6;
+    border-color: #6b7280;
 }

--- a/frontend/src/components/PokerGame.tsx
+++ b/frontend/src/components/PokerGame.tsx
@@ -100,7 +100,7 @@ export function PokerGame({ onClose, onAction, onNewRound, gameState, loading }:
                         />
 
                         {/* Action Buttons - Right next to cards */}
-                        {!gameState.game_over && (
+                        {!gameState.game_over ? (
                             <PokerActions
                                 isYourTurn={gameState.is_your_turn}
                                 callAmount={gameState.call_amount}
@@ -113,6 +113,18 @@ export function PokerGame({ onClose, onAction, onNewRound, gameState, loading }:
                                 onCall={handleCall}
                                 onRaise={handleRaise}
                             />
+                        ) : (
+                            /* Play Again / Cash Out buttons - Same position as action buttons */
+                            <div className={styles.inlineGameOverButtons}>
+                                {!gameState.session_over && (
+                                    <button onClick={onNewRound} className={styles.inlinePlayAgainButton} disabled={loading}>
+                                        {loading ? 'Dealing...' : 'Play Again'}
+                                    </button>
+                                )}
+                                <button onClick={onClose} className={styles.inlineCashOutButton}>
+                                    {gameState.session_over ? 'Exit' : 'Cash Out'}
+                                </button>
+                            </div>
                         )}
                     </div>
 
@@ -163,20 +175,11 @@ export function PokerGame({ onClose, onAction, onNewRound, gameState, loading }:
                             ))
                         }
                     </div>
-                    <div className={styles.gameOverButtons}>
-                        {!gameState.session_over ? (
-                            <button onClick={onNewRound} className={styles.playAgainButton} disabled={loading}>
-                                {loading ? 'Dealing...' : 'Play Again'}
-                            </button>
-                        ) : (
-                            <div className={styles.sessionOverMessage}>
-                                {humanPlayer && humanPlayer.energy > 100 ? 'Great session! You made profit!' : 'Better luck next time!'}
-                            </div>
-                        )}
-                        <button onClick={onClose} className={styles.exitButton}>
-                            {gameState.session_over ? 'Exit' : 'Cash Out'}
-                        </button>
-                    </div>
+                    {gameState.session_over && (
+                        <div className={styles.sessionOverMessage}>
+                            {humanPlayer && humanPlayer.energy > 100 ? 'Great session! You made profit!' : 'Better luck next time!'}
+                        </div>
+                    )}
                 </div>
             )}
         </div>

--- a/frontend/src/components/poker/PokerActions.module.css
+++ b/frontend/src/components/poker/PokerActions.module.css
@@ -4,6 +4,7 @@
     justify-content: flex-start;
     align-items: center;
     min-height: 44px;
+    min-width: 300px;
     padding: 8px 12px;
     background: linear-gradient(135deg, rgba(30, 41, 59, 0.8) 0%, rgba(15, 23, 42, 0.9) 100%);
     border-radius: 8px;
@@ -150,6 +151,7 @@
     color: #94a3b8;
     text-align: center;
     font-style: italic;
+    min-width: 200px;
 }
 
 .waitingDots {

--- a/frontend/src/components/poker/PokerPlayer.module.css
+++ b/frontend/src/components/poker/PokerPlayer.module.css
@@ -66,6 +66,7 @@
     border-radius: 8px;
     border: 2px solid #3b82f6;
     transition: all 0.3s ease;
+    min-width: 200px;
 }
 
 .humanPlayer.humanActive {
@@ -86,6 +87,7 @@
     display: flex;
     align-items: center;
     gap: 6px;
+    min-width: 90px;
 }
 
 .chipStackContainer {
@@ -101,6 +103,7 @@
     color: #fbbf24;
     font-weight: bold;
     font-size: 11px;
+    min-width: 55px;
 }
 
 .yourCards {


### PR DESCRIPTION
- Add min-width to humanPlayer (200px), playerStats (90px), and currentBet (55px) to prevent left section from resizing when bet amounts change
- Add min-width (300px) to PokerActions container to keep buttons in consistent position during waiting/active states
- Move Play Again and Cash Out buttons inline with action buttons instead of in separate game over section below
- Style inline buttons to match existing action button aesthetics

This prevents buttons from shifting right when the left info changes.