### PR TITLE
Simplify creating new tanks

### DIFF
--- a/frontend/src/pages/NetworkDashboard.tsx
+++ b/frontend/src/pages/NetworkDashboard.tsx
@@ -29,6 +29,8 @@ export function NetworkDashboard() {
     // Transfer history state
     const [showHistory, setShowHistory] = useState(false);
 
+    const totalTanks = servers.reduce((sum, s) => sum + s.tanks.length, 0);
+
     const fetchServers = useCallback(async () => {
         try {
             setError(null);
@@ -59,12 +61,13 @@ export function NetworkDashboard() {
 
     const handleCreateTank = async (e: React.FormEvent) => {
         e.preventDefault();
-        if (!newTankName.trim() || !selectedServerId) return;
+        if (!selectedServerId) return;
 
         setCreating(true);
         try {
+            const name = newTankName.trim() || `Tank ${totalTanks + 1}`;
             const params = new URLSearchParams({
-                name: newTankName.trim(),
+                name,
                 description: newTankDescription.trim(),
                 server_id: selectedServerId,
             });
@@ -105,7 +108,15 @@ export function NetworkDashboard() {
         }
     };
 
-    const totalTanks = servers.reduce((sum, s) => sum + s.tanks.length, 0);
+    const handleOpenCreateForm = () => {
+        setShowCreateForm(true);
+        if (!newTankName.trim()) {
+            setNewTankName(`Tank ${totalTanks + 1}`);
+        }
+        if (!selectedServerId && servers[0]) {
+            setSelectedServerId(servers[0].server.server_id);
+        }
+    };
 
     return (
         <div style={{
@@ -161,7 +172,7 @@ export function NetworkDashboard() {
                             📋 History
                         </button>
                         <button
-                            onClick={() => setShowCreateForm(true)}
+                            onClick={handleOpenCreateForm}
                             style={{
                                 padding: '10px 20px',
                                 backgroundColor: '#3b82f6',
@@ -260,7 +271,7 @@ export function NetworkDashboard() {
                             <div style={{ display: 'flex', gap: '12px' }}>
                                 <button
                                     type="submit"
-                                    disabled={creating || !newTankName.trim()}
+                                    disabled={creating || !selectedServerId}
                                     style={{
                                         padding: '10px 20px',
                                         backgroundColor: creating ? '#475569' : '#22c55e',


### PR DESCRIPTION
## Summary
- prefill the create tank form with sensible defaults so users can create tanks immediately
- generate a default tank name when none is provided and fall back to the selected server
- keep the create action available without manual input

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692500b901548331a5e60444218ce0bc)