### PR TITLE
Centralize backend logging configuration

### DIFF
--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -1,0 +1,52 @@
+"""Centralized logging configuration for backend services."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable, Optional
+
+DEFAULT_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
+DEFAULT_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
+def configure_logging(
+    *,
+    level: Optional[str] = None,
+    format: str = DEFAULT_FORMAT,
+    datefmt: str = DEFAULT_DATEFMT,
+    include_uvicorn: bool = True,
+    extra_loggers: Optional[Iterable[str]] = None,
+) -> logging.Logger:
+    """Configure application logging with sensible defaults.
+
+    Args:
+        level: Optional explicit log level. Falls back to ``TANK_LOG_LEVEL`` env
+            var or INFO when not provided.
+        format: Log format string.
+        datefmt: Date format string.
+        include_uvicorn: Whether to align uvicorn loggers with the backend level.
+        extra_loggers: Additional logger names to align with the configured level.
+
+    Returns:
+        The application logger configured for the backend (``tank.backend``).
+    """
+
+    resolved_level = (level or os.getenv("TANK_LOG_LEVEL", "INFO")).upper()
+    logging.basicConfig(level=resolved_level, format=format, datefmt=datefmt)
+
+    app_logger = logging.getLogger("tank.backend")
+    app_logger.setLevel(resolved_level)
+
+    if include_uvicorn:
+        for uvicorn_logger in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+            logging.getLogger(uvicorn_logger).setLevel(resolved_level)
+
+    if extra_loggers:
+        for logger_name in extra_loggers:
+            logging.getLogger(logger_name).setLevel(resolved_level)
+
+    app_logger.debug(
+        "Logging configured", extra={"level": resolved_level, "format": format}
+    )
+    return app_logger


### PR DESCRIPTION
## Summary
- add centralized logging configuration helper for backend services
- update FastAPI entrypoint to reuse shared logging setup and align uvicorn log levels

## Testing
- python -m compileall backend/logging_config.py backend/main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927d3b992688331b8480c31baf41ece)