### PR TITLE
Show Tank World Net frame rate

### DIFF
--- a/backend/simulation_manager.py
+++ b/backend/simulation_manager.py
@@ -266,5 +266,8 @@ class SimulationManager:
             "client_count": self.client_count,
             "frame": self.world.frame_count if self.running else 0,
             "paused": self.world.paused if self.running else True,
+            "fps": round(self._runner.current_actual_fps, 1)
+            if self.running
+            else 0.0,
             "stats": stats,
         }

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -201,6 +201,7 @@ export interface TankStatus {
     client_count: number;
     frame: number;
     paused: boolean;
+    fps?: number;
     stats?: TankStatsSummary;
 }
 

--- a/frontend/src/pages/NetworkDashboard.tsx
+++ b/frontend/src/pages/NetworkDashboard.tsx
@@ -493,7 +493,7 @@ interface TankCardProps {
 }
 
 function TankCard({ tankStatus, onDelete, onRefresh }: TankCardProps) {
-    const { tank, running, client_count, frame, paused } = tankStatus;
+    const { tank, running, client_count, frame, paused, fps } = tankStatus;
     const stats = tankStatus.stats ?? {
         fish_count: 0,
         generation: 0,
@@ -611,6 +611,9 @@ function TankCard({ tankStatus, onDelete, onRefresh }: TankCardProps) {
                         <div style={{ fontSize: '10px', color: '#94a3b8', marginBottom: 3 }}>Frame</div>
                         <div style={{ fontSize: '16px', color: '#e2e8f0', fontWeight: 700 }}>
                             {frame.toLocaleString()}
+                        </div>
+                        <div style={{ fontSize: '11px', color: '#94a3b8', marginTop: 2 }}>
+                            {fps != null ? `${fps.toFixed(1)} FPS` : 'FPS —'}
                         </div>
                     </div>
                     <div style={{ background: '#1e293b', borderRadius: '6px', padding: '10px', border: '1px solid #334155' }}>


### PR DESCRIPTION
## Summary
- expose current simulation FPS in Tank World Net status responses
- display FPS alongside frame counts on the Tank World Net dashboard

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f819c0488331a6cca252f0751aa9)