### PR TITLE
Align tank previews with tank aspect ratio

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -2,7 +2,7 @@
  * Canvas component for rendering the simulation
  */
 
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState, type CSSProperties } from 'react';
 import type { SimulationUpdate } from '../types/simulation';
 import { Renderer } from '../utils/renderer';
 import { ImageLoader } from '../utils/ImageLoader';
@@ -13,9 +13,10 @@ interface CanvasProps {
     height?: number;
     onEntityClick?: (entityId: number, entityType: string) => void;
     selectedEntityId?: number | null;
+    style?: CSSProperties;
 }
 
-export function Canvas({ state, width = 800, height = 600, onEntityClick, selectedEntityId }: CanvasProps) {
+export function Canvas({ state, width = 800, height = 600, onEntityClick, selectedEntityId, style }: CanvasProps) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const rendererRef = useRef<Renderer | null>(null);
     const [imagesLoaded, setImagesLoaded] = useState(false);
@@ -187,6 +188,7 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
             onClick={handleCanvasClick}
             style={{
                 cursor: onEntityClick ? 'pointer' : 'default',
+                ...style,
             }}
         />
     );

--- a/frontend/src/components/TankThumbnail.tsx
+++ b/frontend/src/components/TankThumbnail.tsx
@@ -3,6 +3,8 @@ import { Canvas } from './Canvas';
 import { config } from '../config';
 import type { SimulationUpdate } from '../types/simulation';
 
+const TANK_ASPECT_RATIO = '1088 / 612';
+
 interface TankThumbnailProps {
     tankId: string;
     status: 'running' | 'paused' | 'stopped';
@@ -65,37 +67,52 @@ export function TankThumbnail({ tankId, status }: TankThumbnailProps) {
         };
     }, [tankId]);
 
+    const containerStyle = {
+        position: 'relative' as const,
+        borderRadius: '10px',
+        overflow: 'hidden',
+        border: '1px solid #334155',
+        backgroundColor: '#0f172a',
+        aspectRatio: TANK_ASPECT_RATIO,
+        width: '100%',
+    };
+
+    const overlayStyle = {
+        position: 'absolute' as const,
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+    };
+
     return (
         <div style={{ position: 'relative' }}>
-            <div style={{
-                borderRadius: '10px',
-                overflow: 'hidden',
-                border: '1px solid #334155',
-                backgroundColor: '#0f172a',
-                minHeight: '180px',
-            }}>
+            <div style={containerStyle}>
                 {loading ? (
-                    <div style={{
-                        height: '180px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        color: '#64748b',
-                        fontSize: '14px',
-                    }}>
+                    <div
+                        style={{
+                            ...overlayStyle,
+                            color: '#64748b',
+                            fontSize: '14px',
+                        }}
+                    >
                         Loading preview...
                     </div>
                 ) : state ? (
-                    <Canvas state={state} width={320} height={180} />
+                    <Canvas
+                        state={state}
+                        width={320}
+                        height={180}
+                        style={{ width: '100%', height: '100%', display: 'block' }}
+                    />
                 ) : (
-                    <div style={{
-                        height: '180px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        color: '#ef4444',
-                        fontSize: '12px',
-                    }}>
+                    <div
+                        style={{
+                            ...overlayStyle,
+                            color: '#ef4444',
+                            fontSize: '12px',
+                        }}
+                    >
                         {error || 'No data'}
                     </div>
                 )}


### PR DESCRIPTION
## Summary
- add an optional style prop to the Canvas component for responsive embedding
- enforce the tank's aspect ratio on tank preview containers and fill them with the canvas
- keep loading and error preview overlays centered inside the fixed-ratio space

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925067f09f08331a158b22b291295a1)