### PR TITLE
Handle missing poker stats on leaderboard generation

### DIFF
--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -652,7 +652,19 @@ class EcosystemManager:
             return []
 
         # Filter to only fish with poker games played
-        poker_fish = [f for f in fish_list if isinstance(f, Fish) and f.poker_stats.total_games > 0]
+        poker_fish = []
+        for fish in fish_list:
+            if not isinstance(fish, Fish):
+                continue
+
+            # Ensure poker stats exist for legacy fish instances
+            if not hasattr(fish, "poker_stats") or fish.poker_stats is None:
+                from core.fish.poker_stats_component import FishPokerStats
+
+                fish.poker_stats = FishPokerStats()
+
+            if fish.poker_stats.total_games > 0:
+                poker_fish.append(fish)
 
         # Sort by the requested metric
         if sort_by == "net_energy":


### PR DESCRIPTION
## Summary
- safeguard poker leaderboard creation by initializing missing poker stats on fish
- skip non-fish entries while rebuilding leaderboard list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210da051d08331b95a20eb553324c2)