### PR TITLE
Prevent renderer orientation cache growth

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -40,6 +40,9 @@ export function Canvas({ state, width = 800, height = 600 }: CanvasProps) {
 
     const renderer = rendererRef.current;
 
+    // Prevent orientation cache from growing without bound when entities churn
+    renderer.pruneEntityFacingCache(state.entities.map((entity) => entity.id));
+
     // Clear canvas with time-of-day effects
     renderer.clear(width, height, state.stats?.time);
 

--- a/frontend/src/utils/renderer.ts
+++ b/frontend/src/utils/renderer.ts
@@ -124,6 +124,21 @@ export class Renderer {
         }
     }
 
+    /**
+     * Drop orientation cache entries for entities that no longer exist.
+     * Prevents unbounded growth when the simulation spawns many short-lived
+     * entities (e.g., food), which can otherwise exhaust browser memory over
+     * time.
+     */
+    pruneEntityFacingCache(activeEntityIds: Iterable<number>) {
+        const activeIds = new Set(activeEntityIds);
+        for (const cachedId of this.entityFacingLeft.keys()) {
+            if (!activeIds.has(cachedId)) {
+                this.entityFacingLeft.delete(cachedId);
+            }
+        }
+    }
+
     private getTimeOfDayPalette(timeOfDay?: string): TimeOfDayPalette {
         const key = timeOfDay?.toLowerCase() ?? 'day';
 


### PR DESCRIPTION
## Summary
- add pruning for cached entity facing directions in the canvas renderer
- clear cached orientation data each render based on active entities to avoid memory growth

## Testing
- npm run build *(fails: existing TypeScript errors in App.tsx and fractalPlant.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923be7096ec8331b9d571149c87f636)