### PR TITLE
Sync fast forward control with simulation state

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -553,6 +553,7 @@ class SimulationRunner:
             plant_energy=stats.get("plant_energy", 0.0),
             poker_stats=poker_stats_payload,
             fps=round(self.current_actual_fps, 1),
+            fast_forward=self.fast_forward,
         )
 
     def _collect_poker_events(self) -> List[PokerEventPayload]:
@@ -851,6 +852,7 @@ class SimulationRunner:
                 self._invalidate_state_cache()
                 # Unpause after reset for intuitive behavior
                 self.world.paused = False
+                self.fast_forward = False
                 logger.info("Simulation reset")
 
             elif command == "fast_forward":

--- a/backend/state_payloads.py
+++ b/backend/state_payloads.py
@@ -171,6 +171,7 @@ class StatsPayload:
     plant_energy: float  # Total energy of all plants
     poker_stats: PokerStatsPayload
     fps: float = 0.0
+    fast_forward: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         data = _to_dict(self)

--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -3,8 +3,9 @@
 This module manages population dynamics, statistics, and ecosystem health.
 """
 
-from collections import defaultdict
+import logging
 import os
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 from core.constants import MAX_ECOSYSTEM_EVENTS, TOTAL_ALGORITHM_COUNT
@@ -21,6 +22,9 @@ from core.ecosystem_stats import (
 if TYPE_CHECKING:
     from core.entities import Fish
     from core.genetics import Genome
+
+
+logger = logging.getLogger(__name__)
 
 
 class EcosystemManager:

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -2,7 +2,7 @@
  * Control panel component with simulation controls
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Command } from '../types/simulation';
 import { Button } from './ui';
 import styles from './ControlPanel.module.css';
@@ -13,11 +13,16 @@ interface ControlPanelProps {
     onPlayPoker?: () => void;
     showTree?: boolean;
     onToggleTree?: () => void;
+    fastForwardEnabled?: boolean;
 }
 
-export function ControlPanel({ onCommand, isConnected, onPlayPoker, showTree, onToggleTree }: ControlPanelProps) {
+export function ControlPanel({ onCommand, isConnected, onPlayPoker, showTree, onToggleTree, fastForwardEnabled }: ControlPanelProps) {
     const [isPaused, setIsPaused] = useState(false);
     const [isFastForward, setIsFastForward] = useState(false);
+
+    useEffect(() => {
+        setIsFastForward(Boolean(fastForwardEnabled));
+    }, [fastForwardEnabled]);
 
     const handleAddFood = () => {
         onCommand({ command: 'add_food' });

--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -151,6 +151,7 @@ export function TankView({ tankId }: TankViewProps) {
                     onPlayPoker={handleStartPoker}
                     showTree={showTree}
                     onToggleTree={() => setShowTree(!showTree)}
+                    fastForwardEnabled={state?.stats?.fast_forward}
                 />
             </div>
 

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -193,6 +193,7 @@ export interface StatsData {
     plant_energy: number; // Total energy of all plants
     poker_stats: PokerStatsData;
     fps?: number;
+    fast_forward?: boolean;
 }
 
 export interface SimulationUpdate {


### PR DESCRIPTION
## Summary
- add fast_forward flag to simulation stats and reset to normal speed on resets
- synchronize the control panel fast forward toggle with the server-reported state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a50d405083319c38eb3623b47238)