### PR TITLE
Implement delta WebSocket payloads

### DIFF
--- a/backend/state_payloads.py
+++ b/backend/state_payloads.py
@@ -1,0 +1,253 @@
+"""Lightweight data transfer objects for simulation state serialization."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# Ensure consistent module aliasing whether imported as `state_payloads` or `backend.state_payloads`
+sys.modules.setdefault("state_payloads", sys.modules[__name__])
+sys.modules.setdefault("backend.state_payloads", sys.modules[__name__])
+
+
+def _compact_dict(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of *data* with None values removed."""
+    return {k: v for k, v in data.items() if v is not None}
+
+
+@dataclass(slots=True)
+class EntitySnapshot:
+    """Minimal snapshot of an entity for client rendering."""
+
+    id: int
+    type: str
+    x: float
+    y: float
+    width: float
+    height: float
+    vel_x: float = 0.0
+    vel_y: float = 0.0
+    energy: Optional[float] = None
+    generation: Optional[int] = None
+    age: Optional[int] = None
+    species: Optional[str] = None
+    genome_data: Optional[Dict[str, Any]] = None
+    food_type: Optional[str] = None
+    plant_type: Optional[int] = None
+
+    def to_full_dict(self) -> Dict[str, Any]:
+        """Return the full payload used on sync frames."""
+
+        return _compact_dict(
+            {
+                "id": self.id,
+                "type": self.type,
+                "x": self.x,
+                "y": self.y,
+                "width": self.width,
+                "height": self.height,
+                "vel_x": self.vel_x,
+                "vel_y": self.vel_y,
+                "energy": self.energy,
+                "generation": self.generation,
+                "age": self.age,
+                "species": self.species,
+                "genome_data": self.genome_data,
+                "food_type": self.food_type,
+                "plant_type": self.plant_type,
+            }
+        )
+
+    def to_delta_dict(self) -> Dict[str, Any]:
+        """Return only fast-changing fields for delta frames."""
+
+        return {
+            "id": self.id,
+            "x": self.x,
+            "y": self.y,
+            "vel_x": self.vel_x,
+            "vel_y": self.vel_y,
+        }
+
+
+@dataclass(slots=True)
+class PokerStatsPayload:
+    total_games: int
+    total_wins: int
+    total_losses: int
+    total_ties: int
+    total_energy_won: float
+    total_energy_lost: float
+    net_energy: float
+    best_hand_rank: int
+    best_hand_name: str
+    win_rate: float = 0.0
+    win_rate_pct: str = "0.0%"
+    roi: float = 0.0
+    vpip: float = 0.0
+    vpip_pct: str = "0.0%"
+    bluff_success_rate: float = 0.0
+    bluff_success_pct: str = "0.0%"
+    button_win_rate: float = 0.0
+    button_win_rate_pct: str = "0.0%"
+    off_button_win_rate: float = 0.0
+    off_button_win_rate_pct: str = "0.0%"
+    positional_advantage: float = 0.0
+    positional_advantage_pct: str = "0.0%"
+    aggression_factor: float = 0.0
+    avg_hand_rank: float = 0.0
+    total_folds: int = 0
+    preflop_folds: int = 0
+    postflop_folds: int = 0
+    showdown_win_rate: str = "0.0%"
+    avg_fold_rate: str = "0.0%"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.__dict__
+
+
+@dataclass(slots=True)
+class StatsPayload:
+    frame: int
+    population: int
+    generation: int
+    max_generation: int
+    births: int
+    deaths: int
+    capacity: str
+    time: str
+    death_causes: Dict[str, int]
+    fish_count: int
+    food_count: int
+    plant_count: int
+    total_energy: float
+    poker_stats: PokerStatsPayload
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = self.__dict__.copy()
+        data["poker_stats"] = self.poker_stats.to_dict()
+        return data
+
+
+@dataclass(slots=True)
+class PokerEventPayload:
+    frame: int
+    winner_id: int
+    loser_id: int
+    winner_hand: str
+    loser_hand: str
+    energy_transferred: float
+    message: str
+    is_jellyfish: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.__dict__
+
+
+@dataclass(slots=True)
+class PokerLeaderboardEntryPayload:
+    rank: int
+    fish_id: int
+    generation: int
+    algorithm: str
+    energy: float
+    age: int
+    total_games: int
+    wins: int
+    losses: int
+    ties: int
+    win_rate: float
+    net_energy: float
+    roi: float
+    current_streak: int
+    best_streak: int
+    best_hand: str
+    best_hand_rank: int
+    showdown_win_rate: float
+    fold_rate: float
+    positional_advantage: float
+    recent_win_rate: float = 0.0
+    skill_trend: str = "stable"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.__dict__
+
+
+@dataclass(slots=True)
+class AutoEvaluateStatsPayload:
+    hands_played: int
+    hands_remaining: int
+    players: List[Dict[str, Any]]
+    game_over: bool
+    winner: Optional[str]
+    reason: str
+    performance_history: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.__dict__
+
+
+@dataclass(slots=True)
+class FullStatePayload:
+    """Full snapshot with complete entity data."""
+
+    frame: int
+    elapsed_time: int
+    entities: List[EntitySnapshot]
+    stats: StatsPayload
+    poker_events: List[PokerEventPayload]
+    poker_leaderboard: List[PokerLeaderboardEntryPayload]
+    auto_evaluation: Optional[AutoEvaluateStatsPayload] = None
+    type: str = "update"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return _compact_dict(
+            {
+                "type": self.type,
+                "frame": self.frame,
+                "elapsed_time": self.elapsed_time,
+                "entities": [e.to_full_dict() for e in self.entities],
+                "stats": self.stats.to_dict(),
+                "poker_events": [e.to_dict() for e in self.poker_events],
+                "poker_leaderboard": [e.to_dict() for e in self.poker_leaderboard],
+                "auto_evaluation": self.auto_evaluation.to_dict()
+                if self.auto_evaluation
+                else None,
+            }
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), separators=(",", ":"))
+
+
+@dataclass(slots=True)
+class DeltaStatePayload:
+    """Delta update that only carries incremental changes."""
+
+    frame: int
+    elapsed_time: int
+    updates: List[Dict[str, Any]]
+    added: List[Dict[str, Any]]
+    removed: List[int]
+    poker_events: List[PokerEventPayload]
+    stats: Optional[StatsPayload]
+    type: str = "delta"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return _compact_dict(
+            {
+                "type": self.type,
+                "frame": self.frame,
+                "elapsed_time": self.elapsed_time,
+                "updates": self.updates,
+                "added": self.added,
+                "removed": self.removed,
+                "poker_events": [e.to_dict() for e in self.poker_events],
+                "stats": self.stats.to_dict() if self.stats else None,
+            }
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), separators=(",", ":"))

--- a/backend/test_integration.py
+++ b/backend/test_integration.py
@@ -3,7 +3,7 @@
 import json
 import time
 
-from models import SimulationUpdate
+from state_payloads import FullStatePayload
 from simulation_runner import SimulationRunner
 
 
@@ -32,14 +32,10 @@ def test_state_serialization():
     runner.start()
     time.sleep(0.5)
 
-    state = runner.get_state()
-    assert isinstance(state, SimulationUpdate), "State should be SimulationUpdate"
+    state = runner.get_state(force_full=True, allow_delta=False)
+    assert isinstance(state, FullStatePayload), "State should be FullStatePayload"
 
-    # Test JSON serialization
-    json_str = state.model_dump_json()
-    assert len(json_str) > 0, "JSON should not be empty"
-
-    # Test JSON is valid
+    json_str = state.to_json()
     parsed = json.loads(json_str)
     assert "type" in parsed
     assert "frame" in parsed
@@ -58,7 +54,7 @@ def test_all_entity_types():
     runner.start()
     time.sleep(1)
 
-    state = runner.get_state()
+    state = runner.get_state(force_full=True, allow_delta=False)
     entity_types = {e.type for e in state.entities}
 
     expected_types = {"fish", "plant", "crab", "castle"}
@@ -91,10 +87,10 @@ def test_commands():
     time.sleep(0.5)
 
     # Test add_food
-    initial_food = runner.get_state().stats.food_count
+    initial_food = runner.get_state(force_full=True, allow_delta=False).stats.food_count
     runner.handle_command("add_food")
     time.sleep(0.3)
-    new_food = runner.get_state().stats.food_count
+    new_food = runner.get_state(force_full=True, allow_delta=False).stats.food_count
     assert new_food > initial_food, "Food count should increase"
 
     # Test pause

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -141,6 +141,17 @@ export interface SimulationUpdate {
   auto_evaluation?: AutoEvaluateStats;
 }
 
+export interface DeltaUpdate {
+  type: 'delta';
+  frame: number;
+  elapsed_time: number;
+  updates: Pick<EntityData, 'id' | 'x' | 'y' | 'vel_x' | 'vel_y'>[];
+  added: EntityData[];
+  removed: number[];
+  poker_events: PokerEventData[];
+  stats?: StatsData;
+}
+
 export interface Command {
   command: 'add_food' | 'spawn_fish' | 'pause' | 'resume' | 'reset' | 'start_poker' | 'poker_action' | 'poker_new_round' | 'standard_poker_series' | 'poker_autopilot_action';
   data?: Record<string, unknown>;
@@ -157,7 +168,7 @@ export interface ErrorMessage {
   message: string;
 }
 
-export type WebSocketMessage = SimulationUpdate | CommandAck | ErrorMessage;
+export type WebSocketMessage = SimulationUpdate | DeltaUpdate | CommandAck | ErrorMessage;
 
 // Poker Game State
 export interface PokerPlayer {


### PR DESCRIPTION
## Summary
- add lightweight state payload dataclasses to avoid Pydantic overhead and support delta updates
- update simulation runner and websocket broadcaster to emit sync frames and delta frames with added/removed entity tracking
- teach frontend websocket hook and typings to apply delta updates against existing state

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210ee6c1c88331bda4324b1283969b)