### PR TITLE
Allow plants to migrate between connected tanks

### DIFF
--- a/backend/migration_handler.py
+++ b/backend/migration_handler.py
@@ -77,8 +77,8 @@ class BackendMigrationHandler:
 
         # Perform the migration
         try:
-            # Serialize the entity
-            entity_data = serialize_entity_for_transfer(entity)
+            # Serialize the entity (pass direction for plants to select appropriate edge spot)
+            entity_data = serialize_entity_for_transfer(entity, migration_direction=direction)
             if entity_data is None:
                 logger.error("Failed to serialize entity for transfer")
                 return False

--- a/core/root_spots.py
+++ b/core/root_spots.py
@@ -345,3 +345,37 @@ class RootSpotManager:
 
         # Fall back to any empty spot
         return self.get_random_empty_spot()
+
+    def get_edge_empty_spot(self, direction: str) -> Optional[RootSpot]:
+        """Get an empty spot at the specified edge of the tank.
+
+        Used for plant migration - plants migrating from the left should appear
+        on the right, and vice versa.
+
+        Args:
+            direction: "left" or "right" - which edge to prefer
+
+        Returns:
+            Empty RootSpot at the specified edge, or None if all spots are occupied
+        """
+        empty_spots = [s for s in self.spots if not s.occupied and not s.blocked]
+        if not empty_spots:
+            return None
+
+        # Define edge spots (first 3 and last 3 of the spot list)
+        edge_count = 3
+
+        if direction == "left":
+            # Prefer leftmost spots (low spot IDs)
+            edge_spots = [s for s in empty_spots if s.spot_id < edge_count]
+        else:  # "right"
+            # Prefer rightmost spots (high spot IDs)
+            total_spots = len(self.spots)
+            edge_spots = [s for s in empty_spots if s.spot_id >= total_spots - edge_count]
+
+        # If edge spots are available, prefer them
+        if edge_spots:
+            return random.choice(edge_spots)
+
+        # Fall back to any empty spot if edge spots are full
+        return random.choice(empty_spots)


### PR DESCRIPTION
Plants in leftmost or rightmost root spots (first 2 and last 2 of 25) can now migrate to connected tanks:

- Plants periodically check for migration (every 300 frames)
- Edge plants have 20% probability to migrate per check
- Migrating plants appear at opposite edge in destination tank (left → right edge, right → left edge)
- Root spot manager now has get_edge_empty_spot() for edge placement
- Migration uses same dependency injection pattern as fish
- Migrated plants release root spot and are removed from source

Backend changes:
- serialize_entity_for_transfer() accepts migration_direction parameter
- _deserialize_plant() prefers edge spots for migrating plants
- Migration handler passes direction to serialization

Core changes:
- FractalPlant tracks migration with _migrated flag and timer
- is_dead() returns true for migrated plants
- _attempt_migration() delegates to environment.migration_handler
- _check_migration() determines edge position and attempts migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)