### PR TITLE
Adjust simulation status log formatting

### DIFF
--- a/backend/simulation_manager.py
+++ b/backend/simulation_manager.py
@@ -96,7 +96,9 @@ class SimulationManager:
         )
 
         # Create simulation runner
-        self._runner = SimulationRunner(seed=seed)
+        self._runner = SimulationRunner(
+            seed=seed, tank_id=self.tank_info.tank_id, tank_name=self.tank_info.name
+        )
 
         # Track connected WebSocket clients
         self._connected_clients: Set[WebSocket] = set()

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -38,11 +38,18 @@ logger = logging.getLogger(__name__)
 class SimulationRunner:
     """Runs the simulation in a background thread and provides state updates."""
 
-    def __init__(self, seed: Optional[int] = None, tank_id: Optional[str] = None):
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        tank_id: Optional[str] = None,
+        tank_name: Optional[str] = None,
+    ):
         """Initialize the simulation runner.
 
         Args:
             seed: Optional random seed for deterministic behavior
+            tank_id: Optional unique identifier for the tank
+            tank_name: Optional human-readable name for the tank
         """
         # Create TankWorld configuration
         config = TankWorldConfig(headless=True)
@@ -97,6 +104,7 @@ class SimulationRunner:
 
         # Migration support
         self.tank_id = tank_id
+        self.tank_name = tank_name
         self.connection_manager = None  # Set after initialization
         self.tank_registry = None  # Set after initialization
         self.migration_lock = threading.Lock()
@@ -262,8 +270,10 @@ class SimulationRunner:
                         self.last_fps_time = current_time
                         # Log stats periodically
                         stats = self.world.get_stats()
+                        tank_label = self.tank_name or self.tank_id or "Unknown Tank"
                         logger.info(
-                            f"Simulation Status: FPS={self.current_actual_fps:.1f}, "
+                            f"{tank_label} Simulation Status "
+                            f"FPS={self.current_actual_fps:.1f}, "
                             f"Fish={stats.get('fish_count', 0)}, "
                             f"Plants={stats.get('plant_count', 0)}, "
                             f"Energy={stats.get('total_energy', 0.0):.1f}"

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -98,8 +98,6 @@ class SimulationRunner:
         self.auto_eval_running: bool = False
         self.auto_eval_interval_seconds = 15.0
         self.last_auto_eval_time = 0.0
-        self.auto_eval_interval_seconds = 15.0
-        self.last_auto_eval_time = 0.0
         self.auto_eval_lock = threading.Lock()
 
         # Migration support
@@ -250,14 +248,14 @@ class SimulationRunner:
                     frame_count += 1
 
                     with self.lock:
-                            try:
-                                self.world.update()
-                            except Exception as e:
-                                logger.error(
-                                    f"Simulation loop: Error updating world at frame {frame_count}: {e}",
-                                    exc_info=True,
-                                )
-                                # Continue running even if update fails
+                        try:
+                            self.world.update()
+                        except Exception as e:
+                            logger.error(
+                                f"Simulation loop: Error updating world at frame {frame_count}: {e}",
+                                exc_info=True,
+                            )
+                            # Continue running even if update fails
 
                     self._start_auto_evaluation_if_needed()
 


### PR DESCRIPTION
## Summary
- simplify periodic simulation status logs to prefix with the tank label without brackets

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927d61a48a883319b6e0a4afc61e7b2)