### PR TITLE
Display player last move next to community cards

### DIFF
--- a/frontend/src/components/PokerGame.tsx
+++ b/frontend/src/components/PokerGame.tsx
@@ -151,6 +151,7 @@ export function PokerGame({ onClose, onAction, onNewRound, onGetAutopilotAction,
             <PokerTable
                 pot={gameState.pot}
                 communityCards={gameState.community_cards}
+                players={gameState.players}
                 resultBanner={gameState.game_over && !gameState.session_over ? (
                     <div className={`${styles.resultBanner} ${gameState.winner === 'You' ? styles.winBanner : styles.loseBanner}`}>
                         {gameState.winner === 'You' ? (

--- a/frontend/src/components/poker/PokerTable.module.css
+++ b/frontend/src/components/poker/PokerTable.module.css
@@ -86,3 +86,47 @@
 .resultArea {
     flex: 0 0 auto;
 }
+
+.lastMovesArea {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 200px;
+}
+
+.lastMovesLabel {
+    font-size: 10px;
+    color: #94a3b8;
+    text-align: center;
+}
+
+.lastMovesList {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: rgba(15, 23, 42, 0.5);
+    border: 1px solid rgba(59, 130, 246, 0.3);
+    border-radius: 6px;
+    padding: 8px;
+}
+
+.lastMoveItem {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+}
+
+.lastMovePlayer {
+    color: #94a3b8;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.lastMoveAction {
+    color: #fbbf24;
+    font-weight: bold;
+    text-transform: uppercase;
+    font-size: 11px;
+}

--- a/frontend/src/components/poker/PokerTable.tsx
+++ b/frontend/src/components/poker/PokerTable.tsx
@@ -5,6 +5,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { PlayingCard } from './PlayingCard';
 import { ChipStack } from './PokerChip';
+import type { PokerGamePlayer } from '../../types/simulation';
 import styles from './PokerTable.module.css';
 import cardStyles from './PlayingCard.module.css';
 
@@ -12,11 +13,12 @@ interface PokerTableProps {
     pot: number;
     communityCards: string[];
     resultBanner?: React.ReactNode;
+    players: PokerGamePlayer[];
 }
 
 const CARD_FLIP_DELAY = 1000; // 1 second between card flips
 
-export function PokerTable({ pot, communityCards, resultBanner }: PokerTableProps) {
+export function PokerTable({ pot, communityCards, resultBanner, players }: PokerTableProps) {
     const [revealedCards, setRevealedCards] = useState<string[]>([]);
     const [flippingIndex, setFlippingIndex] = useState<number | null>(null);
     const prevCardsRef = useRef<string[]>([]);
@@ -128,14 +130,33 @@ export function PokerTable({ pot, communityCards, resultBanner }: PokerTableProp
                     </div>
                 </div>
 
-                {/* Right side: Result banner only (phase is now in header) */}
-                {resultBanner && (
-                    <div className={styles.rightArea}>
+                {/* Right side: Last moves or result banner */}
+                <div className={styles.rightArea}>
+                    {/* Show last moves when game is active */}
+                    {!resultBanner && (
+                        <div className={styles.lastMovesArea}>
+                            <div className={styles.lastMovesLabel}>Last Moves</div>
+                            <div className={styles.lastMovesList}>
+                                {players.map((player) => (
+                                    <div key={player.player_id} className={styles.lastMoveItem}>
+                                        <span className={styles.lastMovePlayer}>
+                                            {player.is_human ? 'You' : player.name}:
+                                        </span>
+                                        <span className={styles.lastMoveAction}>
+                                            {player.last_action || '—'}
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                    {/* Show result banner when game is over */}
+                    {resultBanner && (
                         <div className={styles.resultArea}>
                             {resultBanner}
                         </div>
-                    </div>
-                )}
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -265,6 +265,7 @@ export interface PokerGamePlayer {
     algorithm?: string;
     genome_data?: FishGenomeData;
     hole_cards: string[];
+    last_action?: string | null;
 }
 
 export interface PokerGameState {


### PR DESCRIPTION
- Track last_action (fold, check, call, raise, bet) for each player in PlayerState
- Update game state serialization to include last_action field
- Add last_action to TypeScript PokerGamePlayer interface
- Display "Last Moves" panel to the right of community cards showing each player's most recent action
- Reset last_action at the start of each new hand
- Style last moves display with dark background and highlighted action text

🤖 Generated with [Claude Code](https://claude.com/claude-code)