### PR TITLE
Update default tank name to Tank 1

### DIFF
--- a/backend/simulation_manager.py
+++ b/backend/simulation_manager.py
@@ -62,7 +62,7 @@ class SimulationManager:
 
     def __init__(
         self,
-        tank_name: str = "Local Tank",
+        tank_name: str = "Tank 1",
         tank_description: str = "A local fish tank simulation",
         seed: Optional[int] = None,
     ):

--- a/backend/tank_registry.py
+++ b/backend/tank_registry.py
@@ -46,7 +46,7 @@ class TankRegistry:
         """Initialize the tank registry.
 
         Args:
-            create_default: If True, creates a default "Local Tank" on init
+            create_default: If True, creates a default "Tank 1" on init
         """
         self._tanks: Dict[str, SimulationManager] = {}
         self._default_tank_id: Optional[str] = None
@@ -54,7 +54,7 @@ class TankRegistry:
 
         if create_default:
             default_tank = self.create_tank(
-                name="Local Tank",
+                name="Tank 1",
                 description="A local fish tank simulation",
             )
             self._default_tank_id = default_tank.tank_id

--- a/tests/test_tank_registry.py
+++ b/tests/test_tank_registry.py
@@ -14,7 +14,7 @@ class TestTankRegistry:
         assert registry.tank_count == 1
         assert registry.default_tank_id is not None
         assert registry.default_tank is not None
-        assert registry.default_tank.tank_info.name == "Local Tank"
+        assert registry.default_tank.tank_info.name == "Tank 1"
 
         # Clean up
         registry.stop_all()


### PR DESCRIPTION
## Summary
- set the default tank name to "Tank 1" in the simulation manager and registry initialization
- update registry docstring and tests to reflect the new default name

## Testing
- pytest tests/test_tank_registry.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692506de59a08331b0eaaab8cfa55488)