### PR TITLE
Fix connection visibility with two tanks

### DIFF
--- a/frontend/src/components/TankNetworkMap.tsx
+++ b/frontend/src/components/TankNetworkMap.tsx
@@ -122,6 +122,24 @@ export function TankNetworkMap({ servers }: TankNetworkMapProps) {
             };
         };
 
+        // With only two tanks the default ring layout stacks them vertically, which hides
+        // the connecting tube in the middle. Give the pair a clear left/right layout so
+        // their connection line is always visible.
+        if (tanks.length === 2) {
+            return [
+                {
+                    ...tanks[0],
+                    x: centerX - radiusX / 2,
+                    y: centerY,
+                },
+                {
+                    ...tanks[1],
+                    x: centerX + radiusX / 2,
+                    y: centerY,
+                },
+            ];
+        }
+
         return tanks.map((tank, index) => {
             const position = getRingPosition(index, tanks.length, radiusX, radiusY, centerX, centerY);
             return {


### PR DESCRIPTION
## Summary
- adjust the tank network map layout for pairs of tanks to keep migration tubes visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69262d3f2a0083319a33640a28f706d7)