### PR TITLE
Block plant root spots under static obstacles

### DIFF
--- a/core/entities/base.py
+++ b/core/entities/base.py
@@ -104,6 +104,9 @@ class Agent:
         self.width: float = DEFAULT_AGENT_SIZE  # Default size
         self.height: float = DEFAULT_AGENT_SIZE
 
+        # Whether this entity should block fractal plant root spots beneath it
+        self.blocks_root_spots: bool = False
+
         # Test compatibility attributes
         self.rect: Rect = Rect(x, y, self.width, self.height)
         self.image: Optional[object] = None  # Placeholder for test compatibility
@@ -258,6 +261,7 @@ class Castle(Agent):
             screen_height: Height of simulation area
         """
         super().__init__(environment, x, y, 0, screen_width, screen_height)
+        self.blocks_root_spots = True
         # Make castle 50% larger than previous size (was 150x150 -> now 225x225)
         # Use set_size to keep the collision rect in sync
         self.set_size(225.0, 225.0)

--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -154,6 +154,7 @@ class SimulationEngine(BaseSimulator):
 
         # Create initial fractal plants
         if FRACTAL_PLANTS_ENABLED and self.root_spot_manager is not None:
+            self._block_root_spots_with_obstacles()
             self.create_initial_fractal_plants()
 
     def create_initial_entities(self) -> None:
@@ -166,6 +167,15 @@ class SimulationEngine(BaseSimulator):
             self.environment, self.ecosystem, SCREEN_WIDTH, SCREEN_HEIGHT, rng=self.rng
         )
         self.entities_list.extend(population)
+
+    def _block_root_spots_with_obstacles(self) -> None:
+        """Prevent plants from spawning where static obstacles live."""
+
+        if self.root_spot_manager is None:
+            return
+
+        for entity in self.entities_list:
+            self.root_spot_manager.block_spots_for_entity(entity, padding=10.0)
 
     def _get_fractal_variant_counts(self) -> Dict[str, int]:
         """Count how many plants of each LLM variant are present."""
@@ -325,6 +335,9 @@ class SimulationEngine(BaseSimulator):
         # Add to spatial grid incrementally
         if self.environment:
             self.environment.add_agent_to_grid(entity)
+        # Prevent future plants from spawning under blocking obstacles
+        if self.root_spot_manager:
+            self.root_spot_manager.block_spots_for_entity(entity, padding=10.0)
         # Invalidate cached lists
         self._cache_dirty = True
 


### PR DESCRIPTION
## Summary
- add a blocks_root_spots flag so castles mark nearby plant root sites as unavailable
- teach the root spot manager to track blocked sites and ignore them when selecting spots
- block root spots when obstacles are added before spawning initial fractal plants

## Testing
- python -m pytest tests/test_vector2.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692287a31c6883319a01825baff6f306)