### PR TITLE
Release root spots when fractal plants are removed

### DIFF
--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -390,6 +390,9 @@ class SimulationEngine(BaseSimulator):
     def remove_entity(self, entity: entities.Agent) -> None:
         """Remove an entity from the simulation."""
         if entity in self.entities_list:
+            # Ensure fractal plant root spots are released even when removed externally
+            if isinstance(entity, FractalPlant):
+                entity.die()
             self.entities_list.remove(entity)
             # Remove from spatial grid incrementally
             if self.environment:


### PR DESCRIPTION
## Summary
- ensure removing a fractal plant always releases its root spot so future plants can spawn
- remove the fallback emergency respawn logic added previously

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288daa186c8331a6a013b74b8edaa8)