### PR TITLE
Add delete functionality for network tanks

### DIFF
--- a/backend/routers/tanks.py
+++ b/backend/routers/tanks.py
@@ -200,13 +200,6 @@ def setup_router(
         Returns:
             Success message or 404 if not found
         """
-        # Don't allow deleting the default tank
-        if tank_id == tank_registry.default_tank_id and tank_registry.tank_count == 1:
-            return JSONResponse(
-                {"error": "Cannot delete the last remaining tank"},
-                status_code=400,
-            )
-
         # Stop broadcast first
         await stop_broadcast_callback(tank_id)
 

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -300,15 +300,15 @@ def test_pause_and_resume_update_status_and_trigger_broadcast():
     assert start_calls == [manager.tank_id]
 
 
-def test_cannot_delete_last_remaining_tank():
+def test_can_delete_last_remaining_tank():
     manager = FakeTankManager("tank-1", "Tank 1")
     registry = FakeTankRegistry([manager])
     client = build_tanks_client(registry)
 
     response = client.delete(f"/api/tanks/{manager.tank_id}")
 
-    assert response.status_code == 400
-    assert "Cannot delete the last remaining tank" in response.json()["error"]
+    assert response.status_code == 200
+    assert "deleted" in response.json()["message"].lower()
 
 
 def test_create_tank_rejects_invalid_server():


### PR DESCRIPTION
Removed the restriction that prevented users from deleting the last tank in the registry. Previously, attempting to delete the only remaining tank would return a 400 error with message "Cannot delete the last remaining tank".

Changes:
- Removed check in DELETE /api/tanks/{tank_id} endpoint that prevented deletion when tank_count == 1
- Updated test from test_cannot_delete_last_remaining_tank to test_can_delete_last_remaining_tank
- Test now expects 200 success response instead of 400 error

Users can now delete all tanks from the network dashboard, including the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)