### PR TITLE
Add Codex Max plant fractal variant

### DIFF
--- a/core/entities/fractal_plant.py
+++ b/core/entities/fractal_plant.py
@@ -219,6 +219,13 @@ class FractalPlant(Agent):
 
         energy_gain *= reduction_factor
 
+        # Special variants have a small energy collection bonus
+        variant_type = getattr(self.genome, "fractal_type", "lsystem")
+        if variant_type == "mandelbrot":
+            energy_gain *= 1.1
+        elif variant_type == "codex_max":
+            energy_gain *= 1.12
+
         self.energy = min(self.max_energy, self.energy + energy_gain)
 
     def _try_produce_nectar(self, time_of_day: Optional[float]) -> Optional["PlantNectar"]:

--- a/core/entities/fractal_plant.py
+++ b/core/entities/fractal_plant.py
@@ -30,6 +30,13 @@ from core.constants import (
 )
 
 
+# Runtime bonuses per fractal variant to mirror the documented perks
+VARIANT_ENERGY_BONUS = {
+    "mandelbrot": 1.1,  # 10% more passive energy
+    "codex_max": 1.08,  # Slight efficiency edge
+}
+
+
 class FractalPlant(Agent):
     """A fractal plant entity with evolving L-system genetics.
 
@@ -190,13 +197,8 @@ class FractalPlant(Agent):
         # Base rate from genome
         base_rate = self.genome.base_energy_rate
 
-        # Variant-specific bonuses (resolve merge conflicts between genome description
-        # and runtime behavior by applying the promised perks here)
-        variant_bonus = 1.0
-        if self.genome.fractal_type == "mandelbrot":
-            variant_bonus = 1.1  # 10% more passive energy for Mandelbrot blooms
-        elif self.genome.fractal_type == "codex_max":
-            variant_bonus = 1.08  # Slight efficiency edge for Codex Max plants
+        # Variant-specific bonuses keep runtime behavior aligned with genome docs
+        variant_bonus = VARIANT_ENERGY_BONUS.get(self.genome.fractal_type, 1.0)
 
         # Compound growth factor: more energy = faster collection
         # Uses sqrt to prevent runaway growth

--- a/core/entities/fractal_plant.py
+++ b/core/entities/fractal_plant.py
@@ -190,13 +190,21 @@ class FractalPlant(Agent):
         # Base rate from genome
         base_rate = self.genome.base_energy_rate
 
+        # Variant-specific bonuses (resolve merge conflicts between genome description
+        # and runtime behavior by applying the promised perks here)
+        variant_bonus = 1.0
+        if self.genome.fractal_type == "mandelbrot":
+            variant_bonus = 1.1  # 10% more passive energy for Mandelbrot blooms
+        elif self.genome.fractal_type == "codex_max":
+            variant_bonus = 1.08  # Slight efficiency edge for Codex Max plants
+
         # Compound growth factor: more energy = faster collection
         # Uses sqrt to prevent runaway growth
         growth_factor = 1.0 + (self.energy / self.max_energy) ** 0.5 * 0.5
 
         # Time of day affects photosynthesis
         # Day = 1.0, Dawn/Dusk = 0.7, Night = 0.3
-        energy_gain = base_rate * growth_factor * time_modifier
+        energy_gain = base_rate * growth_factor * variant_bonus * time_modifier
 
         # Reduce energy production if neighboring root slots are occupied.
         # If both adjacent slots are full -> -50%, if one is full -> -25%.
@@ -218,13 +226,6 @@ class FractalPlant(Agent):
                 reduction_factor = 0.75
 
         energy_gain *= reduction_factor
-
-        # Special variants have a small energy collection bonus
-        variant_type = getattr(self.genome, "fractal_type", "lsystem")
-        if variant_type == "mandelbrot":
-            energy_gain *= 1.1
-        elif variant_type == "codex_max":
-            energy_gain *= 1.12
 
         self.energy = min(self.max_energy, self.energy + energy_gain)
 

--- a/core/plant_genetics.py
+++ b/core/plant_genetics.py
@@ -36,6 +36,9 @@ class PlantGenome:
         growth_efficiency: How much energy converts to size (0.5-1.5)
         nectar_threshold_ratio: Energy ratio to produce nectar (0.6-0.9)
 
+    Fractal Variants:
+        fractal_type: Rendering style for the plant's fractal (e.g., 'lsystem', 'mandelbrot', 'codex_max')
+
     Fitness:
         fitness_score: Accumulated fitness over lifetime
     """
@@ -62,6 +65,9 @@ class PlantGenome:
     base_energy_rate: float = 0.02
     growth_efficiency: float = 1.0
     nectar_threshold_ratio: float = 0.75
+
+    # Variant traits
+    fractal_type: str = "lsystem"
 
     # Fitness tracking
     fitness_score: float = field(default=0.0)
@@ -192,9 +198,83 @@ class PlantGenome:
             base_energy_rate=rng.uniform(0.01, 0.04),
             growth_efficiency=rng.uniform(0.6, 1.4),
             nectar_threshold_ratio=rng.uniform(0.6, 0.9),
+            fractal_type="lsystem",
         )
 
         # Generate production rules based on branch_probability
+        genome._production_rules = genome._generate_default_rules()
+
+        return genome
+
+    @classmethod
+    def create_mandelbrot_variant(
+        cls, rng: Optional["random.Random"] = None
+    ) -> "PlantGenome":
+        """Create a Mandelbrot-inspired plant genome.
+
+        This variant signals the renderer to use a Mandelbrot set visualization
+        and slightly boosts base energy traits to reflect its special status.
+        """
+        import random as random_module
+
+        rng = rng or random_module
+
+        genome = cls(
+            axiom="F",
+            angle=rng.uniform(20.0, 35.0),
+            length_ratio=rng.uniform(0.6, 0.8),
+            branch_probability=rng.uniform(0.7, 0.95),
+            curve_factor=rng.uniform(0.05, 0.2),
+            color_hue=rng.uniform(0.55, 0.75),
+            color_saturation=rng.uniform(0.6, 1.0),
+            stem_thickness=rng.uniform(0.9, 1.3),
+            leaf_density=rng.uniform(0.4, 0.8),
+            aggression=rng.uniform(0.2, 0.6),
+            bluff_frequency=rng.uniform(0.05, 0.25),
+            risk_tolerance=rng.uniform(0.3, 0.7),
+            base_energy_rate=rng.uniform(0.02, 0.045),
+            growth_efficiency=rng.uniform(0.9, 1.4),
+            nectar_threshold_ratio=rng.uniform(0.6, 0.85),
+            fractal_type="mandelbrot",
+        )
+
+        genome._production_rules = genome._generate_default_rules()
+
+        return genome
+
+    @classmethod
+    def create_codex_max_variant(
+        cls, rng: Optional["random.Random"] = None
+    ) -> "PlantGenome":
+        """Create a GPT-5.1-Codex-Max inspired fractal genome.
+
+        This variant leans into phyllotaxis spirals and glassy leaves to match
+        the Codex aesthetic while granting a modest efficiency edge.
+        """
+
+        import random as random_module
+
+        rng = rng or random_module
+
+        genome = cls(
+            axiom="F",
+            angle=rng.uniform(18.0, 32.0),
+            length_ratio=rng.uniform(0.62, 0.8),
+            branch_probability=rng.uniform(0.72, 0.95),
+            curve_factor=rng.uniform(0.08, 0.22),
+            color_hue=rng.uniform(0.5, 0.68),
+            color_saturation=rng.uniform(0.55, 0.95),
+            stem_thickness=rng.uniform(0.85, 1.25),
+            leaf_density=rng.uniform(0.45, 0.85),
+            aggression=rng.uniform(0.25, 0.65),
+            bluff_frequency=rng.uniform(0.05, 0.25),
+            risk_tolerance=rng.uniform(0.35, 0.75),
+            base_energy_rate=rng.uniform(0.022, 0.048),
+            growth_efficiency=rng.uniform(1.0, 1.5),
+            nectar_threshold_ratio=rng.uniform(0.58, 0.82),
+            fractal_type="codex_max",
+        )
+
         genome._production_rules = genome._generate_default_rules()
 
         return genome
@@ -247,6 +327,7 @@ class PlantGenome:
             base_energy_rate=mutate_float(parent.base_energy_rate, 0.01, 0.05),
             growth_efficiency=mutate_float(parent.growth_efficiency, 0.5, 1.5),
             nectar_threshold_ratio=mutate_float(parent.nectar_threshold_ratio, 0.6, 0.9),
+            fractal_type=parent.fractal_type,
             # Reset fitness
             fitness_score=0.0,
         )
@@ -384,6 +465,7 @@ class PlantGenome:
             "growth_efficiency": self.growth_efficiency,
             "nectar_threshold_ratio": self.nectar_threshold_ratio,
             "fitness_score": self.fitness_score,
+            "fractal_type": self.fractal_type,
             "production_rules": [
                 {"input": inp, "output": out, "prob": prob}
                 for inp, out, prob in self._production_rules
@@ -422,6 +504,7 @@ class PlantGenome:
             growth_efficiency=data.get("growth_efficiency", 1.0),
             nectar_threshold_ratio=data.get("nectar_threshold_ratio", 0.75),
             fitness_score=data.get("fitness_score", 0.0),
+            fractal_type=data.get("fractal_type", "lsystem"),
         )
 
         if rules:

--- a/core/plant_genetics.py
+++ b/core/plant_genetics.py
@@ -315,7 +315,9 @@ class PlantGenome:
             branch_probability=mutate_float(parent.branch_probability, 0.6, 1.0),
             curve_factor=mutate_float(parent.curve_factor, 0.0, 0.3),
             # Visual traits
-            color_hue=mutate_float(parent.color_hue, 0.2, 0.5),
+            # Allow broader hues so special variants (e.g., Mandelbrot or Codex Max)
+            # keep their distinctive palettes when reproducing.
+            color_hue=mutate_float(parent.color_hue, 0.2, 0.8),
             color_saturation=mutate_float(parent.color_saturation, 0.4, 1.0),
             stem_thickness=mutate_float(parent.stem_thickness, 0.5, 1.5),
             leaf_density=mutate_float(parent.leaf_density, 0.3, 1.0),

--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -176,8 +176,14 @@ class SimulationEngine(BaseSimulator):
             if spot is None:
                 break  # No more empty spots
 
-            # Create a random genome
-            genome = PlantGenome.create_random(rng=self.rng)
+            # Create a random genome, occasionally using special variants
+            roll = self.rng.random()
+            if roll < 0.2:
+                genome = PlantGenome.create_codex_max_variant(rng=self.rng)
+            elif roll < 0.45:
+                genome = PlantGenome.create_mandelbrot_variant(rng=self.rng)
+            else:
+                genome = PlantGenome.create_random(rng=self.rng)
 
             # Create the plant
             plant = FractalPlant(

--- a/frontend/src/utils/fractalPlant.ts
+++ b/frontend/src/utils/fractalPlant.ts
@@ -15,6 +15,7 @@ export interface PlantGenomeData {
     color_saturation: number;
     stem_thickness: number;
     leaf_density: number;
+    fractal_type?: 'lsystem' | 'mandelbrot' | 'codex_max';
     production_rules: Array<{
         input: string;
         output: string;
@@ -46,6 +47,11 @@ interface FractalLeaf {
     size: number;
 }
 
+interface MandelbrotCacheEntry {
+    signature: string;
+    texture: HTMLCanvasElement;
+}
+
 /**
  * Cache for plant rendering to avoid regenerating L-system every frame.
  */
@@ -60,6 +66,8 @@ interface PlantRenderCache {
 
 // Module-level cache keyed by plant id to avoid flickering when plants drift
 const plantCache = new Map<number, PlantRenderCache>();
+const mandelbrotCache = new Map<number, MandelbrotCacheEntry>();
+const codexBloomCache = new Map<number, MandelbrotCacheEntry>();
 
 /**
  * Create a stable signature for a genome so cache invalidation happens when traits change.
@@ -75,6 +83,7 @@ function getGenomeSignature(genome: PlantGenomeData): string {
         genome.length_ratio,
         genome.branch_probability,
         genome.curve_factor,
+        genome.fractal_type ?? 'lsystem',
         genome.color_hue,
         genome.color_saturation,
         genome.stem_thickness,
@@ -89,6 +98,194 @@ function getGenomeSignature(genome: PlantGenomeData): string {
 function seededRandom(seed: number): number {
     const x = Math.sin(seed) * 10000;
     return x - Math.floor(x);
+}
+
+function generateMandelbrotTexture(genome: PlantGenomeData, cacheKey: number): HTMLCanvasElement {
+    const canvas = document.createElement('canvas');
+    const size = 140;
+    canvas.width = size;
+    canvas.height = size;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return canvas;
+
+    const imageData = ctx.createImageData(size, size);
+    const maxIterations = 40;
+    const baseHue = genome.color_hue ?? 0.6;
+    const saturation = genome.color_saturation ?? 0.8;
+
+    for (let py = 0; py < size; py++) {
+        const cy = (py / size) * 2.4 - 1.2; // Range [-1.2, 1.2]
+        for (let px = 0; px < size; px++) {
+            const cx = (px / size) * 3.0 - 2.1; // Range [-2.1, 0.9]
+            let zx = 0;
+            let zy = 0;
+            let iter = 0;
+
+            while (zx * zx + zy * zy <= 4 && iter < maxIterations) {
+                const temp = zx * zx - zy * zy + cx;
+                zy = 2 * zx * zy + cy;
+                zx = temp;
+                iter++;
+            }
+
+            const mix = iter / maxIterations;
+            const hue = (baseHue + mix * 0.25 + cacheKey * 0.0001) % 1;
+            const lightness = iter === maxIterations ? 0.1 : 0.25 + mix * 0.55;
+            const [r, g, b] = hslToRgbTuple(hue, saturation, lightness);
+
+            const maskX = (px - size / 2) / (size / 2);
+            const maskY = py / size;
+            let alpha = 1 - Math.pow(Math.abs(maskX), 1.4) * 0.55 - maskY * 0.1;
+            alpha = Math.max(0, Math.min(1, alpha));
+
+            const idx = (py * size + px) * 4;
+            imageData.data[idx] = r;
+            imageData.data[idx + 1] = g;
+            imageData.data[idx + 2] = b;
+            imageData.data[idx + 3] = Math.floor(alpha * 255);
+        }
+    }
+
+    ctx.putImageData(imageData, 0, 0);
+
+    // Mask the harsh square into an organic blossom silhouette
+    ctx.save();
+    ctx.beginPath();
+    const centerX = size / 2;
+    const centerY = size * 0.58;
+    const baseRadius = size * 0.45;
+    // Create a wavy outline reminiscent of overlapping leaves
+    for (let i = 0; i <= 80; i++) {
+        const t = (i / 80) * Math.PI * 2;
+        const ripple = Math.sin(t * 3) * 0.1 + Math.sin(t * 6) * 0.05;
+        const radius = baseRadius * (0.82 + ripple);
+        const x = centerX + Math.cos(t) * radius;
+        const y = centerY + Math.sin(t) * radius * 0.9;
+        if (i === 0) {
+            ctx.moveTo(x, y);
+        } else {
+            ctx.lineTo(x, y);
+        }
+    }
+    ctx.closePath();
+    ctx.globalCompositeOperation = 'destination-in';
+    ctx.fillStyle = '#fff';
+    ctx.fill();
+
+    // Add a subtle leaf-vein impression to tie back to plants
+    ctx.globalCompositeOperation = 'overlay';
+    ctx.strokeStyle = `rgba(255, 255, 255, 0.08)`;
+    ctx.lineWidth = 2;
+    for (let branch = -2; branch <= 2; branch++) {
+        const offset = branch * 0.22 * baseRadius;
+        ctx.beginPath();
+        ctx.moveTo(centerX + offset * 0.2, centerY + baseRadius * 0.05);
+        ctx.quadraticCurveTo(
+            centerX + offset * 0.6,
+            centerY - baseRadius * 0.2,
+            centerX + offset,
+            centerY - baseRadius * 0.6
+        );
+        ctx.stroke();
+    }
+
+    ctx.restore();
+
+    // Soft edge halo to blend into the water background
+    const halo = ctx.createRadialGradient(centerX, centerY - baseRadius * 0.3, baseRadius * 0.2, centerX, centerY, baseRadius);
+    halo.addColorStop(0, 'rgba(255, 255, 255, 0.08)');
+    halo.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    ctx.fillStyle = halo;
+    ctx.globalCompositeOperation = 'lighter';
+    ctx.beginPath();
+    ctx.arc(centerX, centerY - baseRadius * 0.1, baseRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    return canvas;
+}
+
+function generateCodexMaxTexture(genome: PlantGenomeData, cacheKey: number): HTMLCanvasElement {
+    const canvas = document.createElement('canvas');
+    const size = 170;
+    canvas.width = size;
+    canvas.height = size;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return canvas;
+
+    const centerX = size / 2;
+    const centerY = size * 0.58;
+    const baseHue = genome.color_hue ?? 0.58;
+    const saturation = genome.color_saturation ?? 0.85;
+
+    // Misty background glow
+    const bg = ctx.createRadialGradient(centerX, centerY, size * 0.08, centerX, centerY, size * 0.65);
+    bg.addColorStop(0, `hsla(${baseHue * 360}, ${saturation * 100}%, 62%, 0.28)`);
+    bg.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, size, size);
+
+    // Phyllotaxis inspired petal tessellation
+    const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+    const totalPetals = 180;
+    for (let i = 0; i < totalPetals; i++) {
+        const t = i / totalPetals;
+        const angle = i * goldenAngle + cacheKey * 0.0002;
+        const radius = Math.pow(t, 0.6) * (size * 0.46);
+        const px = centerX + Math.cos(angle) * radius * 0.32;
+        const py = centerY - Math.sin(angle * 0.9) * radius * 0.4;
+
+        const pulse = 0.22 + Math.sin(i * 0.35) * 0.06;
+        const hue = (baseHue + 0.04 * Math.sin(i * 0.15)) % 1;
+        const lightness = 0.35 + t * 0.28 + pulse;
+        const [r, g, b] = hslToRgbTuple(hue, saturation, lightness);
+
+        ctx.save();
+        ctx.translate(px, py);
+        ctx.rotate(angle + Math.sin(i * 0.05) * 0.2);
+        ctx.beginPath();
+        const petalLength = size * 0.3 * (0.35 + Math.pow(1 - t, 0.5));
+        ctx.moveTo(0, 0);
+        ctx.quadraticCurveTo(size * 0.05, -petalLength * 0.35, 0, -petalLength);
+        ctx.quadraticCurveTo(-size * 0.05, -petalLength * 0.35, 0, 0);
+        ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${0.18 + (1 - t) * 0.4})`;
+        ctx.fill();
+        ctx.restore();
+    }
+
+    // Glassy vein overlay
+    ctx.save();
+    ctx.translate(centerX, centerY);
+    ctx.lineWidth = 1.5;
+    ctx.strokeStyle = `rgba(255, 255, 255, 0.18)`;
+    for (let i = 0; i < 10; i++) {
+        ctx.rotate(goldenAngle * 1.4);
+        ctx.beginPath();
+        ctx.moveTo(0, -size * 0.05);
+        ctx.quadraticCurveTo(size * 0.16, -size * 0.28, 0, -size * 0.55);
+        ctx.stroke();
+    }
+    ctx.restore();
+
+    // Central core
+    const [cr, cg, cb] = hslToRgbTuple(baseHue, saturation, 0.72);
+    const core = ctx.createRadialGradient(centerX, centerY - size * 0.12, 6, centerX, centerY - size * 0.12, 32);
+    core.addColorStop(0, `rgba(${cr}, ${cg}, ${cb}, 0.9)`);
+    core.addColorStop(1, `rgba(${cr}, ${cg}, ${cb}, 0)`);
+    ctx.fillStyle = core;
+    ctx.beginPath();
+    ctx.arc(centerX, centerY - size * 0.12, 26, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Aura rim
+    ctx.lineWidth = 2.5;
+    ctx.strokeStyle = `rgba(${cr}, ${cg}, ${cb}, 0.3)`;
+    ctx.beginPath();
+    ctx.ellipse(centerX, centerY - size * 0.12, size * 0.38, size * 0.32, 0, 0, Math.PI * 2);
+    ctx.stroke();
+
+    return canvas;
 }
 
 /**
@@ -284,6 +481,31 @@ function hslToRgb(h: number, s: number, l: number): string {
     return `rgb(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)})`;
 }
 
+function hslToRgbTuple(h: number, s: number, l: number): [number, number, number] {
+    let r: number, g: number, b: number;
+
+    if (s === 0) {
+        r = g = b = l;
+    } else {
+        const hue2rgb = (p: number, q: number, t: number): number => {
+            if (t < 0) t += 1;
+            if (t > 1) t -= 1;
+            if (t < 1 / 6) return p + (q - p) * 6 * t;
+            if (t < 1 / 2) return q;
+            if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+            return p;
+        };
+
+        const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+        const p = 2 * l - q;
+        r = hue2rgb(p, q, h + 1 / 3);
+        g = hue2rgb(p, q, h);
+        b = hue2rgb(p, q, h - 1 / 3);
+    }
+
+    return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+}
+
 /**
  * Render a fractal plant to a canvas context.
  */
@@ -298,6 +520,35 @@ export function renderFractalPlant(
     elapsedTime: number,
     nectarReady: boolean = false
 ): void {
+    const fractalType = genome.fractal_type ?? 'lsystem';
+    if (fractalType === 'mandelbrot') {
+        renderMandelbrotPlant(
+            ctx,
+            plantId,
+            genome,
+            x,
+            y,
+            sizeMultiplier,
+            elapsedTime,
+            nectarReady
+        );
+        return;
+    }
+
+    if (fractalType === 'codex_max') {
+        renderCodexMaxPlant(
+            ctx,
+            plantId,
+            genome,
+            x,
+            y,
+            sizeMultiplier,
+            elapsedTime,
+            nectarReady
+        );
+        return;
+    }
+
     // Use plant id for caching so geometry stays stable even if position jitters
     const cacheKey = plantId;
     const genomeSignature = `${iterations}:${getGenomeSignature(genome)}`;
@@ -473,6 +724,222 @@ export function renderFractalPlant(
         ctx.strokeStyle = 'rgba(255, 255, 200, 0.8)';
         ctx.lineWidth = 1;
         ctx.stroke();
+    }
+
+    ctx.restore();
+}
+
+function renderCodexMaxPlant(
+    ctx: CanvasRenderingContext2D,
+    plantId: number,
+    genome: PlantGenomeData,
+    x: number,
+    y: number,
+    sizeMultiplier: number,
+    elapsedTime: number,
+    nectarReady: boolean
+): void {
+    const cacheKey = plantId;
+    const signature = getGenomeSignature(genome);
+    const cached = codexBloomCache.get(cacheKey);
+
+    let texture: HTMLCanvasElement;
+
+    if (!cached || cached.signature !== signature) {
+        texture = generateCodexMaxTexture(genome, cacheKey);
+        codexBloomCache.set(cacheKey, { signature, texture });
+    } else {
+        texture = cached.texture;
+    }
+
+    const baseWidth = 150;
+    const baseHeight = 190;
+    const width = baseWidth * sizeMultiplier;
+    const height = baseHeight * sizeMultiplier;
+
+    const sway = Math.sin(elapsedTime * 0.0011 + plantId * 0.61) * 4.5;
+    const bloomSpin = Math.sin(elapsedTime * 0.0007 + plantId * 0.45) * 0.25;
+
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate((sway * Math.PI) / 180);
+
+    // Twin helix stems for a techy botanical profile
+    const [sr, sg, sb] = hslToRgbTuple(genome.color_hue ?? 0.55, genome.color_saturation ?? 0.88, 0.32);
+    ctx.lineWidth = width * 0.05;
+    ctx.lineCap = 'round';
+    ctx.strokeStyle = `rgba(${sr}, ${sg}, ${sb}, 0.6)`;
+    ctx.beginPath();
+    ctx.moveTo(-width * 0.06, 0);
+    ctx.quadraticCurveTo(-width * 0.12, -height * 0.45, 0, -height * 0.82);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(width * 0.06, 0);
+    ctx.quadraticCurveTo(width * 0.14, -height * 0.38, 0, -height * 0.78);
+    ctx.stroke();
+
+    // Side fronds hugging the bloom
+    ctx.fillStyle = `rgba(${sr}, ${sg}, ${sb}, 0.45)`;
+    for (let i = -2; i <= 2; i++) {
+        const angle = (i * 14 * Math.PI) / 180;
+        const frondHeight = height * (0.12 + Math.abs(i) * 0.04);
+        ctx.save();
+        ctx.translate(0, -height * 0.35 + i * 10);
+        ctx.rotate(angle);
+        ctx.beginPath();
+        ctx.ellipse(width * 0.22, -frondHeight * 0.08, width * 0.18, frondHeight, 16 * (Math.PI / 180), 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+    }
+
+    // Leafy collar around the blossom
+    const collar = ctx.createLinearGradient(-width * 0.3, -height * 0.55, width * 0.3, -height * 0.1);
+    collar.addColorStop(0, `rgba(${sr}, ${sg}, ${sb}, 0.25)`);
+    collar.addColorStop(1, `rgba(${sr}, ${sg}, ${sb}, 0.05)`);
+    ctx.fillStyle = collar;
+    ctx.beginPath();
+    ctx.ellipse(0, -height * 0.55, width * 0.45, height * 0.2, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Draw Codex bloom texture with a slow spin
+    ctx.save();
+    ctx.translate(0, -height * 0.75);
+    ctx.rotate(bloomSpin);
+    ctx.drawImage(texture, -width / 2, -height * 0.5, width, height * 0.95);
+    ctx.restore();
+
+    // Halo hinting at AI circuitry
+    const [ar, ag, ab] = hslToRgbTuple(genome.color_hue ?? 0.55, genome.color_saturation ?? 0.88, 0.6);
+    const aura = ctx.createRadialGradient(0, -height * 0.9, 10, 0, -height * 0.9, width * 0.8);
+    aura.addColorStop(0, `rgba(${ar}, ${ag}, ${ab}, 0.32)`);
+    aura.addColorStop(0.5, `rgba(${ar}, ${ag}, ${ab}, 0.12)`);
+    aura.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    ctx.fillStyle = aura;
+    ctx.fillRect(-width / 2, -height * 1.05, width, height * 1.1);
+
+    if (nectarReady) {
+        const pulse = 0.65 + Math.sin(elapsedTime * 0.006) * 0.25;
+        const topY = -height * 0.96;
+        ctx.beginPath();
+        const glow = ctx.createRadialGradient(0, topY, 4, 0, topY, 30);
+        glow.addColorStop(0, `rgba(235, 245, 200, ${pulse})`);
+        glow.addColorStop(0.6, `rgba(200, 245, 220, ${pulse * 0.6})`);
+        glow.addColorStop(1, 'rgba(180, 230, 255, 0)');
+        ctx.arc(0, topY, 17, 0, Math.PI * 2);
+        ctx.fillStyle = glow;
+        ctx.fill();
+
+        ctx.beginPath();
+        ctx.arc(0, topY, 8, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(255, 255, 240, ${0.7 + pulse * 0.25})`;
+        ctx.fill();
+    }
+
+    ctx.restore();
+}
+
+function renderMandelbrotPlant(
+    ctx: CanvasRenderingContext2D,
+    plantId: number,
+    genome: PlantGenomeData,
+    x: number,
+    y: number,
+    sizeMultiplier: number,
+    elapsedTime: number,
+    nectarReady: boolean
+): void {
+    const cacheKey = plantId;
+    const signature = getGenomeSignature(genome);
+    const cached = mandelbrotCache.get(cacheKey);
+
+    let texture: HTMLCanvasElement;
+
+    if (!cached || cached.signature !== signature) {
+        texture = generateMandelbrotTexture(genome, cacheKey);
+        mandelbrotCache.set(cacheKey, { signature, texture });
+    } else {
+        texture = cached.texture;
+    }
+
+    const baseWidth = 140;
+    const baseHeight = 160;
+    const width = baseWidth * sizeMultiplier;
+    const height = baseHeight * sizeMultiplier;
+
+    // Gentle sway
+    const sway = Math.sin(elapsedTime * 0.0009 + plantId * 0.7) * 3.5;
+
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate((sway * Math.PI) / 180);
+
+    // Draw glowing stem anchor with a subtle vine curl
+    const [sr, sg, sb] = hslToRgbTuple(genome.color_hue ?? 0.6, genome.color_saturation ?? 0.85, 0.35);
+    const stemGradient = ctx.createLinearGradient(0, 0, 0, -height * 0.45);
+    stemGradient.addColorStop(0, `rgba(${sr}, ${sg}, ${sb}, 0.7)`);
+    stemGradient.addColorStop(1, `rgba(${sr}, ${sg}, ${sb}, 0.1)`);
+    ctx.fillStyle = stemGradient;
+    ctx.fillRect(-width * 0.07, -height * 0.95, width * 0.14, height * 0.95);
+
+    ctx.strokeStyle = `rgba(${sr}, ${sg}, ${sb}, 0.35)`;
+    ctx.lineWidth = width * 0.04;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(0, -height * 0.1);
+    ctx.quadraticCurveTo(width * 0.12, -height * 0.4, 0, -height * 0.7);
+    ctx.stroke();
+
+    // Leaf fronds hugging the Mandelbrot bloom
+    ctx.fillStyle = `rgba(${sr}, ${sg}, ${sb}, 0.35)`;
+    for (let i = -2; i <= 2; i++) {
+        const angle = (i * 12 * Math.PI) / 180;
+        const leafHeight = height * 0.18 + Math.abs(i) * 4;
+        ctx.save();
+        ctx.translate(0, -height * 0.35 + i * 10);
+        ctx.rotate(angle);
+        ctx.beginPath();
+        ctx.ellipse(
+            width * 0.14,
+            -leafHeight * 0.15,
+            width * 0.12,
+            leafHeight,
+            12 * (Math.PI / 180),
+            0,
+            Math.PI * 2
+        );
+        ctx.fill();
+        ctx.restore();
+    }
+
+    // Draw Mandelbrot texture
+    ctx.drawImage(texture, -width / 2, -height, width, height);
+
+    // Highlight aura with a softer botanical glow
+    const [ar, ag, ab] = hslToRgbTuple(genome.color_hue ?? 0.6, genome.color_saturation ?? 0.85, 0.58);
+    const aura = ctx.createRadialGradient(0, -height * 0.8, 12, 0, -height * 0.82, width * 0.7);
+    aura.addColorStop(0, `rgba(${ar}, ${ag}, ${ab}, 0.28)`);
+    aura.addColorStop(0.4, `rgba(${ar}, ${ag}, ${ab}, 0.12)`);
+    aura.addColorStop(1, `rgba(${ar}, ${ag}, ${ab}, 0)`);
+    ctx.fillStyle = aura;
+    ctx.fillRect(-width / 2, -height, width, height);
+
+    if (nectarReady) {
+        const pulse = 0.6 + Math.sin(elapsedTime * 0.005) * 0.25;
+        const topY = -height * 0.9;
+        ctx.beginPath();
+        const glow = ctx.createRadialGradient(0, topY, 4, 0, topY, 28);
+        glow.addColorStop(0, `rgba(255, 230, 150, ${pulse})`);
+        glow.addColorStop(0.6, `rgba(255, 200, 120, ${pulse * 0.7})`);
+        glow.addColorStop(1, 'rgba(255, 180, 100, 0)');
+        ctx.arc(0, topY, 16, 0, Math.PI * 2);
+        ctx.fillStyle = glow;
+        ctx.fill();
+
+        ctx.beginPath();
+        ctx.arc(0, topY, 7, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(255, 240, 200, ${0.7 + pulse * 0.3})`;
+        ctx.fill();
     }
 
     ctx.restore();


### PR DESCRIPTION
## Summary
- add a Codex Max genome variant with bespoke trait ranges, spawn weighting, and a small energy perk
- render the Codex Max plant as a luminous phyllotaxis bloom with twin-helix stems and cached textures
- extend frontend fractal utilities to generate and draw the new Codex Max fractal style

## Testing
- python -m pytest tests/test_visual_genetics.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225b31eed88331a5b2cdf7be8e2c70)