### PR TITLE
Fix multiple player highlights during turns

### DIFF
--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -38,22 +38,24 @@ export function TankView({ tankId }: TankViewProps) {
 
     // Process AI turns one at a time with delay for visual feedback
     const processAiTurnsWithDelay = async () => {
-        const AI_TURN_DELAY = 800; // ms to show each AI player's turn
-        
+        const AI_TURN_DELAY = 1000; // ms to show each AI player's turn before they act
+
         const processNextAiTurn = async (): Promise<void> => {
             try {
+                // Wait BEFORE the AI makes their move so user can see who's about to act
+                await new Promise(resolve => setTimeout(resolve, AI_TURN_DELAY));
+
                 const response = await sendCommandWithResponse({
                     command: 'poker_process_ai_turn',
                     data: {},
                 });
-                
+
                 if (response.state) {
                     setPokerGameState(response.state);
                 }
-                
-                // If an action was taken, wait and check for more AI turns
+
+                // If an action was taken, process next AI turn
                 if (response.action_taken) {
-                    await new Promise(resolve => setTimeout(resolve, AI_TURN_DELAY));
                     await processNextAiTurn();
                 }
                 // If no action taken (human_turn or game_over), we're done
@@ -61,9 +63,8 @@ export function TankView({ tankId }: TankViewProps) {
                 console.error('Failed to process AI turn:', error);
             }
         };
-        
-        // Small initial delay to show the first AI player's highlight
-        await new Promise(resolve => setTimeout(resolve, 300));
+
+        // Start processing AI turns (delay happens at the beginning of processNextAiTurn)
         await processNextAiTurn();
     };
 


### PR DESCRIPTION
Problem: Multiple players were being highlighted at the same time, and AI players weren't visibly highlighted before making their moves.

Solution:
- Moved 1-second delay to BEFORE AI processes their turn (was after)
- Now highlights AI player for 1 second while waiting for their move
- Only one player is highlighted at a time (the one about to act)
- Increased delay from 800ms to 1000ms as requested

This gives users clear visual feedback about whose turn it is and prevents confusing multi-player highlights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)