### PR TITLE
Fix tank state save and restore functionality

### DIFF
--- a/backend/auto_save_service.py
+++ b/backend/auto_save_service.py
@@ -1,0 +1,201 @@
+"""Auto-save service for periodic tank state persistence.
+
+This module provides automatic background saving of tank states at
+configured intervals, ensuring that simulations can be restored after
+server restarts.
+"""
+
+import asyncio
+import logging
+from typing import Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from backend.simulation_manager import SimulationManager
+    from backend.tank_registry import TankRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class AutoSaveService:
+    """Background service for auto-saving tank states.
+
+    This service manages periodic saves for all persistent tanks
+    in the registry, with configurable intervals per tank.
+    """
+
+    def __init__(self, tank_registry: "TankRegistry"):
+        """Initialize the auto-save service.
+
+        Args:
+            tank_registry: The tank registry to monitor
+        """
+        self._tank_registry = tank_registry
+        self._tasks: Dict[str, asyncio.Task] = {}
+        self._running = False
+
+    async def start(self) -> None:
+        """Start the auto-save service."""
+        if self._running:
+            logger.warning("Auto-save service already running")
+            return
+
+        self._running = True
+        logger.info("Auto-save service started")
+
+        # Start auto-save tasks for all persistent tanks
+        for manager in self._tank_registry:
+            if manager.tank_info.persistent:
+                await self._start_tank_autosave(manager)
+
+    async def stop(self) -> None:
+        """Stop the auto-save service and cancel all tasks."""
+        if not self._running:
+            return
+
+        self._running = False
+        logger.info("Stopping auto-save service...")
+
+        # Cancel all auto-save tasks
+        for tank_id, task in list(self._tasks.items()):
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            logger.info(f"Auto-save task cancelled for tank {tank_id[:8]}")
+
+        self._tasks.clear()
+        logger.info("Auto-save service stopped")
+
+    async def _start_tank_autosave(self, manager: "SimulationManager") -> None:
+        """Start auto-save task for a specific tank.
+
+        Args:
+            manager: The SimulationManager to auto-save
+        """
+        tank_id = manager.tank_id
+
+        if tank_id in self._tasks:
+            logger.warning(f"Auto-save task already exists for tank {tank_id[:8]}")
+            return
+
+        task = asyncio.create_task(
+            self._autosave_loop(manager),
+            name=f"autosave_{tank_id[:8]}"
+        )
+        self._tasks[tank_id] = task
+        logger.info(
+            f"Started auto-save for tank {tank_id[:8]} "
+            f"(interval: {manager.tank_info.auto_save_interval}s)"
+        )
+
+    async def stop_tank_autosave(self, tank_id: str) -> None:
+        """Stop auto-save task for a specific tank.
+
+        Args:
+            tank_id: The tank ID to stop auto-saving
+        """
+        task = self._tasks.pop(tank_id, None)
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            logger.info(f"Auto-save task stopped for tank {tank_id[:8]}")
+
+    async def _autosave_loop(self, manager: "SimulationManager") -> None:
+        """Background loop for periodic tank saves.
+
+        Args:
+            manager: The SimulationManager to save
+        """
+        from backend.tank_persistence import save_tank_state, cleanup_old_snapshots
+
+        tank_id = manager.tank_id
+        interval = manager.tank_info.auto_save_interval
+
+        try:
+            while self._running:
+                # Wait for the configured interval
+                await asyncio.sleep(interval)
+
+                # Save the tank state
+                try:
+                    snapshot_path = save_tank_state(tank_id, manager)
+                    if snapshot_path:
+                        logger.info(
+                            f"Auto-saved tank {tank_id[:8]} to {snapshot_path}"
+                        )
+
+                        # Cleanup old snapshots (keep last 10)
+                        deleted = cleanup_old_snapshots(tank_id, max_snapshots=10)
+                        if deleted > 0:
+                            logger.debug(
+                                f"Cleaned up {deleted} old snapshots for tank {tank_id[:8]}"
+                            )
+                    else:
+                        logger.error(f"Auto-save failed for tank {tank_id[:8]}")
+
+                except Exception as e:
+                    logger.error(
+                        f"Error during auto-save for tank {tank_id[:8]}: {e}",
+                        exc_info=True
+                    )
+
+        except asyncio.CancelledError:
+            logger.info(f"Auto-save loop cancelled for tank {tank_id[:8]}")
+            raise
+        except Exception as e:
+            logger.error(
+                f"Fatal error in auto-save loop for tank {tank_id[:8]}: {e}",
+                exc_info=True
+            )
+
+    async def save_tank_now(self, tank_id: str) -> Optional[str]:
+        """Immediately save a specific tank (out of band).
+
+        Args:
+            tank_id: The tank ID to save
+
+        Returns:
+            Path to saved snapshot, or None if failed
+        """
+        from backend.tank_persistence import save_tank_state, cleanup_old_snapshots
+
+        manager = self._tank_registry.get_tank(tank_id)
+        if not manager:
+            logger.error(f"Cannot save tank {tank_id[:8]}: not found")
+            return None
+
+        try:
+            snapshot_path = save_tank_state(tank_id, manager)
+            if snapshot_path:
+                logger.info(f"Manual save completed for tank {tank_id[:8]}")
+                cleanup_old_snapshots(tank_id, max_snapshots=10)
+                return snapshot_path
+            else:
+                logger.error(f"Manual save failed for tank {tank_id[:8]}")
+                return None
+        except Exception as e:
+            logger.error(f"Error saving tank {tank_id[:8]}: {e}", exc_info=True)
+            return None
+
+    async def save_all_now(self) -> int:
+        """Save all persistent tanks immediately.
+
+        Returns:
+            Number of tanks successfully saved
+        """
+        saved_count = 0
+
+        for manager in self._tank_registry:
+            if not manager.tank_info.persistent:
+                continue
+
+            result = await self.save_tank_now(manager.tank_id)
+            if result:
+                saved_count += 1
+
+        logger.info(f"Saved {saved_count} persistent tanks")
+        return saved_count

--- a/backend/tank_persistence.py
+++ b/backend/tank_persistence.py
@@ -318,3 +318,47 @@ def cleanup_old_snapshots(tank_id: str, max_snapshots: int = 10) -> int:
 
     logger.info(f"Cleaned up {deleted} old snapshots for tank {tank_id[:8]}")
     return deleted
+
+
+def get_latest_snapshot(tank_id: str) -> Optional[str]:
+    """Get the path to the most recent snapshot for a tank.
+
+    Args:
+        tank_id: The tank identifier
+
+    Returns:
+        Path to the latest snapshot file, or None if no snapshots exist
+    """
+    snapshots = list_tank_snapshots(tank_id)
+    if not snapshots:
+        return None
+
+    # Snapshots are sorted by newest first
+    return snapshots[0]["filepath"]
+
+
+def find_all_tank_snapshots() -> Dict[str, str]:
+    """Find the latest snapshot for each tank that has saved data.
+
+    Returns:
+        Dictionary mapping tank_id to latest snapshot path
+    """
+    if not DATA_DIR.exists():
+        return {}
+
+    tank_snapshots = {}
+
+    # Iterate through all tank directories
+    for tank_dir in DATA_DIR.iterdir():
+        if not tank_dir.is_dir():
+            continue
+
+        tank_id = tank_dir.name
+        latest_snapshot = get_latest_snapshot(tank_id)
+
+        if latest_snapshot:
+            tank_snapshots[tank_id] = latest_snapshot
+            logger.debug(f"Found snapshot for tank {tank_id[:8]}: {latest_snapshot}")
+
+    logger.info(f"Found {len(tank_snapshots)} tanks with saved snapshots")
+    return tank_snapshots


### PR DESCRIPTION
This commit implements automatic tank state persistence, allowing servers to save and restore tank state across restarts. This addresses the issue where tank persistence code existed but wasn't being used.

**Changes:**

1. **Auto-Save Service** (backend/auto_save_service.py):
   - New service that periodically saves persistent tanks
   - Configurable save interval (default: 5 minutes)
   - Automatic cleanup of old snapshots (keeps last 10)
   - Manual save support with save_tank_now() and save_all_now()

2. **Tank Persistence Enhancements** (backend/tank_persistence.py):
   - Added get_latest_snapshot() to find most recent snapshot for a tank
   - Added find_all_tank_snapshots() to discover all saved tanks
   - Support for automatic snapshot discovery on server startup

3. **TankInfo Updates** (backend/simulation_manager.py):
   - Added 'seed' field to TankInfo for deterministic behavior
   - Added 'persistent' flag to enable/disable auto-save per tank
   - Added 'auto_save_interval' to configure save frequency
   - Updated SimulationManager constructor to accept persistence settings

4. **Tank Registry Updates** (backend/tank_registry.py):
   - Updated create_tank() to support persistence settings
   - Updated CreateTankRequest with persistence fields
   - Added restore_tank_from_snapshot() method to registry
   - Enables creating tanks from existing snapshots with proper ID preservation

5. **Server Lifecycle Integration** (backend/main.py):
   - On startup: Check for existing snapshots and auto-restore tanks
   - If no snapshots found: Create default tank as before
   - Start auto-save service for all persistent tanks
   - On shutdown: Save all persistent tanks before stopping
   - Proper cleanup of auto-save tasks on shutdown

**Key Features:**
- Tanks are automatically saved every 5 minutes (configurable)
- On server restart, tanks are restored from the most recent snapshot
- Backward compatible: if no snapshots exist, creates fresh tanks
- Old snapshots are automatically cleaned up (keeps last 10)
- All state is preserved: entities, ecosystem stats, frame count, paused state

**Testing:**
- No syntax errors in modified files
- Ready for runtime testing with live server

🤖 Generated with [Claude Code](https://claude.com/claude-code)