### PR TITLE
Broaden food grid to include all Food subclasses

### DIFF
--- a/core/environment.py
+++ b/core/environment.py
@@ -8,7 +8,7 @@ import math
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type
 
-from core.entities import Agent
+from core.entities import Agent, Food
 
 
 class SpatialGrid:
@@ -35,6 +35,10 @@ class SpatialGrid:
         self.cell_size = cell_size
         self.cols = math.ceil(width / cell_size)
         self.rows = math.ceil(height / cell_size)
+
+        # Base type used to identify all food-like agents (covers subclasses
+        # like LiveFood and PlantNectar without needing explicit name checks)
+        self._food_base_type = Food
 
         # Grid storage: dict of (col, row) -> dict of type -> list of agents
         # Using list instead of set for faster iteration in tight loops
@@ -71,7 +75,7 @@ class SpatialGrid:
         type_name = agent_type.__name__
         if type_name == 'Fish':
             self.fish_grid[cell].append(agent)
-        elif type_name == 'Food' or type_name == 'LiveFood':
+        elif issubclass(agent_type, self._food_base_type):
             self.food_grid[cell].append(agent)
             
         self.agent_cells[agent] = cell
@@ -97,7 +101,7 @@ class SpatialGrid:
                     self.fish_grid[cell].remove(agent)
                     if not self.fish_grid[cell]:
                         del self.fish_grid[cell]
-            elif type_name == 'Food' or type_name == 'LiveFood':
+            elif issubclass(agent_type, self._food_base_type):
                 if agent in self.food_grid[cell]:
                     self.food_grid[cell].remove(agent)
                     if not self.food_grid[cell]:
@@ -133,7 +137,7 @@ class SpatialGrid:
                         self.fish_grid[old_cell].remove(agent)
                         if not self.fish_grid[old_cell]:
                             del self.fish_grid[old_cell]
-                elif type_name == 'Food' or type_name == 'LiveFood':
+                elif issubclass(agent_type, self._food_base_type):
                     if agent in self.food_grid[old_cell]:
                         self.food_grid[old_cell].remove(agent)
                         if not self.food_grid[old_cell]:
@@ -146,7 +150,7 @@ class SpatialGrid:
             type_name = agent_type.__name__
             if type_name == 'Fish':
                 self.fish_grid[new_cell].append(agent)
-            elif type_name == 'Food' or type_name == 'LiveFood':
+            elif issubclass(agent_type, self._food_base_type):
                 self.food_grid[new_cell].append(agent)
                 
             self.agent_cells[agent] = new_cell


### PR DESCRIPTION
## Summary
- index food grid entries using the base Food type so all subclasses, including nectar, are tracked
- ensure add/remove/update operations use subclass checks rather than name matching for food agents

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692946b66cc48331ba3180fd07aa6586)