### PR TITLE
Plan Tank World Network next steps and testing

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,12 +25,37 @@ The server will start on `http://localhost:8000`
 
 ### HTTP Endpoints
 
-- `GET /` - API information
+- `GET /` - API information (includes Tank World Net status)
 - `GET /health` - Health check with simulation stats
+- `GET /api/tank/info` - Get default tank metadata (backwards compatible)
+- `GET /api/lineage` - Get phylogenetic lineage data for default tank
 
-### WebSocket Endpoint
+### Tank World Net - Multi-Tank API
 
-- `WS /ws` - Real-time simulation updates and commands
+Tank World Net enables running multiple independent tank simulations on a single server:
+
+- `GET /api/tanks` - List all tanks in the registry
+- `POST /api/tanks?name=...&description=...` - Create a new tank
+- `GET /api/tanks/{tank_id}` - Get specific tank info
+- `DELETE /api/tanks/{tank_id}` - Remove a tank
+- `GET /api/tanks/{tank_id}/lineage` - Get lineage for specific tank
+
+**Query Parameters for POST /api/tanks:**
+- `name` (required): Human-readable tank name
+- `description`: Tank description
+- `seed`: Random seed for deterministic behavior
+- `owner`: Owner identifier
+- `is_public`: Whether tank is publicly visible (default: true)
+- `allow_transfers`: Enable entity transfers between tanks (default: false)
+
+### WebSocket Endpoints
+
+- `WS /ws` - Connect to default tank (backwards compatible)
+- `WS /ws/{tank_id}` - Connect to a specific tank by ID
+
+**Frontend URL Parameters:**
+- `?tank={tank_id}` - Connect to a specific tank
+- `?server=ws://host:port` - Connect to a remote server
 
 ## WebSocket Protocol
 

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -5,7 +5,7 @@ import logging
 import threading
 import time
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import orjson
 
@@ -67,11 +67,11 @@ class SimulationRunner:
         # Cache state and only rebuild every N frames (reduces from 30 FPS to 15 FPS)
         self.websocket_update_interval = 2  # Send every 2 frames
         self.frames_since_websocket_update = 0
-        self._cached_state: Optional[FullStatePayload | DeltaStatePayload] = None
+        self._cached_state: Optional[Union[FullStatePayload, DeltaStatePayload]] = None
         self._cached_state_frame: Optional[int] = None
         self.delta_sync_interval = 30
         self._last_full_frame: Optional[int] = None
-        self._last_entities: dict[int, EntitySnapshot] = {}
+        self._last_entities: Dict[int, EntitySnapshot] = {}
 
         # Human poker game management
         self.human_poker_game: Optional[HumanPokerGame] = None
@@ -80,8 +80,8 @@ class SimulationRunner:
         self.standard_poker_series: Optional[AutoEvaluatePokerGame] = None
 
         # Ongoing auto-evaluation against static baseline
-        self.auto_eval_history: list[dict[str, Any]] = []
-        self.auto_eval_stats: Optional[dict[str, Any]] = None
+        self.auto_eval_history: List[Dict[str, Any]] = []
+        self.auto_eval_stats: Optional[Dict[str, Any]] = None
         self.auto_eval_running: bool = False
         self.auto_eval_interval_seconds = 60.0
         self.last_auto_eval_time = 0.0
@@ -273,7 +273,7 @@ class SimulationRunner:
             # Still allow benchmarking if we have strong plants even when fish leaderboard is empty
             pass
 
-        plant_players: list[Dict[str, Any]] = []
+        plant_players: List[Dict[str, Any]] = []
         if plant_list:
             ranked_plants = sorted(
                 plant_list,
@@ -299,7 +299,7 @@ class SimulationRunner:
             daemon=True,
         ).start()
 
-    def _run_auto_evaluation(self, benchmark_players: list[dict[str, Any]]):
+    def _run_auto_evaluation(self, benchmark_players: List[Dict[str, Any]]):
         """Execute a background auto-evaluation series."""
 
         try:
@@ -422,7 +422,7 @@ class SimulationRunner:
             None, self.get_state, force_full, allow_delta
         )
 
-    def serialize_state(self, state: FullStatePayload | DeltaStatePayload) -> bytes:
+    def serialize_state(self, state: Union[FullStatePayload, DeltaStatePayload]) -> bytes:
         """Serialize a state payload with fast JSON and log slow frames."""
 
         start = time.perf_counter()
@@ -456,8 +456,8 @@ class SimulationRunner:
             auto_evaluation=auto_eval,
         )
 
-    def _collect_entities(self) -> list[EntitySnapshot]:
-        entities_data: list[EntitySnapshot] = []
+    def _collect_entities(self) -> List[EntitySnapshot]:
+        entities_data: List[EntitySnapshot] = []
         for entity in self.world.entities_list:
             entity_data = self._entity_to_data(entity)
             if entity_data:
@@ -533,8 +533,8 @@ class SimulationRunner:
             poker_stats=poker_stats_payload,
         )
 
-    def _collect_poker_events(self) -> list[PokerEventPayload]:
-        poker_events: list[PokerEventPayload] = []
+    def _collect_poker_events(self) -> List[PokerEventPayload]:
+        poker_events: List[PokerEventPayload] = []
         recent_events = self.world.engine.poker_events
         for event in recent_events:
             if "Standard Algorithm" in event["message"] or "Auto-eval" in event["message"]:
@@ -557,7 +557,7 @@ class SimulationRunner:
 
         return poker_events
 
-    def _collect_poker_leaderboard(self) -> list[PokerLeaderboardEntryPayload]:
+    def _collect_poker_leaderboard(self) -> List[PokerLeaderboardEntryPayload]:
         if not hasattr(self.world.ecosystem, "get_poker_leaderboard"):
             return []
 

--- a/backend/state_payloads.py
+++ b/backend/state_payloads.py
@@ -23,7 +23,7 @@ def _to_dict(dataclass_obj: Any) -> Dict[str, Any]:
     return {field.name: getattr(dataclass_obj, field.name) for field in dataclass_obj.__dataclass_fields__.values()}
 
 
-@dataclass(slots=True)
+@dataclass
 class EntitySnapshot:
     """Minimal snapshot of an entity for client rendering."""
 
@@ -113,7 +113,7 @@ class EntitySnapshot:
         }
 
 
-@dataclass(slots=True)
+@dataclass
 class PokerStatsPayload:
     total_games: int
     total_fish_games: int
@@ -152,7 +152,7 @@ class PokerStatsPayload:
         return _to_dict(self)
 
 
-@dataclass(slots=True)
+@dataclass
 class StatsPayload:
     frame: int
     population: int
@@ -177,7 +177,7 @@ class StatsPayload:
         return data
 
 
-@dataclass(slots=True)
+@dataclass
 class PokerEventPayload:
     frame: int
     winner_id: int
@@ -194,7 +194,7 @@ class PokerEventPayload:
         return _to_dict(self)
 
 
-@dataclass(slots=True)
+@dataclass
 class PokerLeaderboardEntryPayload:
     rank: int
     fish_id: int
@@ -223,7 +223,7 @@ class PokerLeaderboardEntryPayload:
         return _to_dict(self)
 
 
-@dataclass(slots=True)
+@dataclass
 class AutoEvaluateStatsPayload:
     hands_played: int
     hands_remaining: int
@@ -237,7 +237,7 @@ class AutoEvaluateStatsPayload:
         return _to_dict(self)
 
 
-@dataclass(slots=True)
+@dataclass
 class FullStatePayload:
     """Full snapshot with complete entity data."""
 
@@ -272,7 +272,7 @@ class FullStatePayload:
         return json.dumps(self.to_dict(), separators=(",", ":"))
 
 
-@dataclass(slots=True)
+@dataclass
 class DeltaStatePayload:
     """Delta update that only carries incremental changes."""
 

--- a/backend/tank_registry.py
+++ b/backend/tank_registry.py
@@ -1,0 +1,234 @@
+"""Tank registry for managing multiple tank simulations.
+
+This module provides the TankRegistry class which manages multiple
+SimulationManager instances for Tank World Net. It supports creating,
+listing, accessing, and removing tanks.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from backend.simulation_manager import SimulationManager, TankInfo
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CreateTankRequest:
+    """Request to create a new tank."""
+
+    name: str
+    description: str = ""
+    seed: Optional[int] = None
+    owner: Optional[str] = None
+    is_public: bool = True
+    allow_transfers: bool = False
+
+
+class TankRegistry:
+    """Registry for managing multiple tank simulations.
+
+    This class provides a centralized way to manage multiple SimulationManager
+    instances. Each tank is identified by a unique tank_id and can be accessed,
+    listed, or removed through this registry.
+
+    The registry supports:
+    - Creating new tanks with custom configurations
+    - Listing all tanks (optionally filtered by public visibility)
+    - Accessing individual tanks by ID
+    - Removing tanks and cleaning up their resources
+    - Getting a default tank for backwards compatibility
+    """
+
+    def __init__(self, create_default: bool = True):
+        """Initialize the tank registry.
+
+        Args:
+            create_default: If True, creates a default "Local Tank" on init
+        """
+        self._tanks: Dict[str, SimulationManager] = {}
+        self._default_tank_id: Optional[str] = None
+        self._lock = asyncio.Lock()
+
+        if create_default:
+            default_tank = self.create_tank(
+                name="Local Tank",
+                description="A local fish tank simulation",
+            )
+            self._default_tank_id = default_tank.tank_id
+            logger.info(
+                "TankRegistry initialized with default tank: %s",
+                self._default_tank_id,
+            )
+        else:
+            logger.info("TankRegistry initialized (no default tank)")
+
+    @property
+    def tank_count(self) -> int:
+        """Get the number of tanks in the registry."""
+        return len(self._tanks)
+
+    @property
+    def default_tank_id(self) -> Optional[str]:
+        """Get the default tank ID."""
+        return self._default_tank_id
+
+    @property
+    def default_tank(self) -> Optional[SimulationManager]:
+        """Get the default tank manager."""
+        if self._default_tank_id:
+            return self._tanks.get(self._default_tank_id)
+        return None
+
+    def create_tank(
+        self,
+        name: str,
+        description: str = "",
+        seed: Optional[int] = None,
+        owner: Optional[str] = None,
+        is_public: bool = True,
+        allow_transfers: bool = False,
+    ) -> SimulationManager:
+        """Create a new tank and add it to the registry.
+
+        Args:
+            name: Human-readable name for the tank
+            description: Description of the tank
+            seed: Optional random seed for deterministic behavior
+            owner: Optional owner identifier
+            is_public: Whether the tank is publicly visible
+            allow_transfers: Whether to allow entity transfers
+
+        Returns:
+            The newly created SimulationManager
+        """
+        manager = SimulationManager(
+            tank_name=name,
+            tank_description=description,
+            seed=seed,
+        )
+
+        # Update tank info with additional fields
+        manager.tank_info.owner = owner
+        manager.tank_info.is_public = is_public
+        manager.tank_info.allow_transfers = allow_transfers
+
+        self._tanks[manager.tank_id] = manager
+
+        logger.info(
+            "Created tank: id=%s, name=%s, owner=%s, public=%s",
+            manager.tank_id,
+            name,
+            owner,
+            is_public,
+        )
+
+        return manager
+
+    def get_tank(self, tank_id: str) -> Optional[SimulationManager]:
+        """Get a tank by its ID.
+
+        Args:
+            tank_id: The unique tank identifier
+
+        Returns:
+            The SimulationManager if found, None otherwise
+        """
+        return self._tanks.get(tank_id)
+
+    def get_tank_or_default(self, tank_id: Optional[str] = None) -> Optional[SimulationManager]:
+        """Get a tank by ID, or return the default tank.
+
+        Args:
+            tank_id: Optional tank ID. If None or not found, returns default.
+
+        Returns:
+            The SimulationManager for the specified or default tank
+        """
+        if tank_id:
+            tank = self._tanks.get(tank_id)
+            if tank:
+                return tank
+        return self.default_tank
+
+    def list_tanks(self, include_private: bool = False) -> List[Dict[str, Any]]:
+        """List all tanks in the registry.
+
+        Args:
+            include_private: If True, include non-public tanks
+
+        Returns:
+            List of tank status dictionaries
+        """
+        tanks = []
+        for manager in self._tanks.values():
+            if include_private or manager.tank_info.is_public:
+                tanks.append(manager.get_status())
+        return tanks
+
+    def list_tank_ids(self) -> List[str]:
+        """Get a list of all tank IDs.
+
+        Returns:
+            List of tank IDs
+        """
+        return list(self._tanks.keys())
+
+    def remove_tank(self, tank_id: str) -> bool:
+        """Remove a tank from the registry and clean up resources.
+
+        Args:
+            tank_id: The tank ID to remove
+
+        Returns:
+            True if the tank was removed, False if not found
+        """
+        manager = self._tanks.pop(tank_id, None)
+        if manager is None:
+            logger.warning("Attempted to remove non-existent tank: %s", tank_id)
+            return False
+
+        # Stop the simulation if running
+        if manager.running:
+            manager.stop()
+
+        # Clear the default tank reference if needed
+        if self._default_tank_id == tank_id:
+            self._default_tank_id = None
+            # Set a new default if other tanks exist
+            if self._tanks:
+                self._default_tank_id = next(iter(self._tanks.keys()))
+                logger.info("New default tank: %s", self._default_tank_id)
+
+        logger.info("Removed tank: %s", tank_id)
+        return True
+
+    def start_all(self, start_paused: bool = False) -> None:
+        """Start all tanks in the registry.
+
+        Args:
+            start_paused: Whether to start tanks in paused state
+        """
+        for manager in self._tanks.values():
+            if not manager.running:
+                manager.start(start_paused=start_paused)
+
+    def stop_all(self) -> None:
+        """Stop all tanks in the registry."""
+        for manager in self._tanks.values():
+            if manager.running:
+                manager.stop()
+
+    def __contains__(self, tank_id: str) -> bool:
+        """Check if a tank ID exists in the registry."""
+        return tank_id in self._tanks
+
+    def __len__(self) -> int:
+        """Get the number of tanks."""
+        return len(self._tanks)
+
+    def __iter__(self):
+        """Iterate over tank managers."""
+        return iter(self._tanks.values())

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -2,31 +2,38 @@
  * Configuration for Tank World frontend
  *
  * This module provides centralized configuration for the application,
- * preparing for Tank World Net where users can connect to remote tanks.
+ * supporting Tank World Net where users can connect to multiple tanks.
  */
 
 /**
- * Determine WebSocket URL based on environment
- *
- * Priority order:
- * 1. URL query parameter (?server=ws://...)
- * 2. Environment variable (VITE_WS_URL)
- * 3. Default to same host as page (for local development)
+ * Get the tank ID from URL query parameter
  */
-function getWebSocketUrl(): string {
-  // Check URL query parameter for remote tank connection
+function getTankIdFromUrl(): string | null {
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('tank');
+  }
+  return null;
+}
+
+/**
+ * Get the base WebSocket URL (without tank ID)
+ */
+function getBaseWebSocketUrl(): string {
+  // Check URL query parameter for remote server connection
   if (typeof window !== 'undefined') {
     const params = new URLSearchParams(window.location.search);
     const serverUrl = params.get('server');
     if (serverUrl) {
-      return serverUrl;
+      // Remove any /ws or /ws/{tank_id} suffix to get base
+      return serverUrl.replace(/\/ws(\/[^/]+)?$/, '');
     }
   }
 
   // Check environment variable
   const envUrl = import.meta.env.VITE_WS_URL;
   if (envUrl) {
-    return envUrl;
+    return envUrl.replace(/\/ws(\/[^/]+)?$/, '');
   }
 
   // Default: connect to same host as the page
@@ -34,11 +41,32 @@ function getWebSocketUrl(): string {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const host = window.location.hostname;
     const port = import.meta.env.VITE_WS_PORT || '8000';
-    return `${protocol}//${host}:${port}/ws`;
+    return `${protocol}//${host}:${port}`;
   }
 
   // Fallback for SSR or tests
-  return 'ws://localhost:8000/ws';
+  return 'ws://localhost:8000';
+}
+
+/**
+ * Determine WebSocket URL based on environment
+ *
+ * Priority order:
+ * 1. URL query parameter (?server=ws://... and/or ?tank=uuid)
+ * 2. Environment variable (VITE_WS_URL)
+ * 3. Default to same host as page (for local development)
+ */
+function getWebSocketUrl(): string {
+  const baseUrl = getBaseWebSocketUrl();
+  const tankId = getTankIdFromUrl();
+
+  // If a specific tank is requested, use /ws/{tank_id}
+  if (tankId) {
+    return `${baseUrl}/ws/${tankId}`;
+  }
+
+  // Default: use /ws (connects to default tank)
+  return `${baseUrl}/ws`;
 }
 
 /**
@@ -82,10 +110,61 @@ export const config = {
   /** WebSocket reconnect delay in milliseconds */
   wsReconnectDelay: 3000,
 
+  /** Tank ID from URL (if specified) */
+  tankId: getTankIdFromUrl(),
+
   /** Get the current server URL (for display purposes) */
   get serverDisplay(): string {
     return this.apiBaseUrl.replace(/^https?:\/\//, '');
   },
+
+  /**
+   * Get WebSocket URL for a specific tank
+   * @param tankId - The tank ID to connect to
+   */
+  getWsUrlForTank(tankId: string): string {
+    return `${getBaseWebSocketUrl()}/ws/${tankId}`;
+  },
+
+  /**
+   * Get API URL for listing tanks
+   */
+  get tanksApiUrl(): string {
+    return `${this.apiBaseUrl}/api/tanks`;
+  },
 } as const;
 
 export type Config = typeof config;
+
+/**
+ * Tank information returned from the API
+ */
+export interface TankInfo {
+  tank_id: string;
+  name: string;
+  description: string;
+  created_at: string;
+  owner: string | null;
+  is_public: boolean;
+  allow_transfers: boolean;
+}
+
+/**
+ * Tank status returned from the API
+ */
+export interface TankStatus {
+  tank: TankInfo;
+  running: boolean;
+  client_count: number;
+  frame: number;
+  paused: boolean;
+}
+
+/**
+ * Response from GET /api/tanks
+ */
+export interface TanksListResponse {
+  tanks: TankStatus[];
+  count: number;
+  default_tank_id: string;
+}

--- a/tests/test_tank_registry.py
+++ b/tests/test_tank_registry.py
@@ -1,0 +1,186 @@
+"""Tests for the TankRegistry multi-tank management system."""
+
+import pytest
+from backend.tank_registry import TankRegistry
+
+
+class TestTankRegistry:
+    """Tests for TankRegistry class."""
+
+    def test_registry_creates_default_tank(self):
+        """Test that registry creates a default tank on initialization."""
+        registry = TankRegistry(create_default=True)
+
+        assert registry.tank_count == 1
+        assert registry.default_tank_id is not None
+        assert registry.default_tank is not None
+        assert registry.default_tank.tank_info.name == "Local Tank"
+
+        # Clean up
+        registry.stop_all()
+
+    def test_registry_no_default_tank(self):
+        """Test registry can be created without default tank."""
+        registry = TankRegistry(create_default=False)
+
+        assert registry.tank_count == 0
+        assert registry.default_tank_id is None
+        assert registry.default_tank is None
+
+    def test_create_tank(self):
+        """Test creating a new tank."""
+        registry = TankRegistry(create_default=False)
+
+        manager = registry.create_tank(
+            name="Test Tank",
+            description="A test tank",
+            owner="test_user",
+            is_public=True,
+            allow_transfers=False,
+        )
+
+        assert registry.tank_count == 1
+        assert manager.tank_info.name == "Test Tank"
+        assert manager.tank_info.description == "A test tank"
+        assert manager.tank_info.owner == "test_user"
+        assert manager.tank_info.is_public is True
+        assert manager.tank_info.allow_transfers is False
+
+        # Clean up
+        registry.stop_all()
+
+    def test_get_tank(self):
+        """Test getting a tank by ID."""
+        registry = TankRegistry(create_default=False)
+        manager = registry.create_tank(name="Test Tank")
+
+        # Get by valid ID
+        retrieved = registry.get_tank(manager.tank_id)
+        assert retrieved is manager
+
+        # Get by invalid ID
+        retrieved = registry.get_tank("invalid-id")
+        assert retrieved is None
+
+        # Clean up
+        registry.stop_all()
+
+    def test_get_tank_or_default(self):
+        """Test getting tank with fallback to default."""
+        registry = TankRegistry(create_default=True)
+
+        # Get by None should return default
+        retrieved = registry.get_tank_or_default(None)
+        assert retrieved is registry.default_tank
+
+        # Get by invalid ID should return default
+        retrieved = registry.get_tank_or_default("invalid-id")
+        assert retrieved is registry.default_tank
+
+        # Create a new tank and get by valid ID
+        new_tank = registry.create_tank(name="New Tank")
+        retrieved = registry.get_tank_or_default(new_tank.tank_id)
+        assert retrieved is new_tank
+
+        # Clean up
+        registry.stop_all()
+
+    def test_list_tanks(self):
+        """Test listing tanks."""
+        registry = TankRegistry(create_default=False)
+
+        # Create public and private tanks
+        public_tank = registry.create_tank(name="Public Tank", is_public=True)
+        private_tank = registry.create_tank(name="Private Tank", is_public=False)
+
+        # List public only
+        public_list = registry.list_tanks(include_private=False)
+        assert len(public_list) == 1
+        assert public_list[0]["tank"]["name"] == "Public Tank"
+
+        # List all
+        all_list = registry.list_tanks(include_private=True)
+        assert len(all_list) == 2
+
+        # Clean up
+        registry.stop_all()
+
+    def test_remove_tank(self):
+        """Test removing a tank."""
+        registry = TankRegistry(create_default=False)
+
+        tank1 = registry.create_tank(name="Tank 1")
+        tank2 = registry.create_tank(name="Tank 2")
+
+        assert registry.tank_count == 2
+
+        # Remove tank1
+        result = registry.remove_tank(tank1.tank_id)
+        assert result is True
+        assert registry.tank_count == 1
+        assert registry.get_tank(tank1.tank_id) is None
+
+        # Try to remove non-existent tank
+        result = registry.remove_tank("invalid-id")
+        assert result is False
+
+        # Clean up
+        registry.stop_all()
+
+    def test_list_tank_ids(self):
+        """Test getting list of tank IDs."""
+        registry = TankRegistry(create_default=False)
+
+        tank1 = registry.create_tank(name="Tank 1")
+        tank2 = registry.create_tank(name="Tank 2")
+
+        ids = registry.list_tank_ids()
+        assert len(ids) == 2
+        assert tank1.tank_id in ids
+        assert tank2.tank_id in ids
+
+        # Clean up
+        registry.stop_all()
+
+    def test_contains(self):
+        """Test membership checking."""
+        registry = TankRegistry(create_default=False)
+        tank = registry.create_tank(name="Test Tank")
+
+        assert tank.tank_id in registry
+        assert "invalid-id" not in registry
+
+        # Clean up
+        registry.stop_all()
+
+    def test_iteration(self):
+        """Test iterating over tanks."""
+        registry = TankRegistry(create_default=False)
+
+        tank1 = registry.create_tank(name="Tank 1")
+        tank2 = registry.create_tank(name="Tank 2")
+
+        tanks = list(registry)
+        assert len(tanks) == 2
+        assert tank1 in tanks
+        assert tank2 in tanks
+
+        # Clean up
+        registry.stop_all()
+
+    def test_start_stop_all(self):
+        """Test starting and stopping all tanks."""
+        registry = TankRegistry(create_default=False)
+
+        tank1 = registry.create_tank(name="Tank 1")
+        tank2 = registry.create_tank(name="Tank 2")
+
+        # Start all
+        registry.start_all(start_paused=True)
+        assert tank1.running is True
+        assert tank2.running is True
+
+        # Stop all
+        registry.stop_all()
+        assert tank1.running is False
+        assert tank2.running is False


### PR DESCRIPTION
Add TankRegistry class to manage multiple SimulationManager instances:
- Create/list/get/remove tanks dynamically
- Start/stop all tanks in registry
- Support public/private tank visibility
- Track connected clients per tank

Add multi-tank API endpoints:
- GET /api/tanks - List all tanks
- POST /api/tanks - Create new tank
- GET /api/tanks/{tank_id} - Get tank status
- DELETE /api/tanks/{tank_id} - Remove tank
- GET /api/tanks/{tank_id}/lineage - Get tank lineage

Add WebSocket routing by tank_id:
- /ws - Connect to default tank (backwards compatible)
- /ws/{tank_id} - Connect to specific tank

Update frontend config:
- Support ?tank=uuid query parameter
- Add tank API types and interfaces
- Helper functions for tank-specific WebSocket URLs

All 102 tests passing (91 existing + 11 new TankRegistry tests).

🤖 Generated with [Claude Code](https://claude.ai/code)