### PR TITLE
Add targeted PokerSystem unit tests

### DIFF
--- a/core/poker_system.py
+++ b/core/poker_system.py
@@ -1,0 +1,167 @@
+"""Poker event management for simulation engines."""
+
+from collections import deque
+from typing import Any, Dict, List
+
+from core.fish_poker import PokerInteraction
+
+
+class PokerSystem:
+    """Handle poker interactions and event history."""
+
+    def __init__(self, engine, max_events: int) -> None:
+        self.engine = engine
+        self.poker_events: deque = deque(maxlen=max_events)
+
+    def handle_poker_result(self, poker: PokerInteraction) -> None:
+        """Handle poker outcomes, including reproduction and event logging."""
+        self.add_poker_event(poker)
+
+        if (
+            poker.result is not None
+            and poker.result.reproduction_occurred
+            and poker.result.offspring is not None
+        ):
+            self.engine.add_entity(poker.result.offspring)
+
+    def _add_poker_event_to_history(
+        self,
+        winner_id: int,
+        loser_id: int,
+        winner_hand: str,
+        loser_hand: str,
+        energy_transferred: float,
+        message: str,
+        is_jellyfish: bool,
+    ) -> None:
+        event = {
+            "frame": self.engine.frame_count,
+            "winner_id": winner_id,
+            "loser_id": loser_id,
+            "winner_hand": winner_hand,
+            "loser_hand": loser_hand,
+            "energy_transferred": energy_transferred,
+            "message": message,
+            "is_jellyfish": is_jellyfish,
+        }
+        self.poker_events.append(event)
+
+    def add_poker_event(self, poker: PokerInteraction) -> None:
+        """Add a poker event to the recent events list."""
+        if poker.result is None:
+            return
+
+        result = poker.result
+        num_players = len(result.player_ids)
+
+        if result.winner_id == -1:
+            hand1_desc = result.hand1.description if result.hand1 is not None else "Unknown"
+            if num_players == 2:
+                message = f"Fish #{poker.fish1.fish_id} vs Fish #{poker.fish2.fish_id} - TIE! ({hand1_desc})"
+            else:
+                player_list = ", ".join(f"#{pid}" for pid in result.player_ids)
+                message = f"Fish {player_list} - TIE! ({hand1_desc})"
+        else:
+            winner_hand_obj = None
+            for i, pid in enumerate(result.player_ids):
+                if pid == result.winner_id:
+                    winner_hand_obj = result.player_hands[i]
+                    break
+            winner_desc = winner_hand_obj.description if winner_hand_obj is not None else "Unknown"
+
+            if num_players == 2:
+                message = (
+                    f"Fish #{result.winner_id} beats Fish #{result.loser_id} "
+                    f"with {winner_desc}! (+{result.winner_actual_gain:.1f} energy)"
+                )
+            else:
+                loser_list = ", ".join(f"#{lid}" for lid in result.loser_ids)
+                message = (
+                    f"Fish #{result.winner_id} beats Fish {loser_list} "
+                    f"with {winner_desc}! (+{result.winner_actual_gain:.1f} energy)"
+                )
+
+        winner_hand_obj = result.hand1 if result.winner_id == poker.fish1.fish_id else result.hand2
+        loser_hand_obj = result.hand2 if result.winner_id == poker.fish1.fish_id else result.hand1
+        winner_hand_desc = winner_hand_obj.description if winner_hand_obj is not None else "Unknown"
+        loser_hand_desc = loser_hand_obj.description if loser_hand_obj is not None else "Unknown"
+
+        self._add_poker_event_to_history(
+            result.winner_id,
+            result.loser_id,
+            winner_hand_desc,
+            loser_hand_desc,
+            result.energy_transferred,
+            message,
+            is_jellyfish=False,
+        )
+
+    def add_jellyfish_poker_event(
+        self,
+        fish_id: int,
+        fish_won: bool,
+        fish_hand: str,
+        jellyfish_hand: str,
+        energy_transferred: float,
+    ) -> None:
+        """Add a jellyfish poker event to the recent events list."""
+        if fish_won:
+            message = f"Fish #{fish_id} beats Jellyfish with {fish_hand}! (+{energy_transferred:.1f} energy)"
+        else:
+            message = f"Jellyfish beats Fish #{fish_id} with {jellyfish_hand}! (-{energy_transferred:.1f} energy)"
+
+        self._add_poker_event_to_history(
+            winner_id=fish_id if fish_won else -2,
+            loser_id=-2 if fish_won else fish_id,
+            winner_hand=fish_hand if fish_won else jellyfish_hand,
+            loser_hand=jellyfish_hand if fish_won else fish_hand,
+            energy_transferred=energy_transferred,
+            message=message,
+            is_jellyfish=True,
+        )
+
+    def add_plant_poker_event(
+        self,
+        fish_id: int,
+        plant_id: int,
+        fish_won: bool,
+        fish_hand: str,
+        plant_hand: str,
+        energy_transferred: float,
+    ) -> None:
+        """Record a poker event between a fish and a plant."""
+        if fish_won:
+            winner_id = fish_id
+            loser_id = -3
+            winner_hand = fish_hand
+            loser_hand = plant_hand
+            message = f"Fish #{fish_id} beats Plant #{plant_id} with {fish_hand}! (+{energy_transferred:.1f}⚡)"
+        else:
+            winner_id = -3
+            loser_id = fish_id
+            winner_hand = plant_hand
+            loser_hand = fish_hand
+            message = f"Plant #{plant_id} beats Fish #{fish_id} with {plant_hand}! (+{energy_transferred:.1f}⚡)"
+
+        event = {
+            "frame": self.engine.frame_count,
+            "winner_id": winner_id,
+            "loser_id": loser_id,
+            "winner_hand": winner_hand,
+            "loser_hand": loser_hand,
+            "energy_transferred": energy_transferred,
+            "message": message,
+            "is_jellyfish": False,
+            "is_plant": True,
+            "plant_id": plant_id,
+        }
+
+        self.poker_events.append(event)
+
+    def get_recent_poker_events(self, max_age_frames: int) -> List[Dict[str, Any]]:
+        """Get recent poker events within a frame window."""
+        return [
+            event
+            for event in self.poker_events
+            if self.engine.frame_count - event["frame"] < max_age_frames
+        ]

--- a/core/reproduction_system.py
+++ b/core/reproduction_system.py
@@ -1,0 +1,46 @@
+"""Reproduction helpers for the simulation engine."""
+
+from typing import TYPE_CHECKING
+
+from core.constants import MATING_QUERY_RADIUS
+
+if TYPE_CHECKING:
+    from core.entities import Fish
+    from core.simulation_engine import SimulationEngine
+
+
+class ReproductionSystem:
+    """Handle fish reproduction logic using the engine context."""
+
+    def __init__(self, engine: "SimulationEngine") -> None:
+        self.engine = engine
+
+    def handle_reproduction(self) -> None:
+        """Handle fish reproduction by finding mates."""
+        from core.entities import Fish
+
+        all_entities = self.engine.get_all_entities()
+        fish_list = [e for e in all_entities if type(e) is Fish or isinstance(e, Fish)]
+
+        if len(fish_list) < 2:
+            return
+
+        environment = self.engine.environment
+
+        for fish in fish_list:
+            if not fish.can_reproduce():
+                continue
+
+            if environment is not None:
+                nearby_fish = environment.nearby_agents_by_type(
+                    fish, radius=MATING_QUERY_RADIUS, agent_class=Fish
+                )
+            else:
+                nearby_fish = [f for f in fish_list if f is not fish]
+
+            for potential_mate in nearby_fish:
+                if potential_mate is fish:
+                    continue
+
+                if fish.try_mate(potential_mate):
+                    break

--- a/tests/test_poker_system_unit.py
+++ b/tests/test_poker_system_unit.py
@@ -1,0 +1,138 @@
+"""Unit tests for the PokerSystem helper."""
+
+from types import SimpleNamespace
+
+from core.poker_system import PokerSystem
+
+
+class DummyEngine:
+    """Minimal engine stub for PokerSystem tests."""
+
+    def __init__(self) -> None:
+        self.frame_count = 5
+        self.added_entities = []
+
+    def add_entity(self, entity):
+        self.added_entities.append(entity)
+
+
+class DummyOffspring:
+    pass
+
+
+def _base_result(**overrides):
+    defaults = {
+        "winner_id": -1,
+        "loser_id": -1,
+        "player_ids": [1, 2],
+        "loser_ids": [2],
+        "player_hands": [SimpleNamespace(description="Pair of Aces"), SimpleNamespace(description="Two Pair")],
+        "hand1": SimpleNamespace(description="Pair of Aces"),
+        "hand2": SimpleNamespace(description="Two Pair"),
+        "winner_actual_gain": 0.0,
+        "energy_transferred": 0.0,
+        "reproduction_occurred": False,
+        "offspring": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _poker(result):
+    return SimpleNamespace(
+        result=result,
+        fish1=SimpleNamespace(fish_id=1),
+        fish2=SimpleNamespace(fish_id=2),
+        hand1=result.hand1,
+        hand2=result.hand2,
+    )
+
+
+def test_add_poker_event_records_tie_message():
+    engine = DummyEngine()
+    system = PokerSystem(engine, max_events=10)
+
+    tie_result = _base_result(winner_id=-1, loser_id=-1)
+    poker = _poker(tie_result)
+
+    system.add_poker_event(poker)
+
+    event = system.poker_events[-1]
+    assert event["winner_id"] == -1
+    assert event["loser_id"] == -1
+    assert "TIE" in event["message"]
+    assert event["frame"] == engine.frame_count
+
+
+def test_add_poker_event_records_win_message():
+    engine = DummyEngine()
+    system = PokerSystem(engine, max_events=10)
+
+    result = _base_result(winner_id=1, loser_id=2, winner_actual_gain=12.5, energy_transferred=7.5)
+    poker = _poker(result)
+
+    system.add_poker_event(poker)
+
+    event = system.poker_events[-1]
+    assert event["winner_id"] == 1
+    assert event["loser_id"] == 2
+    assert "+12.5" in event["message"]
+    assert event["energy_transferred"] == 7.5
+
+
+def test_handle_poker_result_adds_offspring():
+    engine = DummyEngine()
+    system = PokerSystem(engine, max_events=10)
+
+    offspring = DummyOffspring()
+    result = _base_result(
+        winner_id=1,
+        loser_id=2,
+        energy_transferred=3.0,
+        reproduction_occurred=True,
+        offspring=offspring,
+    )
+    poker = _poker(result)
+
+    system.handle_poker_result(poker)
+
+    assert offspring in engine.added_entities
+    assert len(system.poker_events) == 1
+
+
+def test_jellyfish_event_flags_and_message():
+    engine = DummyEngine()
+    system = PokerSystem(engine, max_events=10)
+
+    system.add_jellyfish_poker_event(
+        fish_id=5,
+        fish_won=True,
+        fish_hand="Flush",
+        jellyfish_hand="Pair",
+        energy_transferred=4.2,
+    )
+
+    event = system.poker_events[-1]
+    assert event["is_jellyfish"] is True
+    assert "Jellyfish" in event["message"]
+    assert event["winner_id"] == 5
+
+
+def test_plant_event_adds_metadata():
+    engine = DummyEngine()
+    system = PokerSystem(engine, max_events=10)
+
+    system.add_plant_poker_event(
+        fish_id=3,
+        plant_id=8,
+        fish_won=False,
+        fish_hand="Two Pair",
+        plant_hand="Flush",
+        energy_transferred=6.0,
+    )
+
+    event = system.poker_events[-1]
+    assert event["is_plant"] is True
+    assert event["plant_id"] == 8
+    assert event["winner_id"] == -3
+


### PR DESCRIPTION
## Summary
- add stub-based PokerSystem unit tests covering tie, win, and reproduction flows
- verify jellyfish and plant poker event metadata in the PokerSystem event log

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692682fe7f048331b745b71d7880b2e6)