### PR TITLE
Clamp betting payments to available energy

### DIFF
--- a/core/poker/simulation/engine.py
+++ b/core/poker/simulation/engine.py
@@ -248,11 +248,15 @@ def _apply_action(
 
         total_bet = call_payment + actual_raise
         game_state.player_bet(current_player, total_bet)
-        game_state.betting_history.append((current_player, action, actual_raise))
 
         if actual_raise > 0:
+            game_state.betting_history.append((current_player, action, actual_raise))
             game_state.last_raise_amount = actual_raise
             game_state.min_raise = actual_raise
+        else:
+            game_state.betting_history.append(
+                (current_player, BettingAction.CALL, call_payment)
+            )
 
         contexts[current_player].remaining_energy -= total_bet
         return False


### PR DESCRIPTION
## Summary
- prevent call calculations from producing negative values and cap calls to available energy
- limit raises to funds remaining after covering the call, falling back to an all-in call when needed
- keep betting history/pot updates in sync with the new call and raise clamping

## Testing
- python -m py_compile core/poker/simulation/engine.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926c1bd35a48331801044b8b22ebd3f)