### PR TITLE
Fix invisible fractal plants bug

### DIFF
--- a/frontend/src/utils/renderer.ts
+++ b/frontend/src/utils/renderer.ts
@@ -1273,8 +1273,8 @@ export class Renderer {
             ctx.strokeStyle = '#2d5a2d';
             ctx.lineWidth = 3;
             ctx.beginPath();
-            ctx.moveTo(x, y);
-            ctx.lineTo(x, y - height);
+            ctx.moveTo(x, y + height);  // Start at bottom of plant
+            ctx.lineTo(x, y);           // Draw up to top
             ctx.stroke();
             ctx.restore();
             return;


### PR DESCRIPTION
The fallback rendering for fractal plants without genome data was drawing the plant stem in the wrong direction. It was drawing from (x, y) to (x, y - height), which places the stem above the entity bounds and off-screen.

Fixed by drawing from the bottom to top: (x, y + height) to (x, y), which matches the coordinate system used by the main fractal plant renderer where y is the top of the plant and y + height is the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)