### PR TITLE
Include tank name in simulation status logs

### DIFF
--- a/backend/simulation_manager.py
+++ b/backend/simulation_manager.py
@@ -96,7 +96,9 @@ class SimulationManager:
         )
 
         # Create simulation runner
-        self._runner = SimulationRunner(seed=seed)
+        self._runner = SimulationRunner(
+            seed=seed, tank_id=self.tank_info.tank_id, tank_name=self.tank_info.name
+        )
 
         # Track connected WebSocket clients
         self._connected_clients: Set[WebSocket] = set()

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -38,11 +38,18 @@ logger = logging.getLogger(__name__)
 class SimulationRunner:
     """Runs the simulation in a background thread and provides state updates."""
 
-    def __init__(self, seed: Optional[int] = None, tank_id: Optional[str] = None):
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        tank_id: Optional[str] = None,
+        tank_name: Optional[str] = None,
+    ):
         """Initialize the simulation runner.
 
         Args:
             seed: Optional random seed for deterministic behavior
+            tank_id: Optional unique identifier for the tank
+            tank_name: Optional human-readable name for the tank
         """
         # Create TankWorld configuration
         config = TankWorldConfig(headless=True)
@@ -97,6 +104,7 @@ class SimulationRunner:
 
         # Migration support
         self.tank_id = tank_id
+        self.tank_name = tank_name
         self.connection_manager = None  # Set after initialization
         self.tank_registry = None  # Set after initialization
         self.migration_lock = threading.Lock()
@@ -263,7 +271,8 @@ class SimulationRunner:
                         # Log stats periodically
                         stats = self.world.get_stats()
                         logger.info(
-                            f"Simulation Status: FPS={self.current_actual_fps:.1f}, "
+                            f"Simulation Status [Tank={self.tank_name or self.tank_id or 'Unknown'}]: "
+                            f"FPS={self.current_actual_fps:.1f}, "
                             f"Fish={stats.get('fish_count', 0)}, "
                             f"Plants={stats.get('plant_count', 0)}, "
                             f"Energy={stats.get('total_energy', 0.0):.1f}"


### PR DESCRIPTION
## Summary
- pass tank metadata into SimulationRunner so tank identifiers are available for logging
- include the tank name or id in periodic simulation status log entries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927d61a48a883319b6e0a4afc61e7b2)