### PR TITLE
Improve fractal plant stability and caching

### DIFF
--- a/frontend/src/utils/renderer.ts
+++ b/frontend/src/utils/renderer.ts
@@ -1178,6 +1178,7 @@ export class Renderer {
         // Render using the fractal plant utility
         renderFractalPlantUtil(
             ctx,
+            plant.id,
             genome,
             x + width / 2,  // Center X
             baseY,          // Base Y (bottom of plant)


### PR DESCRIPTION
## Summary
- cache fractal plant geometry by id with a deterministic genome signature to prevent redraw flicker when positions change
- regenerate cached geometry automatically when genome traits or iteration counts differ for consistent visuals

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692257fd8a708331b4f745227c7ddbbd)