### PR TITLE
Add poker strength summary to Tank World Net dashboard

### DIFF
--- a/backend/simulation_manager.py
+++ b/backend/simulation_manager.py
@@ -256,6 +256,23 @@ class SimulationManager:
                 "total_energy": world_stats.get("total_energy", 0.0),
                 "fish_energy": world_stats.get("fish_energy", 0.0),
                 "plant_energy": world_stats.get("plant_energy", 0.0),
+                "poker_stats": {
+                    "best_hand_name": world_stats.get("poker_stats", {}).get(
+                        "best_hand_name", "Unknown"
+                    ),
+                    "win_rate_pct": world_stats.get("poker_stats", {}).get(
+                        "win_rate_pct", "0.0%"
+                    ),
+                    "total_fish_games": world_stats.get("poker_stats", {}).get(
+                        "total_fish_games", 0
+                    ),
+                    "total_plant_games": world_stats.get("poker_stats", {}).get(
+                        "total_plant_games", 0
+                    ),
+                    "net_energy": world_stats.get("poker_stats", {}).get(
+                        "net_energy", 0.0
+                    ),
+                },
             }
         except Exception as exc:  # pragma: no cover - defensive guard
             logger.warning("Failed to collect stats for tank %s: %s", self.tank_id, exc)

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -190,6 +190,13 @@ export interface TankStatsSummary {
     total_energy: number;
     fish_energy: number;
     plant_energy: number;
+    poker_stats?: {
+        best_hand_name: string;
+        win_rate_pct: string;
+        total_fish_games: number;
+        total_plant_games: number;
+        net_energy: number;
+    };
 }
 
 /**

--- a/frontend/src/pages/NetworkDashboard.tsx
+++ b/frontend/src/pages/NetworkDashboard.tsx
@@ -512,6 +512,21 @@ function TankCard({ tankStatus, onDelete, onRefresh }: TankCardProps) {
         total_energy: 0,
         fish_energy: 0,
         plant_energy: 0,
+        poker_stats: {
+            best_hand_name: 'Unknown',
+            win_rate_pct: '0.0%',
+            total_fish_games: 0,
+            total_plant_games: 0,
+            net_energy: 0,
+        },
+    };
+
+    const pokerStats = stats.poker_stats ?? {
+        best_hand_name: 'Unknown',
+        win_rate_pct: '0.0%',
+        total_fish_games: 0,
+        total_plant_games: 0,
+        net_energy: 0,
     };
 
     const [actionLoading, setActionLoading] = useState(false);
@@ -632,6 +647,42 @@ function TankCard({ tankStatus, onDelete, onRefresh }: TankCardProps) {
                         <div style={{ fontSize: '10px', color: '#94a3b8', marginBottom: 3 }}>Clients</div>
                         <div style={{ fontSize: '16px', color: '#e2e8f0', fontWeight: 700 }}>
                             {client_count}
+                        </div>
+                    </div>
+                </div>
+
+                <div style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+                    gap: '10px',
+                }}>
+                    <div style={{ background: '#111827', borderRadius: '8px', padding: '10px', border: '1px solid #1f2937' }}>
+                        <div style={{ fontSize: '12px', color: '#94a3b8', marginBottom: 6 }}>Poker Strength</div>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                            <div>
+                                <div style={{ fontSize: '13px', color: '#cbd5e1' }}>Best Hand</div>
+                                <div style={{ fontSize: '16px', color: '#f1f5f9', fontWeight: 700 }}>
+                                    {pokerStats.best_hand_name}
+                                </div>
+                            </div>
+                            <div style={{ textAlign: 'right' }}>
+                                <div style={{ fontSize: '13px', color: '#cbd5e1' }}>Win Rate</div>
+                                <div style={{ fontSize: '16px', color: '#22c55e', fontWeight: 700 }}>
+                                    {pokerStats.win_rate_pct}
+                                </div>
+                            </div>
+                        </div>
+                        <div style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            gap: '8px',
+                            marginTop: 8,
+                            fontSize: '12px',
+                            color: '#94a3b8',
+                        }}>
+                            <span>Fish games: {pokerStats.total_fish_games}</span>
+                            <span>Plant games: {pokerStats.total_plant_games}</span>
+                            <span>Net energy: {pokerStats.net_energy.toFixed(1)}</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- expose poker summary fields in tank status API responses
- extend tank status typing to include poker stats
- show poker strength details for each tank on the Tank World Net page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925161be47883318c06e2123ec26582)