### PR TITLE
Fix Live thumbnails to show full tank

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -20,6 +20,10 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
   const rendererRef = useRef<Renderer | null>(null);
   const [imagesLoaded, setImagesLoaded] = useState(false);
 
+  // Tank world dimensions (from core/constants.py)
+  const WORLD_WIDTH = 1088;
+  const WORLD_HEIGHT = 612;
+
   const handleCanvasClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
     if (!state || !onEntityClick) return;
 
@@ -33,12 +37,18 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
     const clickX = (event.clientX - rect.left) * scaleX;
     const clickY = (event.clientY - rect.top) * scaleY;
 
+    // Account for world-to-canvas scaling
+    const worldScaleX = WORLD_WIDTH / width;
+    const worldScaleY = WORLD_HEIGHT / height;
+    const worldX = clickX * worldScaleX;
+    const worldY = clickY * worldScaleY;
+
     // Find clicked entity (check in reverse order to prioritize entities rendered on top)
     for (let i = state.entities.length - 1; i >= 0; i--) {
       const entity = state.entities[i];
 
       // Skip food items (only allow transferring fish and plants)
-      if (entity.type === 'food' || entity.type === 'nectar') continue;
+      if (entity.type === 'food' || entity.type === 'plant_nectar') continue;
 
       // Check if click is within entity bounds
       const left = entity.x - entity.width / 2;
@@ -46,7 +56,7 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
       const top = entity.y - entity.height / 2;
       const bottom = entity.y + entity.height / 2;
 
-      if (clickX >= left && clickX <= right && clickY >= top && clickY <= bottom) {
+      if (worldX >= left && worldX <= right && worldY >= top && worldY <= bottom) {
         onEntityClick(entity.id, entity.type);
         return;
       }
@@ -74,31 +84,45 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
     if (!state || !rendererRef.current || !imagesLoaded) return;
 
     const renderer = rendererRef.current;
+    const ctx = renderer.ctx;
+
+    // Calculate scale to fit the entire world into the canvas
+    const scaleX = width / WORLD_WIDTH;
+    const scaleY = height / WORLD_HEIGHT;
 
     // Prevent orientation cache from growing without bound when entities churn
     renderer.pruneEntityFacingCache(state.entities.map((entity) => entity.id));
 
-    // Clear canvas with time-of-day effects
-    renderer.clear(width, height, state.stats?.time);
+    // Save context state
+    ctx.save();
 
-    // Render all entities
+    // Apply scale transformation to fit world into canvas
+    ctx.scale(scaleX, scaleY);
+
+    // Clear canvas with time-of-day effects (using world dimensions)
+    renderer.clear(WORLD_WIDTH, WORLD_HEIGHT, state.stats?.time);
+
+    // Render all entities (they're already in world coordinates)
     state.entities.forEach((entity) => {
       renderer.renderEntity(entity, state.elapsed_time || 0);
 
       // Highlight selected entity
       if (selectedEntityId === entity.id) {
-        renderer.ctx.strokeStyle = '#3b82f6';
-        renderer.ctx.lineWidth = 3;
-        renderer.ctx.setLineDash([5, 5]);
-        renderer.ctx.strokeRect(
+        ctx.strokeStyle = '#3b82f6';
+        ctx.lineWidth = 3;
+        ctx.setLineDash([5, 5]);
+        ctx.strokeRect(
           entity.x - entity.width / 2 - 5,
           entity.y - entity.height / 2 - 5,
           entity.width + 10,
           entity.height + 10
         );
-        renderer.ctx.setLineDash([]);
+        ctx.setLineDash([]);
       }
     });
+
+    // Restore context state
+    ctx.restore();
   }, [state, width, height, imagesLoaded, selectedEntityId]);
 
   return (

--- a/frontend/src/utils/renderer.ts
+++ b/frontend/src/utils/renderer.ts
@@ -94,7 +94,7 @@ interface Particle {
 }
 
 export class Renderer {
-    private ctx: CanvasRenderingContext2D;
+    public ctx: CanvasRenderingContext2D;
     private particles: Particle[] = [];
     private initialized = false;
     private currentPalette: TimeOfDayPalette | null = null;


### PR DESCRIPTION
Previously, the thumbnails only showed the top-left corner of the tank because entities were positioned for the full 1088x612 world but rendered on a small 320x180 canvas without scaling.

Now the Canvas component:
- Calculates scale factor (canvas size / world size)
- Applies scale transformation before rendering
- Passes world dimensions to renderer clear() method
- Adjusts click coordinates for world-to-canvas scaling

Also made renderer ctx property public to allow Canvas component to apply transformations, and fixed entity type check for plant_nectar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)