### PR TITLE
Include physical CPU cores in server info

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -154,6 +154,51 @@ def _handle_task_exception(task: asyncio.Task) -> None:
         logger.error(f"Error getting task exception: {e}", exc_info=True)
 
 
+def get_server_info() -> ServerInfo:
+    """Get information about the current server."""
+
+    uptime = time.time() - _server_start_time
+
+    # Try to get resource usage (optional)
+    cpu_percent = None
+    memory_mb = None
+    logical_cpus = os.cpu_count()
+    physical_cpus = None
+    try:
+        import psutil
+
+        process = psutil.Process()
+        cpu_percent = process.cpu_percent(interval=0.1)
+        memory_mb = process.memory_info().rss / 1024 / 1024  # Convert bytes to MB
+        physical_cpus = psutil.cpu_count(logical=False)
+        if physical_cpus is None:
+            physical_cpus = logical_cpus
+    except ImportError:
+        # psutil not available - that's okay
+        pass
+    except Exception as e:
+        logger.debug(f"Could not get resource usage: {e}")
+
+    return ServerInfo(
+        server_id=SERVER_ID,
+        hostname=socket.gethostname(),
+        host=_get_network_ip(),  # Use actual network IP for distributed setups
+        port=DEFAULT_API_PORT,
+        status="online",
+        tank_count=tank_registry.tank_count,
+        version=SERVER_VERSION,
+        uptime_seconds=uptime,
+        cpu_percent=cpu_percent,
+        memory_mb=memory_mb,
+        is_local=True,
+        platform=platform.system(),
+        architecture=platform.machine(),
+        hardware_model=platform.processor() or None,
+        logical_cpus=logical_cpus,
+        physical_cpus=physical_cpus,
+    )
+
+
 # Track background tasks
 _heartbeat_task: Optional[asyncio.Task] = None
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -227,6 +227,7 @@ class ServerInfo(BaseModel):
     architecture: Optional[str] = None  # CPU architecture (x86_64, arm64, etc.)
     hardware_model: Optional[str] = None  # Optional hardware descriptor
     logical_cpus: Optional[int] = None  # Logical CPU count for load estimation
+    physical_cpus: Optional[int] = None  # Physical core count when available
 
 
 class ServerWithTanks(BaseModel):


### PR DESCRIPTION
## Summary
- add physical core count to `ServerInfo` for clearer hardware reporting
- populate logical and physical CPU counts in `get_server_info`

## Testing
- python -m compileall backend/main.py backend/models.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69266c9e6a4c8331acb0629f4a087d02)