### PR TITLE
Preserve frame count when restoring snapshots

### DIFF
--- a/backend/tank_persistence.py
+++ b/backend/tank_persistence.py
@@ -327,7 +327,7 @@ def restore_tank_from_snapshot(snapshot: Dict[str, Any], target_world: Any) -> b
                 logger.warning(f"Skipping nectar restoration: missing source plant {source_plant_id}")
 
         # Restore frame number
-        target_world.frame = snapshot["frame"]
+        target_world.engine.frame_count = snapshot["frame"]
 
         # Restore ecosystem statistics
         if "ecosystem" in snapshot:


### PR DESCRIPTION
## Summary
- ensure restoring a tank snapshot sets the simulation engine frame count so frames persist after loading

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69267144eb248331870ba3e1eb6793d9)