### PR TITLE
Improve canvas initialization safety and organize imports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@
  */
 
 import { Routes, Route, Link, useParams, useLocation } from 'react-router-dom';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { TankView } from './components/TankView';
 import { NetworkDashboard } from './pages/NetworkDashboard';
 import './App.css';
@@ -94,8 +95,6 @@ function NavBar() {
         </nav>
     );
 }
-
-import { ErrorBoundary } from './components/ErrorBoundary';
 
 function App() {
     return (

--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -65,6 +65,8 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
     };
 
     useEffect(() => {
+        let isMounted = true;
+
         try {
             const canvas = canvasRef.current;
             if (!canvas) return;
@@ -79,10 +81,14 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
             const loadImages = async () => {
                 try {
                     await ImageLoader.preloadGameImages();
-                    setImagesLoaded(true);
+                    if (isMounted) {
+                        setImagesLoaded(true);
+                    }
                 } catch (err) {
                     console.error("Failed to load images:", err);
-                    setError(`Failed to load images: ${err instanceof Error ? err.message : String(err)}`);
+                    if (isMounted) {
+                        setError(`Failed to load images: ${err instanceof Error ? err.message : String(err)}`);
+                    }
                 }
             };
 
@@ -91,6 +97,10 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
             console.error("Failed to initialize renderer:", err);
             setError(`Failed to initialize renderer: ${err instanceof Error ? err.message : String(err)}`);
         }
+
+        return () => {
+            isMounted = false;
+        };
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent canvas initialization async tasks from updating state after unmounting
- keep renderer initialization error-safe while retaining canvas error feedback
- align App imports by colocating ErrorBoundary with other top-level imports

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924eac078f4833187c9b6a46fe4bd68)