### PR TITLE
Render poker avatars with tank fish art

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -112,17 +112,39 @@ class SimulationRunner:
             Dictionary with fish player data
         """
         algo_name = fish.genome.behavior_algorithm.algorithm_id
+        genome_data = self._get_fish_genome_data(fish)
         player_data = {
             "fish_id": fish.fish_id,
             "name": f"{algo_name[:15]} (Gen {fish.generation})",
+            "generation": fish.generation,
             "energy": fish.energy,
             "algorithm": algo_name,
+            "genome_data": genome_data,
         }
 
         if include_aggression:
             player_data["aggression"] = getattr(fish.genome, "aggression", 0.5)
 
         return player_data
+
+    def _get_fish_genome_data(self, fish: Fish) -> Optional[Dict[str, Any]]:
+        """Extract visual genome data for a fish to mirror tank rendering."""
+
+        if not hasattr(fish, "genome"):
+            return None
+
+        return {
+            "speed": fish.genome.speed_modifier,
+            "size": getattr(fish, "size", getattr(fish.genome, "size_modifier", 1.0)),
+            "color_hue": fish.genome.color_hue,
+            "template_id": fish.genome.template_id,
+            "fin_size": fish.genome.fin_size,
+            "tail_size": fish.genome.tail_size,
+            "body_aspect": fish.genome.body_aspect,
+            "eye_size": fish.genome.eye_size,
+            "pattern_intensity": fish.genome.pattern_intensity,
+            "pattern_type": fish.genome.pattern_type,
+        }
 
     def start(self, start_paused: bool = False):
         """Start the simulation in a background thread.

--- a/core/human_poker_game.py
+++ b/core/human_poker_game.py
@@ -34,7 +34,9 @@ class PlayerState:
     is_human: bool = False
     # For AI players
     fish_id: Optional[int] = None
+    generation: Optional[int] = None
     algorithm: Optional[str] = None
+    genome_data: Optional[Dict[str, Any]] = None
     aggression: float = 0.5
 
 
@@ -108,7 +110,9 @@ class HumanPokerGame:
                     name=fish.get("name", f"Fish {i+1}"),
                     energy=self.STARTING_ENERGY,
                     fish_id=fish.get("fish_id"),
+                    generation=fish.get("generation"),
                     algorithm=fish.get("algorithm", "Unknown"),
+                    genome_data=fish.get("genome_data"),
                     aggression=fish.get("aggression", 0.5),
                     is_human=False,
                 )
@@ -695,7 +699,10 @@ class HumanPokerGame:
                     "total_bet": int(p.total_bet),
                     "folded": p.folded,
                     "is_human": p.is_human,
+                    "fish_id": p.fish_id,
+                    "generation": p.generation,
                     "algorithm": p.algorithm,
+                    "genome_data": p.genome_data,
                     # Show hole cards for human player or during showdown
                     "hole_cards": (
                         [str(card) for card in p.hole_cards]

--- a/frontend/src/components/PokerGame.tsx
+++ b/frontend/src/components/PokerGame.tsx
@@ -75,6 +75,9 @@ export function PokerGame({ onClose, onAction, onNewRound, gameState, loading }:
                     <PokerPlayer
                         key={player.player_id}
                         name={player.name}
+                        fishId={player.fish_id}
+                        generation={player.generation}
+                        genomeData={player.genome_data}
                         energy={player.energy}
                         currentBet={player.current_bet}
                         folded={player.folded}

--- a/frontend/src/components/poker/PokerPlayer.module.css
+++ b/frontend/src/components/poker/PokerPlayer.module.css
@@ -5,8 +5,8 @@
     border: 1px solid rgba(148, 163, 184, 0.18);
     display: flex;
     align-items: center;
-    gap: 8px;
-    min-height: 63px;
+    gap: 12px;
+    min-height: 90px;
 }
 
 .active {
@@ -18,11 +18,58 @@
     opacity: 0.5;
 }
 
-.opponentName {
-    font-size: 12px;
-    font-weight: bold;
-    color: #3b82f6;
-    min-width: 60px;
+
+.avatarWrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    min-width: 78px;
+}
+
+.avatarCircle {
+    width: 72px;
+    height: 72px;
+    border-radius: 16px;
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.6)), #0f172a;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25), inset 0 0 8px rgba(255, 255, 255, 0.05);
+}
+
+.avatarSvg {
+    width: 70px;
+    height: 70px;
+}
+
+.avatarLabel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+}
+
+.avatarName {
+    font-size: 11px;
+    font-weight: 700;
+    color: #e2e8f0;
+    letter-spacing: 0.2px;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.avatarGen {
+    font-size: 10px;
+    font-weight: 600;
+    color: #94a3b8;
+}
+
+.avatarImage {
+    width: 70px;
+    height: 46px;
+    object-fit: contain;
+    filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.25));
 }
 
 .opponentInfo {

--- a/frontend/src/components/poker/PokerPlayer.tsx
+++ b/frontend/src/components/poker/PokerPlayer.tsx
@@ -2,9 +2,12 @@
  * Poker player card component
  */
 
+import React from 'react';
 import { PlayingCard } from './PlayingCard';
 import { ChipStack } from './PokerChip';
 import styles from './PokerPlayer.module.css';
+import type { FishGenomeData } from '../../types/simulation';
+import { getEyePosition, getFishPath, type FishParams } from '../../utils/fishTemplates';
 
 interface PokerPlayerProps {
     name: string;
@@ -13,7 +16,139 @@ interface PokerPlayerProps {
     folded: boolean;
     isActive: boolean;
     isHuman: boolean;
+    fishId?: number;
+    generation?: number;
+    genomeData?: FishGenomeData;
     cards?: string[];
+}
+
+const DEFAULT_FISH_IMAGE = '/images/george1.png';
+
+function buildFishParams(genomeData?: FishGenomeData): FishParams | null {
+    if (!genomeData) return null;
+
+    return {
+        template_id: genomeData.template_id ?? 0,
+        fin_size: genomeData.fin_size ?? 1,
+        tail_size: genomeData.tail_size ?? 1,
+        body_aspect: genomeData.body_aspect ?? 1,
+        eye_size: genomeData.eye_size ?? 1,
+        pattern_intensity: genomeData.pattern_intensity ?? 0,
+        pattern_type: genomeData.pattern_type ?? 0,
+        color_hue: genomeData.color_hue ?? 0,
+        size: genomeData.size ?? 1,
+    };
+}
+
+function renderPattern(
+    params: FishParams,
+    patternColor: string,
+    baseSize: number,
+    gradientId: string
+): React.ReactNode {
+    const commonProps = {
+        opacity: params.pattern_intensity * 0.4,
+        stroke: patternColor,
+        fill: 'none',
+        strokeWidth: 2,
+    } as const;
+
+    switch (params.pattern_type) {
+        case 0: // Stripes
+            return (
+                <g {...commonProps}>
+                    <line x1={baseSize * 0.3} y1={baseSize * 0.2} x2={baseSize * 0.3} y2={baseSize * 0.8} />
+                    <line x1={baseSize * 0.5} y1={baseSize * 0.2} x2={baseSize * 0.5} y2={baseSize * 0.8} />
+                    <line x1={baseSize * 0.7} y1={baseSize * 0.2} x2={baseSize * 0.7} y2={baseSize * 0.8} />
+                </g>
+            );
+        case 1: // Spots
+            return (
+                <g fill={patternColor} opacity={params.pattern_intensity * 0.4}>
+                    <circle cx={baseSize * 0.4} cy={baseSize * 0.35} r={3} />
+                    <circle cx={baseSize * 0.6} cy={baseSize * 0.4} r={3} />
+                    <circle cx={baseSize * 0.5} cy={baseSize * 0.6} r={3} />
+                    <circle cx={baseSize * 0.7} cy={baseSize * 0.65} r={3} />
+                </g>
+            );
+        case 2: // Solid overlay
+            return (
+                <path
+                    d={getFishPath(params, baseSize)}
+                    fill={patternColor}
+                    opacity={params.pattern_intensity * 0.2}
+                />
+            );
+        case 3: // Gradient
+            return (
+                <>
+                    <defs>
+                        <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
+                            <stop offset="0%" stopColor={patternColor} stopOpacity={params.pattern_intensity * 0.4} />
+                            <stop offset="100%" stopColor="transparent" stopOpacity={0} />
+                        </linearGradient>
+                    </defs>
+                    <path d={getFishPath(params, baseSize)} fill={`url(#${gradientId})`} />
+                </>
+            );
+        default:
+            return null;
+    }
+}
+
+function FishAvatar({
+    fishId,
+    generation,
+    genomeData,
+}: {
+    fishId?: number;
+    generation?: number;
+    genomeData?: FishGenomeData;
+}) {
+    const fishParams = buildFishParams(genomeData);
+    const label = fishId ? `Fish #${fishId}` : 'AI Fish';
+
+    if (!fishParams) {
+        return (
+            <div className={styles.avatarWrapper}>
+                <div className={styles.avatarCircle}>
+                    <img src={DEFAULT_FISH_IMAGE} alt={label} className={styles.avatarImage} />
+                </div>
+                <div className={styles.avatarLabel}>
+                    <span className={styles.avatarName}>{label}</span>
+                    {generation !== undefined && <span className={styles.avatarGen}>Gen {generation}</span>}
+                </div>
+            </div>
+        );
+    }
+
+    const baseSize = 90;
+    const fishPath = getFishPath(fishParams, baseSize);
+    const eyePos = getEyePosition(fishParams, baseSize);
+    const eyeRadius = 3 * fishParams.eye_size;
+    const hueDegrees = (fishParams.color_hue ?? 0) * 360;
+    const baseColor = `hsl(${hueDegrees}deg 70% 60%)`;
+    const strokeColor = `hsl(${hueDegrees}deg 80% 40%)`;
+    const patternColor = `hsl(${hueDegrees}deg 75% 35%)`;
+    const gradientId = `fish-pattern-${fishId ?? 'ai'}`;
+
+    return (
+        <div className={styles.avatarWrapper}>
+            <div className={styles.avatarCircle}>
+                <svg viewBox={`0 0 ${baseSize} ${baseSize}`} className={styles.avatarSvg} aria-hidden>
+                    <path d={fishPath} fill={baseColor} stroke={strokeColor} strokeWidth={2} />
+                    {fishParams.pattern_intensity > 0.05 &&
+                        renderPattern(fishParams, patternColor, baseSize, gradientId)}
+                    <circle cx={eyePos.x} cy={eyePos.y} r={eyeRadius} fill="#ffffff" />
+                    <circle cx={eyePos.x} cy={eyePos.y} r={eyeRadius * 0.5} fill="#0f172a" />
+                </svg>
+            </div>
+            <div className={styles.avatarLabel}>
+                <span className={styles.avatarName}>{label}</span>
+                {generation !== undefined && <span className={styles.avatarGen}>Gen {generation}</span>}
+            </div>
+        </div>
+    );
 }
 
 export function PokerPlayer({
@@ -23,6 +158,9 @@ export function PokerPlayer({
     folded,
     isActive,
     isHuman,
+    fishId,
+    generation,
+    genomeData,
     cards = [],
 }: PokerPlayerProps) {
     const playerClass = `${styles.player} ${folded ? styles.folded : ''} ${isActive ? styles.active : ''}`;
@@ -58,8 +196,8 @@ export function PokerPlayer({
     const showActualCards = cards.length > 0 && cards[0] !== '??';
 
     return (
-        <div className={playerClass}>
-            <div className={styles.opponentName}>{name}</div>
+        <div className={playerClass} title={name}>
+            <FishAvatar fishId={fishId} generation={generation} genomeData={genomeData} />
             <div className={styles.opponentInfo}>
                 <div className={styles.opponentCards}>
                     {showActualCards ? (

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -2,6 +2,20 @@
  * TypeScript types for simulation data
  */
 
+export interface FishGenomeData {
+  speed: number;
+  size: number;
+  color_hue: number;
+  // Visual traits for parametric fish templates
+  template_id: number;
+  fin_size: number;
+  tail_size: number;
+  body_aspect: number;
+  eye_size: number;
+  pattern_intensity: number;
+  pattern_type: number;
+}
+
 export interface EntityData {
   id: number;
   type: 'fish' | 'food' | 'plant' | 'crab' | 'castle' | 'jellyfish';
@@ -19,19 +33,7 @@ export interface EntityData {
   species?: 'solo' | 'algorithmic' | 'neural' | 'schooling';
   generation?: number;
   age?: number;
-  genome_data?: {
-    speed: number;
-    size: number;
-    color_hue: number;
-    // Visual traits for parametric fish templates
-    template_id: number;
-    fin_size: number;
-    tail_size: number;
-    body_aspect: number;
-    eye_size: number;
-    pattern_intensity: number;
-    pattern_type: number;
-  };
+  genome_data?: FishGenomeData;
 
   // Food-specific
   food_type?: string;
@@ -176,7 +178,10 @@ export interface PokerGamePlayer {
   total_bet: number;
   folded: boolean;
   is_human: boolean;
+  fish_id?: number;
+  generation?: number;
   algorithm?: string;
+  genome_data?: FishGenomeData;
   hole_cards: string[];
 }
 


### PR DESCRIPTION
## Summary
- include fish genome rendering data in human poker game state so the UI can mirror tank visuals
- render poker opponents with the same SVG fish art used in the tank (with a fallback image) instead of abstract avatars
- update poker UI styling to present fish number/generation alongside the tank-matched avatar

## Testing
- npm run build --prefix frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d9e39bd88331bc0ccafb182b705f)