### PR TITLE
Optimize websocket serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "uvicorn[standard]>=0.27.0",
     "websockets>=12.0",
     "pydantic>=2.6.0",  # Required for Python 3.13 compatibility
+    "orjson>=3.10.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add an orjson-powered serializer with timing warnings for simulation state frames
- use the serializer in the broadcast loop and log slow serialization/broadcast cycles
- send websocket payloads as bytes to avoid extra JSON decoding overhead

## Testing
- python -m pytest tests/test_environment.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692120e8a148833182e5bb46afe47bb8)