### PR TITLE
Add Tank World Network registration system

### DIFF
--- a/backend/simulation_manager.py
+++ b/backend/simulation_manager.py
@@ -1,0 +1,231 @@
+"""Simulation manager for coordinating tank simulations.
+
+This module provides the SimulationManager class which manages simulation
+lifecycle, client connections, and prepares for future multi-tank support
+in Tank World Net.
+"""
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Optional, Set
+
+from fastapi import WebSocket
+
+from backend.simulation_runner import SimulationRunner
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TankInfo:
+    """Metadata about a tank simulation.
+
+    This dataclass holds identifying information about a tank that will be
+    used for network registration and discovery in Tank World Net.
+    """
+
+    tank_id: str
+    name: str
+    description: str = ""
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    owner: Optional[str] = None
+
+    # Network visibility settings (for future use)
+    is_public: bool = True
+    allow_transfers: bool = False  # Allow fish/plants to transfer between tanks
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize tank info for API responses."""
+        return {
+            "tank_id": self.tank_id,
+            "name": self.name,
+            "description": self.description,
+            "created_at": self.created_at.isoformat(),
+            "owner": self.owner,
+            "is_public": self.is_public,
+            "allow_transfers": self.allow_transfers,
+        }
+
+
+class SimulationManager:
+    """Manages a tank simulation and its connected clients.
+
+    This class encapsulates the lifecycle management of a simulation,
+    including starting/stopping, client tracking, and state retrieval.
+    Designed to support future multi-tank scenarios in Tank World Net.
+    """
+
+    def __init__(
+        self,
+        tank_name: str = "Local Tank",
+        tank_description: str = "A local fish tank simulation",
+        seed: Optional[int] = None,
+    ):
+        """Initialize the simulation manager.
+
+        Args:
+            tank_name: Human-readable name for this tank
+            tank_description: Description of this tank
+            seed: Optional random seed for deterministic behavior
+        """
+        # Generate unique tank ID
+        self.tank_info = TankInfo(
+            tank_id=str(uuid.uuid4()),
+            name=tank_name,
+            description=tank_description,
+        )
+
+        # Create simulation runner
+        self._runner = SimulationRunner(seed=seed)
+
+        # Track connected WebSocket clients
+        self._connected_clients: Set[WebSocket] = set()
+
+        logger.info(
+            "SimulationManager initialized: tank_id=%s, name=%s",
+            self.tank_info.tank_id,
+            self.tank_info.name,
+        )
+
+    @property
+    def tank_id(self) -> str:
+        """Get the unique tank identifier."""
+        return self.tank_info.tank_id
+
+    @property
+    def runner(self) -> SimulationRunner:
+        """Access the underlying simulation runner."""
+        return self._runner
+
+    @property
+    def world(self):
+        """Access the TankWorld instance."""
+        return self._runner.world
+
+    @property
+    def running(self) -> bool:
+        """Check if the simulation is running."""
+        return self._runner.running
+
+    @property
+    def connected_clients(self) -> Set[WebSocket]:
+        """Get the set of connected WebSocket clients."""
+        return self._connected_clients
+
+    @property
+    def client_count(self) -> int:
+        """Get the number of connected clients."""
+        return len(self._connected_clients)
+
+    def start(self, start_paused: bool = False) -> None:
+        """Start the simulation.
+
+        Args:
+            start_paused: Whether to start in paused state
+        """
+        logger.info("Starting simulation for tank %s", self.tank_id)
+        self._runner.start(start_paused=start_paused)
+
+    def stop(self) -> None:
+        """Stop the simulation."""
+        logger.info("Stopping simulation for tank %s", self.tank_id)
+        self._runner.stop()
+
+    def add_client(self, websocket: WebSocket) -> None:
+        """Register a new WebSocket client.
+
+        Args:
+            websocket: The WebSocket connection to track
+        """
+        self._connected_clients.add(websocket)
+        logger.info(
+            "Client added to tank %s. Total clients: %d",
+            self.tank_id,
+            self.client_count,
+        )
+
+    def remove_client(self, websocket: WebSocket) -> None:
+        """Unregister a WebSocket client.
+
+        Args:
+            websocket: The WebSocket connection to remove
+        """
+        self._connected_clients.discard(websocket)
+        logger.info(
+            "Client removed from tank %s. Total clients: %d",
+            self.tank_id,
+            self.client_count,
+        )
+
+    def get_state(self, force_full: bool = False, allow_delta: bool = True):
+        """Get current simulation state.
+
+        Args:
+            force_full: Force a full state update
+            allow_delta: Allow delta compression
+
+        Returns:
+            State payload with tank_id included
+        """
+        state = self._runner.get_state(force_full=force_full, allow_delta=allow_delta)
+        # Inject tank_id for network identification
+        state.tank_id = self.tank_id
+        return state
+
+    async def get_state_async(self, force_full: bool = False, allow_delta: bool = True):
+        """Async wrapper for get_state.
+
+        Args:
+            force_full: Force a full state update
+            allow_delta: Allow delta compression
+
+        Returns:
+            State payload with tank_id included
+        """
+        state = await self._runner.get_state_async(
+            force_full=force_full, allow_delta=allow_delta
+        )
+        # Inject tank_id for network identification
+        state.tank_id = self.tank_id
+        return state
+
+    def serialize_state(self, state) -> bytes:
+        """Serialize state payload to bytes.
+
+        Args:
+            state: State payload to serialize
+
+        Returns:
+            Serialized bytes
+        """
+        return self._runner.serialize_state(state)
+
+    async def handle_command_async(
+        self, command: str, data: Optional[Dict[str, Any]] = None
+    ):
+        """Handle a command from a client.
+
+        Args:
+            command: Command type
+            data: Optional command data
+
+        Returns:
+            Command result
+        """
+        return await self._runner.handle_command_async(command, data)
+
+    def get_status(self) -> Dict[str, Any]:
+        """Get current tank status for API responses.
+
+        Returns:
+            Dictionary with tank status information
+        """
+        return {
+            "tank": self.tank_info.to_dict(),
+            "running": self.running,
+            "client_count": self.client_count,
+            "frame": self.world.frame_count if self.running else 0,
+            "paused": self.world.paused if self.running else True,
+        }

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -60,8 +60,6 @@ class SimulationRunner:
 
         # Target frame rate
         self.fps = FRAME_RATE
-        # Target frame rate
-        self.fps = FRAME_RATE
         self.frame_time = 1.0 / self.fps
         self.fast_forward = False
 
@@ -826,7 +824,8 @@ class SimulationRunner:
                 self.fast_forward = enabled
                 logger.info(f"Fast forward {'enabled' if enabled else 'disabled'}")
 
-
+            elif command == "start_poker":
+                # Start a new poker game with top 3 fish
                 logger.info("Starting human poker game...")
                 try:
                     # Get top 3 fish from leaderboard

--- a/backend/state_payloads.py
+++ b/backend/state_payloads.py
@@ -249,11 +249,13 @@ class FullStatePayload:
     poker_leaderboard: List[PokerLeaderboardEntryPayload]
     auto_evaluation: Optional[AutoEvaluateStatsPayload] = None
     type: str = "update"
+    tank_id: Optional[str] = None  # Tank World Net identifier
 
     def to_dict(self) -> Dict[str, Any]:
         return _compact_dict(
             {
                 "type": self.type,
+                "tank_id": self.tank_id,
                 "frame": self.frame,
                 "elapsed_time": self.elapsed_time,
                 "entities": [e.to_full_dict() for e in self.entities],
@@ -282,11 +284,13 @@ class DeltaStatePayload:
     poker_events: List[PokerEventPayload]
     stats: Optional[StatsPayload]
     type: str = "delta"
+    tank_id: Optional[str] = None  # Tank World Net identifier
 
     def to_dict(self) -> Dict[str, Any]:
         return _compact_dict(
             {
                 "type": self.type,
+                "tank_id": self.tank_id,
                 "frame": self.frame,
                 "elapsed_time": self.elapsed_time,
                 "updates": self.updates,

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,91 @@
+/**
+ * Configuration for Tank World frontend
+ *
+ * This module provides centralized configuration for the application,
+ * preparing for Tank World Net where users can connect to remote tanks.
+ */
+
+/**
+ * Determine WebSocket URL based on environment
+ *
+ * Priority order:
+ * 1. URL query parameter (?server=ws://...)
+ * 2. Environment variable (VITE_WS_URL)
+ * 3. Default to same host as page (for local development)
+ */
+function getWebSocketUrl(): string {
+  // Check URL query parameter for remote tank connection
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    const serverUrl = params.get('server');
+    if (serverUrl) {
+      return serverUrl;
+    }
+  }
+
+  // Check environment variable
+  const envUrl = import.meta.env.VITE_WS_URL;
+  if (envUrl) {
+    return envUrl;
+  }
+
+  // Default: connect to same host as the page
+  if (typeof window !== 'undefined') {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const host = window.location.hostname;
+    const port = import.meta.env.VITE_WS_PORT || '8000';
+    return `${protocol}//${host}:${port}/ws`;
+  }
+
+  // Fallback for SSR or tests
+  return 'ws://localhost:8000/ws';
+}
+
+/**
+ * Determine API base URL based on environment
+ */
+function getApiBaseUrl(): string {
+  // Check URL query parameter
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    const serverUrl = params.get('server');
+    if (serverUrl) {
+      // Convert ws:// to http://
+      return serverUrl.replace(/^wss?:/, 'http:').replace(/\/ws$/, '');
+    }
+  }
+
+  // Check environment variable
+  const envUrl = import.meta.env.VITE_API_URL;
+  if (envUrl) {
+    return envUrl;
+  }
+
+  // Default: connect to same host as the page
+  if (typeof window !== 'undefined') {
+    const host = window.location.hostname;
+    const port = import.meta.env.VITE_API_PORT || '8000';
+    return `http://${host}:${port}`;
+  }
+
+  // Fallback
+  return 'http://localhost:8000';
+}
+
+export const config = {
+  /** WebSocket URL for real-time simulation updates */
+  wsUrl: getWebSocketUrl(),
+
+  /** API base URL for HTTP endpoints */
+  apiBaseUrl: getApiBaseUrl(),
+
+  /** WebSocket reconnect delay in milliseconds */
+  wsReconnectDelay: 3000,
+
+  /** Get the current server URL (for display purposes) */
+  get serverDisplay(): string {
+    return this.apiBaseUrl.replace(/^https?:\/\//, '');
+  },
+} as const;
+
+export type Config = typeof config;

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -4,9 +4,7 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 import type { SimulationUpdate, Command, CommandResponse, DeltaUpdate } from '../types/simulation';
-
-const WS_URL = 'ws://localhost:8000/ws';
-const WS_RECONNECT_DELAY = 3000; // 3 seconds
+import { config } from '../config';
 
 export function useWebSocket() {
     const [state, setState] = useState<SimulationUpdate | null>(null);
@@ -18,7 +16,7 @@ export function useWebSocket() {
 
     const connect = useCallback(() => {
         try {
-            const ws = new WebSocket(WS_URL);
+            const ws = new WebSocket(config.wsUrl);
             ws.binaryType = 'arraybuffer';
 
             ws.onopen = () => {
@@ -64,7 +62,7 @@ export function useWebSocket() {
                     if (connectRef.current) {
                         connectRef.current();
                     }
-                }, WS_RECONNECT_DELAY);
+                }, config.wsReconnectDelay);
             };
 
             wsRef.current = ws;
@@ -129,6 +127,10 @@ export function useWebSocket() {
         isConnected,
         sendCommand,
         sendCommandWithResponse,
+        /** Current server URL for display */
+        serverUrl: config.serverDisplay,
+        /** Current tank ID (from state) */
+        tankId: state?.tank_id ?? null,
     };
 }
 
@@ -153,6 +155,7 @@ function applyDelta(state: SimulationUpdate, delta: DeltaUpdate): SimulationUpda
 
     return {
         ...state,
+        tank_id: delta.tank_id ?? state.tank_id,
         frame: delta.frame,
         elapsed_time: delta.elapsed_time,
         entities: Array.from(entityMap.values()),

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -196,6 +196,7 @@ export interface StatsData {
 
 export interface SimulationUpdate {
     type: 'update';
+    tank_id?: string;  // Tank World Net identifier
     frame: number;
     elapsed_time: number;
     entities: EntityData[];
@@ -207,6 +208,7 @@ export interface SimulationUpdate {
 
 export interface DeltaUpdate {
     type: 'delta';
+    tank_id?: string;  // Tank World Net identifier
     frame: number;
     elapsed_time: number;
     updates: Pick<EntityData, 'id' | 'x' | 'y' | 'vel_x' | 'vel_y' | 'poker_effect_state'>[];


### PR DESCRIPTION
Add foundational architecture for multi-tank network support:

- Create SimulationManager class to encapsulate simulation lifecycle, client tracking, and tank metadata (backend/simulation_manager.py)
- Add TankInfo dataclass for tank identification and network settings
- Add tank_id field to FullStatePayload and DeltaStatePayload for network identification of which tank data belongs to
- Add /api/tank/info endpoint for tank metadata retrieval
- Create frontend config.ts for configurable WebSocket URL supporting:
  - URL query parameter (?server=ws://...)
  - Environment variable (VITE_WS_URL)
  - Auto-detect from page host
- Update useWebSocket hook to use config and expose serverUrl/tankId
- Update TypeScript types to include tank_id in state updates

This prepares the codebase for Tank World Net where simulations can register with a central service and users can view tanks across devices.