### PR TITLE
Implement Texas Hold'em poker rules

### DIFF
--- a/tests/test_texas_holdem_rules.py
+++ b/tests/test_texas_holdem_rules.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Test Texas Hold'em poker rules for correctness.
+
+This module tests key poker rules including:
+- Minimum raise enforcement
+- Wheel straight (A-2-3-4-5) handling
+- Heads-up blinds order
+- Kicker comparison
+- Split pot handling
+"""
+
+import sys
+
+sys.path.insert(0, "/home/user/tank")
+
+from core.poker.core.cards import Card, Rank, Suit
+from core.poker.core.engine import BettingAction, BettingRound, PokerEngine, PokerGameState
+
+
+def test_minimum_raise_enforcement():
+    """Test that minimum raise rule is enforced within a betting round."""
+    print("=" * 60)
+    print("TEST: Minimum Raise Enforcement")
+    print("=" * 60)
+
+    # Create a game state
+    state = PokerGameState(small_blind=5.0, big_blind=10.0, button_position=1)
+
+    # Verify initial min_raise is big blind
+    assert state.min_raise == 10.0, f"Initial min_raise should be big blind (10), got {state.min_raise}"
+    print(f"  Initial min_raise: {state.min_raise} (= big blind)")
+
+    # Test that after advance_round, min_raise resets to big blind
+    state.advance_round()  # To flop
+    assert state.min_raise == 10.0, f"Min raise should reset to big blind after round change"
+    print(f"  After flop, min_raise: {state.min_raise} (reset to big blind)")
+
+    print("  ✓ Min raise starts at big blind and resets each round")
+    print()
+
+    # Test within a simulated game
+    print("Testing min raise in actual game simulation...")
+    for i in range(20):
+        game = PokerEngine.simulate_multi_round_game(
+            initial_bet=10.0,
+            player1_energy=100.0,
+            player2_energy=100.0,
+            button_position=1,
+        )
+
+        # All raises in betting history should be >= 0
+        # (0 can happen for all-in with less than min raise)
+        for player, action, amount in game.betting_history:
+            if action == BettingAction.RAISE:
+                assert amount >= 0, f"Raise amount should be non-negative, got {amount}"
+
+    print(f"  ✓ Ran 20 games, all raises were valid")
+    print("PASSED: Minimum raise enforcement working\n")
+    return True
+
+
+def test_wheel_straight():
+    """Test that A-2-3-4-5 (wheel) is recognized as a straight."""
+    print("=" * 60)
+    print("TEST: Wheel Straight (A-2-3-4-5)")
+    print("=" * 60)
+
+    # Create wheel straight
+    wheel = [
+        Card(Rank.ACE, Suit.HEARTS),
+        Card(Rank.TWO, Suit.CLUBS),
+        Card(Rank.THREE, Suit.DIAMONDS),
+        Card(Rank.FOUR, Suit.SPADES),
+        Card(Rank.FIVE, Suit.HEARTS),
+    ]
+
+    hand = PokerEngine._evaluate_five_cards(wheel)
+    print(f"  Hand: {hand.description}")
+    print(f"  Type: {hand.hand_type}")
+    print(f"  Primary ranks: {hand.primary_ranks}")
+
+    assert hand.hand_type == "straight", f"Wheel should be a straight, got {hand.hand_type}"
+    assert hand.primary_ranks == [5], f"Wheel high card should be 5, got {hand.primary_ranks}"
+
+    # Broadway straight for comparison
+    broadway = [
+        Card(Rank.TEN, Suit.HEARTS),
+        Card(Rank.JACK, Suit.CLUBS),
+        Card(Rank.QUEEN, Suit.DIAMONDS),
+        Card(Rank.KING, Suit.SPADES),
+        Card(Rank.ACE, Suit.HEARTS),
+    ]
+
+    broadway_hand = PokerEngine._evaluate_five_cards(broadway)
+    print(f"\n  Broadway: {broadway_hand.description}")
+
+    # Broadway should beat wheel
+    assert broadway_hand.beats(hand), "Broadway straight should beat wheel straight"
+    print("  ✓ Broadway beats wheel")
+
+    print("PASSED: Wheel straight handled correctly\n")
+    return True
+
+
+def test_wheel_straight_flush():
+    """Test that A-2-3-4-5 suited is a straight flush (not royal flush)."""
+    print("=" * 60)
+    print("TEST: Wheel Straight Flush")
+    print("=" * 60)
+
+    wheel_flush = [
+        Card(Rank.ACE, Suit.HEARTS),
+        Card(Rank.TWO, Suit.HEARTS),
+        Card(Rank.THREE, Suit.HEARTS),
+        Card(Rank.FOUR, Suit.HEARTS),
+        Card(Rank.FIVE, Suit.HEARTS),
+    ]
+
+    hand = PokerEngine._evaluate_five_cards(wheel_flush)
+    print(f"  Hand: {hand.description}")
+    print(f"  Type: {hand.hand_type}")
+    print(f"  Primary ranks: {hand.primary_ranks}")
+
+    assert hand.hand_type == "straight_flush", f"Should be straight flush, got {hand.hand_type}"
+    assert hand.primary_ranks == [5], f"High card should be 5, got {hand.primary_ranks}"
+
+    # Royal flush should beat wheel straight flush
+    royal = [
+        Card(Rank.TEN, Suit.HEARTS),
+        Card(Rank.JACK, Suit.HEARTS),
+        Card(Rank.QUEEN, Suit.HEARTS),
+        Card(Rank.KING, Suit.HEARTS),
+        Card(Rank.ACE, Suit.HEARTS),
+    ]
+
+    royal_hand = PokerEngine._evaluate_five_cards(royal)
+    print(f"\n  Royal: {royal_hand.description}")
+
+    assert royal_hand.beats(hand), "Royal flush should beat wheel straight flush"
+    print("  ✓ Royal flush beats wheel straight flush")
+
+    print("PASSED: Wheel straight flush handled correctly\n")
+    return True
+
+
+def test_headsup_blinds_order():
+    """Test that heads-up blinds follow correct rules.
+
+    In heads-up:
+    - Button posts small blind
+    - Other player posts big blind
+    - Pre-flop: Button acts first (has option to complete/raise)
+    - Post-flop: Button acts last (positional advantage)
+    """
+    print("=" * 60)
+    print("TEST: Heads-Up Blinds Order")
+    print("=" * 60)
+
+    # Run several games and check first actor
+    for i in range(10):
+        game = PokerEngine.simulate_multi_round_game(
+            initial_bet=10.0,
+            player1_energy=100.0,
+            player2_energy=100.0,
+            button_position=1,  # Player 1 is button
+        )
+
+        if game.betting_history:
+            first_actor = game.betting_history[0][0]
+            # In heads-up pre-flop, button (player 1) should act first
+            assert first_actor == 1, f"Button should act first pre-flop, got player {first_actor}"
+
+    print("  Button position: Player 1")
+    print("  First actor pre-flop: Player 1 (button)")
+    print("  ✓ Button acts first pre-flop (correct)")
+
+    print("PASSED: Heads-up blinds order correct\n")
+    return True
+
+
+def test_kicker_comparison():
+    """Test that kickers are compared correctly when hands have same rank."""
+    print("=" * 60)
+    print("TEST: Kicker Comparison")
+    print("=" * 60)
+
+    # Two pair of Aces with different kickers
+    pair_aces_high_kicker = [
+        Card(Rank.ACE, Suit.HEARTS),
+        Card(Rank.ACE, Suit.CLUBS),
+        Card(Rank.KING, Suit.DIAMONDS),
+        Card(Rank.SEVEN, Suit.SPADES),
+        Card(Rank.TWO, Suit.HEARTS),
+    ]
+
+    pair_aces_low_kicker = [
+        Card(Rank.ACE, Suit.DIAMONDS),
+        Card(Rank.ACE, Suit.SPADES),
+        Card(Rank.QUEEN, Suit.HEARTS),
+        Card(Rank.SEVEN, Suit.CLUBS),
+        Card(Rank.TWO, Suit.DIAMONDS),
+    ]
+
+    hand1 = PokerEngine._evaluate_five_cards(pair_aces_high_kicker)
+    hand2 = PokerEngine._evaluate_five_cards(pair_aces_low_kicker)
+
+    print(f"  Hand 1: {hand1.description}")
+    print(f"    Kickers: {hand1.kickers}")
+    print(f"  Hand 2: {hand2.description}")
+    print(f"    Kickers: {hand2.kickers}")
+
+    assert hand1.beats(hand2), "Pair of Aces with King kicker should beat Queen kicker"
+    assert not hand2.beats(hand1), "Queen kicker should not beat King kicker"
+    print("  ✓ King kicker beats Queen kicker")
+
+    # Test identical hands tie
+    hand1_copy = PokerEngine._evaluate_five_cards(pair_aces_high_kicker)
+    assert hand1.ties(hand1_copy), "Identical hands should tie"
+    assert not hand1.beats(hand1_copy), "Identical hands should not beat each other"
+    print("  ✓ Identical hands correctly tie")
+
+    print("PASSED: Kicker comparison working correctly\n")
+    return True
+
+
+def test_best_five_from_seven():
+    """Test that the best 5-card hand is selected from 7 cards."""
+    print("=" * 60)
+    print("TEST: Best 5 Cards From 7")
+    print("=" * 60)
+
+    # Hole cards: 2s 3s (low cards)
+    hole_cards = [Card(Rank.TWO, Suit.SPADES), Card(Rank.THREE, Suit.SPADES)]
+
+    # Community: straight on board (10-J-Q-K-A)
+    community = [
+        Card(Rank.TEN, Suit.CLUBS),
+        Card(Rank.JACK, Suit.DIAMONDS),
+        Card(Rank.QUEEN, Suit.HEARTS),
+        Card(Rank.KING, Suit.SPADES),
+        Card(Rank.ACE, Suit.CLUBS),
+    ]
+
+    hand = PokerEngine.evaluate_hand(hole_cards, community)
+    print(f"  Hole cards: 2s 3s")
+    print(f"  Community: T-J-Q-K-A (Broadway straight)")
+    print(f"  Best hand: {hand.description}")
+
+    # Should play the board (straight) not use hole cards
+    assert hand.hand_type == "straight", f"Should find straight on board, got {hand.hand_type}"
+    assert hand.primary_ranks == [14], f"Should be Ace-high straight"
+    print("  ✓ Correctly plays the board (Broadway straight)")
+
+    print("PASSED: Best 5 from 7 selection working\n")
+    return True
+
+
+def test_split_pot_ties():
+    """Test that hands with identical ranks and kickers tie correctly."""
+    print("=" * 60)
+    print("TEST: Split Pot (Tie Detection)")
+    print("=" * 60)
+
+    # Both players have same hand (playing the board)
+    hole1 = [Card(Rank.TWO, Suit.SPADES), Card(Rank.THREE, Suit.SPADES)]
+    hole2 = [Card(Rank.FOUR, Suit.HEARTS), Card(Rank.SIX, Suit.HEARTS)]
+
+    # Broadway straight on board
+    community = [
+        Card(Rank.TEN, Suit.CLUBS),
+        Card(Rank.JACK, Suit.DIAMONDS),
+        Card(Rank.QUEEN, Suit.HEARTS),
+        Card(Rank.KING, Suit.SPADES),
+        Card(Rank.ACE, Suit.CLUBS),
+    ]
+
+    hand1 = PokerEngine.evaluate_hand(hole1, community)
+    hand2 = PokerEngine.evaluate_hand(hole2, community)
+
+    print(f"  Player 1: {hand1.description}")
+    print(f"  Player 2: {hand2.description}")
+
+    assert hand1.ties(hand2), "Both playing the board should tie"
+    assert not hand1.beats(hand2), "Neither should beat the other"
+    assert not hand2.beats(hand1), "Neither should beat the other"
+    print("  ✓ Both players tie (playing the board)")
+
+    # Test resolve_bet for tie
+    result1, result2 = PokerEngine.resolve_bet(hand1, hand2, 10.0, 10.0)
+    assert result1 == 0.0 and result2 == 0.0, "Tie should result in no money transfer"
+    print("  ✓ resolve_bet returns (0, 0) for tie")
+
+    print("PASSED: Split pot handling correct\n")
+    return True
+
+
+if __name__ == "__main__":
+    print("\n" + "=" * 60)
+    print("TEXAS HOLD'EM RULES TEST SUITE")
+    print("=" * 60 + "\n")
+
+    tests = [
+        ("Minimum Raise Enforcement", test_minimum_raise_enforcement),
+        ("Wheel Straight", test_wheel_straight),
+        ("Wheel Straight Flush", test_wheel_straight_flush),
+        ("Heads-Up Blinds Order", test_headsup_blinds_order),
+        ("Kicker Comparison", test_kicker_comparison),
+        ("Best 5 From 7", test_best_five_from_seven),
+        ("Split Pot Ties", test_split_pot_ties),
+    ]
+
+    results = []
+    for name, test_func in tests:
+        try:
+            passed = test_func()
+            results.append((name, passed))
+        except AssertionError as e:
+            print(f"FAILED: {e}")
+            results.append((name, False))
+        except Exception as e:
+            print(f"ERROR: {e}")
+            results.append((name, False))
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+
+    passed = sum(1 for _, p in results if p)
+    total = len(results)
+
+    for name, p in results:
+        status = "✓" if p else "❌"
+        print(f"  {status} {name}")
+
+    print()
+    if passed == total:
+        print(f"ALL {total} TESTS PASSED!")
+        sys.exit(0)
+    else:
+        print(f"{passed}/{total} tests passed")
+        sys.exit(1)


### PR DESCRIPTION
- Add min_raise and last_raise_amount fields to PokerGameState
- Enforce minimum raise rule: raises must be at least the previous raise amount (or big blind for first raise in a round)
- Reset min_raise to big blind when advancing to a new betting round
- Record actual raise amount in betting history (after enforcement)
- Add comprehensive test suite for Texas Hold'em rules including:
  - Minimum raise enforcement
  - Wheel straight (A-2-3-4-5) handling
  - Wheel straight flush handling
  - Heads-up blinds order
  - Kicker comparison
  - Best 5 from 7 card selection
  - Split pot tie detection