### PR TITLE
Decouple poker mechanics from fish entities

### DIFF
--- a/core/fish_poker.py
+++ b/core/fish_poker.py
@@ -14,7 +14,7 @@ Features:
 
 import random
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from core.entities import LifeStage
 from core.poker.core import BettingAction, PokerEngine, PokerHand
@@ -92,7 +92,7 @@ class PokerParticipant:
         self.last_cooldown_age = getattr(self.fish, "age", self.last_cooldown_age)
 
 
-_POKER_PARTICIPANTS: dict[int, PokerParticipant] = {}
+_POKER_PARTICIPANTS: Dict[int, PokerParticipant] = {}
 
 
 def _get_participant(fish: "Fish") -> PokerParticipant:

--- a/core/poker/__init__.py
+++ b/core/poker/__init__.py
@@ -48,6 +48,7 @@ from core.poker.strategy import (
     crossover_poker_strategies,
     get_random_poker_strategy,
 )
+from core.poker.table import PokerTable
 
 __all__ = [
     # Core
@@ -79,4 +80,5 @@ __all__ = [
     "ALL_POKER_STRATEGIES",
     "get_random_poker_strategy",
     "crossover_poker_strategies",
+    "PokerTable",
 ]

--- a/core/poker/table.py
+++ b/core/poker/table.py
@@ -1,0 +1,28 @@
+"""Table orchestration for poker games between fish players."""
+from typing import Iterable, Optional, TYPE_CHECKING
+
+from core.entities import Fish
+
+if TYPE_CHECKING:
+    from core.fish_poker import PokerResult
+
+
+class PokerTable:
+    """Run poker hands for a collection of fish without mixing concerns."""
+
+    def __init__(self, players: Iterable[Fish]):
+        self.players = list(players)
+        if len(self.players) < 2:
+            raise ValueError("PokerTable requires at least two players")
+
+    def play_hand(self, bet_amount: Optional[float] = None) -> Optional["PokerResult"]:
+        """Play a poker hand among the configured players."""
+
+        from core.fish_poker import PokerInteraction
+
+        interaction = PokerInteraction(*self.players)
+        if not interaction.can_play_poker():
+            return None
+
+        interaction.play_poker(bet_amount=bet_amount)
+        return interaction.result


### PR DESCRIPTION
## Summary
- remove poker-specific state from fish entities and add a dedicated energy adjustment helper
- manage poker state within the poker module via participant tracking and shared reproduction logic
- add a PokerTable orchestrator for playing hands between fish players

## Testing
- python -m pytest tests/test_poker_energy.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210ac0aa9c833186a6b3082269ae32)