### PR TITLE
Add Mandelbrot fractal plant variant with energy bonus

### DIFF
--- a/core/entities/fractal_plant.py
+++ b/core/entities/fractal_plant.py
@@ -219,6 +219,10 @@ class FractalPlant(Agent):
 
         energy_gain *= reduction_factor
 
+        # Mandelbrot variants have a small energy collection bonus
+        if getattr(self.genome, "fractal_type", "lsystem") == "mandelbrot":
+            energy_gain *= 1.1
+
         self.energy = min(self.max_energy, self.energy + energy_gain)
 
     def _try_produce_nectar(self, time_of_day: Optional[float]) -> Optional["PlantNectar"]:

--- a/core/plant_genetics.py
+++ b/core/plant_genetics.py
@@ -36,6 +36,9 @@ class PlantGenome:
         growth_efficiency: How much energy converts to size (0.5-1.5)
         nectar_threshold_ratio: Energy ratio to produce nectar (0.6-0.9)
 
+    Fractal Variants:
+        fractal_type: Rendering style for the plant's fractal (e.g., 'lsystem', 'mandelbrot')
+
     Fitness:
         fitness_score: Accumulated fitness over lifetime
     """
@@ -62,6 +65,9 @@ class PlantGenome:
     base_energy_rate: float = 0.02
     growth_efficiency: float = 1.0
     nectar_threshold_ratio: float = 0.75
+
+    # Variant traits
+    fractal_type: str = "lsystem"
 
     # Fitness tracking
     fitness_score: float = field(default=0.0)
@@ -192,9 +198,46 @@ class PlantGenome:
             base_energy_rate=rng.uniform(0.01, 0.04),
             growth_efficiency=rng.uniform(0.6, 1.4),
             nectar_threshold_ratio=rng.uniform(0.6, 0.9),
+            fractal_type="lsystem",
         )
 
         # Generate production rules based on branch_probability
+        genome._production_rules = genome._generate_default_rules()
+
+        return genome
+
+    @classmethod
+    def create_mandelbrot_variant(
+        cls, rng: Optional["random.Random"] = None
+    ) -> "PlantGenome":
+        """Create a Mandelbrot-inspired plant genome.
+
+        This variant signals the renderer to use a Mandelbrot set visualization
+        and slightly boosts base energy traits to reflect its special status.
+        """
+        import random as random_module
+
+        rng = rng or random_module
+
+        genome = cls(
+            axiom="F",
+            angle=rng.uniform(20.0, 35.0),
+            length_ratio=rng.uniform(0.6, 0.8),
+            branch_probability=rng.uniform(0.7, 0.95),
+            curve_factor=rng.uniform(0.05, 0.2),
+            color_hue=rng.uniform(0.55, 0.75),
+            color_saturation=rng.uniform(0.6, 1.0),
+            stem_thickness=rng.uniform(0.9, 1.3),
+            leaf_density=rng.uniform(0.4, 0.8),
+            aggression=rng.uniform(0.2, 0.6),
+            bluff_frequency=rng.uniform(0.05, 0.25),
+            risk_tolerance=rng.uniform(0.3, 0.7),
+            base_energy_rate=rng.uniform(0.02, 0.045),
+            growth_efficiency=rng.uniform(0.9, 1.4),
+            nectar_threshold_ratio=rng.uniform(0.6, 0.85),
+            fractal_type="mandelbrot",
+        )
+
         genome._production_rules = genome._generate_default_rules()
 
         return genome
@@ -247,6 +290,7 @@ class PlantGenome:
             base_energy_rate=mutate_float(parent.base_energy_rate, 0.01, 0.05),
             growth_efficiency=mutate_float(parent.growth_efficiency, 0.5, 1.5),
             nectar_threshold_ratio=mutate_float(parent.nectar_threshold_ratio, 0.6, 0.9),
+            fractal_type=parent.fractal_type,
             # Reset fitness
             fitness_score=0.0,
         )
@@ -384,6 +428,7 @@ class PlantGenome:
             "growth_efficiency": self.growth_efficiency,
             "nectar_threshold_ratio": self.nectar_threshold_ratio,
             "fitness_score": self.fitness_score,
+            "fractal_type": self.fractal_type,
             "production_rules": [
                 {"input": inp, "output": out, "prob": prob}
                 for inp, out, prob in self._production_rules
@@ -422,6 +467,7 @@ class PlantGenome:
             growth_efficiency=data.get("growth_efficiency", 1.0),
             nectar_threshold_ratio=data.get("nectar_threshold_ratio", 0.75),
             fitness_score=data.get("fitness_score", 0.0),
+            fractal_type=data.get("fractal_type", "lsystem"),
         )
 
         if rules:

--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -176,8 +176,11 @@ class SimulationEngine(BaseSimulator):
             if spot is None:
                 break  # No more empty spots
 
-            # Create a random genome
-            genome = PlantGenome.create_random(rng=self.rng)
+            # Create a random genome, occasionally using the Mandelbrot variant
+            if self.rng.random() < 0.25:
+                genome = PlantGenome.create_mandelbrot_variant(rng=self.rng)
+            else:
+                genome = PlantGenome.create_random(rng=self.rng)
 
             # Create the plant
             plant = FractalPlant(

--- a/frontend/src/utils/fractalPlant.ts
+++ b/frontend/src/utils/fractalPlant.ts
@@ -15,6 +15,7 @@ export interface PlantGenomeData {
     color_saturation: number;
     stem_thickness: number;
     leaf_density: number;
+    fractal_type?: 'lsystem' | 'mandelbrot';
     production_rules: Array<{
         input: string;
         output: string;
@@ -46,6 +47,11 @@ interface FractalLeaf {
     size: number;
 }
 
+interface MandelbrotCacheEntry {
+    signature: string;
+    texture: HTMLCanvasElement;
+}
+
 /**
  * Cache for plant rendering to avoid regenerating L-system every frame.
  */
@@ -60,6 +66,7 @@ interface PlantRenderCache {
 
 // Module-level cache keyed by plant id to avoid flickering when plants drift
 const plantCache = new Map<number, PlantRenderCache>();
+const mandelbrotCache = new Map<number, MandelbrotCacheEntry>();
 
 /**
  * Create a stable signature for a genome so cache invalidation happens when traits change.
@@ -75,6 +82,7 @@ function getGenomeSignature(genome: PlantGenomeData): string {
         genome.length_ratio,
         genome.branch_probability,
         genome.curve_factor,
+        genome.fractal_type ?? 'lsystem',
         genome.color_hue,
         genome.color_saturation,
         genome.stem_thickness,
@@ -89,6 +97,57 @@ function getGenomeSignature(genome: PlantGenomeData): string {
 function seededRandom(seed: number): number {
     const x = Math.sin(seed) * 10000;
     return x - Math.floor(x);
+}
+
+function generateMandelbrotTexture(genome: PlantGenomeData, cacheKey: number): HTMLCanvasElement {
+    const canvas = document.createElement('canvas');
+    const size = 140;
+    canvas.width = size;
+    canvas.height = size;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return canvas;
+
+    const imageData = ctx.createImageData(size, size);
+    const maxIterations = 40;
+    const baseHue = genome.color_hue ?? 0.6;
+    const saturation = genome.color_saturation ?? 0.8;
+
+    for (let py = 0; py < size; py++) {
+        const cy = (py / size) * 2.4 - 1.2; // Range [-1.2, 1.2]
+        for (let px = 0; px < size; px++) {
+            const cx = (px / size) * 3.0 - 2.1; // Range [-2.1, 0.9]
+            let zx = 0;
+            let zy = 0;
+            let iter = 0;
+
+            while (zx * zx + zy * zy <= 4 && iter < maxIterations) {
+                const temp = zx * zx - zy * zy + cx;
+                zy = 2 * zx * zy + cy;
+                zx = temp;
+                iter++;
+            }
+
+            const mix = iter / maxIterations;
+            const hue = (baseHue + mix * 0.25 + cacheKey * 0.0001) % 1;
+            const lightness = iter === maxIterations ? 0.1 : 0.25 + mix * 0.55;
+            const [r, g, b] = hslToRgbTuple(hue, saturation, lightness);
+
+            const maskX = (px - size / 2) / (size / 2);
+            const maskY = py / size;
+            let alpha = 1 - Math.pow(Math.abs(maskX), 1.4) * 0.55 - maskY * 0.1;
+            alpha = Math.max(0, Math.min(1, alpha));
+
+            const idx = (py * size + px) * 4;
+            imageData.data[idx] = r;
+            imageData.data[idx + 1] = g;
+            imageData.data[idx + 2] = b;
+            imageData.data[idx + 3] = Math.floor(alpha * 255);
+        }
+    }
+
+    ctx.putImageData(imageData, 0, 0);
+    return canvas;
 }
 
 /**
@@ -284,6 +343,31 @@ function hslToRgb(h: number, s: number, l: number): string {
     return `rgb(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)})`;
 }
 
+function hslToRgbTuple(h: number, s: number, l: number): [number, number, number] {
+    let r: number, g: number, b: number;
+
+    if (s === 0) {
+        r = g = b = l;
+    } else {
+        const hue2rgb = (p: number, q: number, t: number): number => {
+            if (t < 0) t += 1;
+            if (t > 1) t -= 1;
+            if (t < 1 / 6) return p + (q - p) * 6 * t;
+            if (t < 1 / 2) return q;
+            if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+            return p;
+        };
+
+        const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+        const p = 2 * l - q;
+        r = hue2rgb(p, q, h + 1 / 3);
+        g = hue2rgb(p, q, h);
+        b = hue2rgb(p, q, h - 1 / 3);
+    }
+
+    return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+}
+
 /**
  * Render a fractal plant to a canvas context.
  */
@@ -298,6 +382,21 @@ export function renderFractalPlant(
     elapsedTime: number,
     nectarReady: boolean = false
 ): void {
+    const fractalType = genome.fractal_type ?? 'lsystem';
+    if (fractalType === 'mandelbrot') {
+        renderMandelbrotPlant(
+            ctx,
+            plantId,
+            genome,
+            x,
+            y,
+            sizeMultiplier,
+            elapsedTime,
+            nectarReady
+        );
+        return;
+    }
+
     // Use plant id for caching so geometry stays stable even if position jitters
     const cacheKey = plantId;
     const genomeSignature = `${iterations}:${getGenomeSignature(genome)}`;
@@ -473,6 +572,81 @@ export function renderFractalPlant(
         ctx.strokeStyle = 'rgba(255, 255, 200, 0.8)';
         ctx.lineWidth = 1;
         ctx.stroke();
+    }
+
+    ctx.restore();
+}
+
+function renderMandelbrotPlant(
+    ctx: CanvasRenderingContext2D,
+    plantId: number,
+    genome: PlantGenomeData,
+    x: number,
+    y: number,
+    sizeMultiplier: number,
+    elapsedTime: number,
+    nectarReady: boolean
+): void {
+    const cacheKey = plantId;
+    const signature = getGenomeSignature(genome);
+    const cached = mandelbrotCache.get(cacheKey);
+
+    let texture: HTMLCanvasElement;
+
+    if (!cached || cached.signature !== signature) {
+        texture = generateMandelbrotTexture(genome, cacheKey);
+        mandelbrotCache.set(cacheKey, { signature, texture });
+    } else {
+        texture = cached.texture;
+    }
+
+    const baseWidth = 140;
+    const baseHeight = 160;
+    const width = baseWidth * sizeMultiplier;
+    const height = baseHeight * sizeMultiplier;
+
+    // Gentle sway
+    const sway = Math.sin(elapsedTime * 0.0009 + plantId * 0.7) * 3.5;
+
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate((sway * Math.PI) / 180);
+
+    // Draw glowing stem anchor
+    const [sr, sg, sb] = hslToRgbTuple(genome.color_hue ?? 0.6, genome.color_saturation ?? 0.85, 0.35);
+    const stemGradient = ctx.createLinearGradient(0, 0, 0, -height * 0.4);
+    stemGradient.addColorStop(0, `rgba(${sr}, ${sg}, ${sb}, 0.55)`);
+    stemGradient.addColorStop(1, `rgba(${sr}, ${sg}, ${sb}, 0.05)`);
+    ctx.fillStyle = stemGradient;
+    ctx.fillRect(-width * 0.08, -height, width * 0.16, height);
+
+    // Draw Mandelbrot texture
+    ctx.drawImage(texture, -width / 2, -height, width, height);
+
+    // Highlight aura
+    const [ar, ag, ab] = hslToRgbTuple(genome.color_hue ?? 0.6, genome.color_saturation ?? 0.85, 0.6);
+    const aura = ctx.createRadialGradient(0, -height * 0.8, 10, 0, -height * 0.8, width * 0.6);
+    aura.addColorStop(0, `rgba(${ar}, ${ag}, ${ab}, 0.35)`);
+    aura.addColorStop(1, `rgba(${ar}, ${ag}, ${ab}, 0)`);
+    ctx.fillStyle = aura;
+    ctx.fillRect(-width / 2, -height, width, height);
+
+    if (nectarReady) {
+        const pulse = 0.6 + Math.sin(elapsedTime * 0.005) * 0.25;
+        const topY = -height * 0.9;
+        ctx.beginPath();
+        const glow = ctx.createRadialGradient(0, topY, 4, 0, topY, 28);
+        glow.addColorStop(0, `rgba(255, 230, 150, ${pulse})`);
+        glow.addColorStop(0.6, `rgba(255, 200, 120, ${pulse * 0.7})`);
+        glow.addColorStop(1, 'rgba(255, 180, 100, 0)');
+        ctx.arc(0, topY, 16, 0, Math.PI * 2);
+        ctx.fillStyle = glow;
+        ctx.fill();
+
+        ctx.beginPath();
+        ctx.arc(0, topY, 7, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(255, 240, 200, ${0.7 + pulse * 0.3})`;
+        ctx.fill();
     }
 
     ctx.restore();


### PR DESCRIPTION
## Summary
- add a Mandelbrot-based fractal plant genome option with descriptive metadata
- render Mandelbrot plants with a colored texture, glow, and nectar indicator
- boost Mandelbrot variants with a 10% passive energy collection bonus and seed them into initial spawns

## Testing
- python -m pytest tests/test_visual_genetics.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225b31eed88331a5b2cdf7be8e2c70)