### PR TITLE
Add portable server metadata reporting for Tank World Net

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -55,6 +55,22 @@ Tank World Net enables running multiple independent tank simulations on a single
 - `POST /api/tanks/{tank_id}/start` - Start a stopped tank simulation
 - `POST /api/tanks/{tank_id}/stop` - Stop a running tank and its broadcast task
 
+#### Server Inventory API
+
+Use these endpoints to understand what servers are available in the Tank World Net and what
+hardware they are running on (all values are generated with portable `platform`/`os`
+functions, so they work across Linux, macOS, Windows, and ARM boards like Raspberry Pi):
+
+- `GET /api/servers` - List all servers and the tanks running on each one
+- `GET /api/servers/{server_id}` - Get a single server with its tank list
+
+**Server metadata fields:**
+
+- `server_id`, `hostname`, `host`, `port`, `status`, `version`, `uptime_seconds` - lifecycle metadata
+- `tank_count`, `is_local` - multi-tank awareness flags
+- `cpu_percent`, `memory_mb` - optional runtime usage if `psutil` is available
+- `platform`, `architecture`, `hardware_model`, `logical_cpus` - portable hardware descriptors useful for heterogeneous fleets
+
 #### Entity Transfer API
 
 - `POST /api/tanks/{source_tank_id}/transfer?entity_id={id}&destination_tank_id={dest_id}` - Transfer entity between tanks

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import os
 import platform
 import socket
 import sys
@@ -492,6 +493,7 @@ def get_server_info() -> ServerInfo:
     memory_mb = None
     try:
         import psutil
+
         process = psutil.Process()
         cpu_percent = process.cpu_percent(interval=0.1)
         memory_mb = process.memory_info().rss / 1024 / 1024  # Convert bytes to MB
@@ -513,6 +515,10 @@ def get_server_info() -> ServerInfo:
         cpu_percent=cpu_percent,
         memory_mb=memory_mb,
         is_local=True,
+        platform=platform.system(),
+        architecture=platform.machine(),
+        hardware_model=platform.processor() or None,
+        logical_cpus=os.cpu_count(),
     )
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -223,6 +223,10 @@ class ServerInfo(BaseModel):
     cpu_percent: Optional[float] = None  # CPU usage percentage (0-100)
     memory_mb: Optional[float] = None  # Memory usage in MB
     is_local: bool = True  # Whether this is the local server
+    platform: Optional[str] = None  # OS family name (Linux, Windows, Darwin)
+    architecture: Optional[str] = None  # CPU architecture (x86_64, arm64, etc.)
+    hardware_model: Optional[str] = None  # Optional hardware descriptor
+    logical_cpus: Optional[int] = None  # Logical CPU count for load estimation
 
 
 class ServerWithTanks(BaseModel):

--- a/docs/TANK_WORLD_NET_SERVERS.md
+++ b/docs/TANK_WORLD_NET_SERVERS.md
@@ -1,0 +1,56 @@
+# Tank World Net Server Metadata
+
+This note describes how the backend exposes server information in a way that works across
+heterogeneous hardware (desktop workstations, cloud VMs, and ARM SBCs like Raspberry Pi).
+
+## What the API Returns
+
+The `/api/servers` and `/api/servers/{server_id}` endpoints now return a `server` payload
+alongside the tanks that server is running. Each `server` object includes:
+
+- **Identity & connectivity**: `server_id`, `hostname`, `host`, `port`, `status`, `version`
+- **Usage**: `uptime_seconds`, `tank_count`, `is_local`
+- **Runtime metrics (optional)**: `cpu_percent`, `memory_mb` when `psutil` is installed
+- **Portable hardware descriptors**: `platform`, `architecture`, `hardware_model`, `logical_cpus`
+
+## Portability Notes
+
+- Hardware descriptors rely on Python's standard `platform` and `os` modules, which report
+  consistent values across Linux, macOS, Windows, and ARM devices. They avoid shell commands
+  or vendor-specific utilities so the data stays portable.
+- Runtime metrics only appear when `psutil` is available; the API omits them gracefully on
+  constrained systems where `psutil` is not installed or cannot be built.
+- Client code should treat `hardware_model` as optional, because some platforms return an
+  empty string for `platform.processor()`; in those cases the field will be `null`.
+
+## Example Response
+
+```json
+{
+  "servers": [
+    {
+      "server": {
+        "server_id": "local-server",
+        "hostname": "pi-sim-01",
+        "host": "192.168.1.42",
+        "port": 8000,
+        "status": "online",
+        "tank_count": 3,
+        "version": "1.0.0",
+        "uptime_seconds": 45210.3,
+        "cpu_percent": 7.5,
+        "memory_mb": 230.1,
+        "is_local": true,
+        "platform": "Linux",
+        "architecture": "arm64",
+        "hardware_model": "Apple M1",
+        "logical_cpus": 8
+      },
+      "tanks": [
+        { "tank_id": "reef" },
+        { "tank_id": "kelp-forest" }
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary
- add platform and hardware descriptors to Tank World Net server metadata
- expose the new metadata through the server info helper and document the server inventory API
- add a reference document explaining the portable server fields and their usage

## Testing
- python -m compileall backend


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925387471e88331bb82e21bdce846fd)