### PR TITLE
Improve lineage error handling and cleanup behavior template

### DIFF
--- a/core/algorithms/BEHAVIOR_TEMPLATE.py
+++ b/core/algorithms/BEHAVIOR_TEMPLATE.py
@@ -7,6 +7,7 @@ Follow the structure and comments below for best practices.
 File naming: Use descriptive names like 'food_seeking.py' or 'energy_management.py'
 """
 
+import random
 from typing import Tuple
 
 from core.algorithms.base import BehaviorAlgorithm
@@ -138,10 +139,6 @@ class BehaviorTemplate(BehaviorAlgorithm):
         threat_vector = self._get_predator_threat(fish)
         has_threat = threat_vector[0] != 0 or threat_vector[1] != 0
 
-        # Environmental context (optional)
-        # time_of_day = fish.environment.time_system.get_time_of_day()
-        # is_night = time_of_day in ["night", "dusk"]
-
         # --- STEP 2: MAKE DECISIONS ---
 
         # Default: no movement
@@ -159,8 +156,6 @@ class BehaviorTemplate(BehaviorAlgorithm):
                 return self._safe_normalize(dx, dy)
             else:
                 # No food visible: search desperately (random movement)
-                import random
-
                 dx = random.uniform(-1.0, 1.0)
                 dy = random.uniform(-1.0, 1.0)
                 return self._safe_normalize(dx, dy)
@@ -219,8 +214,6 @@ class BehaviorTemplate(BehaviorAlgorithm):
             else:
                 # No nearby fish, explore using custom pattern
                 # This is behavior-specific - implement your strategy here
-                import random
-
                 dx = random.uniform(-0.5, 0.5)
                 dy = random.uniform(-0.5, 0.5)
 

--- a/frontend/src/components/PhylogeneticTree.tsx
+++ b/frontend/src/components/PhylogeneticTree.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import Tree, { type CustomNodeElementProps } from 'react-d3-tree';
 import { transformLineageData } from '../utils/lineageUtils';
-import type { FishRecord, TreeNodeData } from '../utils/lineageUtils';
+import type { FishRecord, TreeNodeData, LineageTransformResult } from '../utils/lineageUtils';
 import { config } from '../config';
 import './PhylogeneticTree.css';
 
@@ -52,14 +52,19 @@ export const PhylogeneticTree: React.FC<PhylogeneticTreeProps> = ({ tankId }) =>
             const data: FishRecord[] = await response.json();
 
             if (data && data.length > 0) {
-                const nestedData = transformLineageData(data);
-                if (nestedData) {
-                    setTreeData(nestedData);
-                    setError(null);  // Clear any previous errors
+                const { tree, error: lineageError }: LineageTransformResult = transformLineageData(data);
+                if (lineageError) {
+                    setTreeData(null);
+                    setError(lineageError);
+                } else if (tree) {
+                    setTreeData(tree);
+                    setError(null); // Clear any previous errors
                 } else {
+                    setTreeData(null);
                     setError(`Failed to build phylogenetic tree from ${data.length} lineage records.`);
                 }
             } else {
+                setTreeData(null);
                 setError('No lineage data available yet. Fish need to reproduce to build the tree.');
             }
 


### PR DESCRIPTION
## Summary
- return structured lineage transform results instead of logging to console and surface errors in the tree component
- prevent hidden errors in the phylogenetic tree by resetting state when lineage parsing fails
- update the behavior template to remove dead code and avoid local imports

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692730bc296483318ff4a728800487f6)