### PR TITLE
Promote module-level imports for simulation performance

### DIFF
--- a/core/collision_system.py
+++ b/core/collision_system.py
@@ -6,6 +6,7 @@ This module provides collision detection for entity objects in the simulation.
 from typing import TYPE_CHECKING
 
 from core.constants import FRACTAL_PLANTS_ENABLED
+from core.entities.fractal_plant import PlantNectar
 
 if TYPE_CHECKING:
     from core.entities import Agent
@@ -110,8 +111,6 @@ class CollisionSystem:
 
     def handle_fish_food_collision(self, fish: "Agent", food: "Agent") -> None:
         """Handle collision between a fish and food, including plant nectar."""
-        from core.entities.fractal_plant import PlantNectar
-
         if isinstance(food, PlantNectar) and FRACTAL_PLANTS_ENABLED:
             fish.eat(food)
 

--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -6,6 +6,7 @@ simulation without any visualization code.
 
 import json
 import logging
+import os
 import random
 import time
 from typing import Any, Dict, List, Optional
@@ -48,6 +49,8 @@ from core.fish_poker import PokerInteraction
 from core.genetics import Genome
 from core.object_pool import FoodPool
 from core.poker_system import PokerSystem
+from core.poker.evaluation.benchmark_eval import BenchmarkEvalConfig
+from core.poker.evaluation.periodic_benchmark import PeriodicBenchmarkEvaluator
 from core.plant_genetics import PlantGenome
 from core.registry import get_algorithm_metadata
 from core.reproduction_system import ReproductionSystem
@@ -190,11 +193,8 @@ class SimulationEngine(BaseSimulator):
         ]
 
         # Periodic poker benchmark evaluation
-        self.benchmark_evaluator: Optional["PeriodicBenchmarkEvaluator"] = None
+        self.benchmark_evaluator: Optional[PeriodicBenchmarkEvaluator] = None
         if enable_poker_benchmarks:
-            from core.poker.evaluation.benchmark_eval import BenchmarkEvalConfig
-            from core.poker.evaluation.periodic_benchmark import PeriodicBenchmarkEvaluator
-
             self.benchmark_evaluator = PeriodicBenchmarkEvaluator(
                 BenchmarkEvalConfig()
             )
@@ -1130,8 +1130,6 @@ class SimulationEngine(BaseSimulator):
             logger.info(f"{report}")
 
             # Save to file
-            import os
-
             os.makedirs("logs", exist_ok=True)
             report_path = os.path.join("logs", "algorithm_performance_report.txt")
             with open(report_path, "w") as f:


### PR DESCRIPTION
## Summary
- move collision handling's PlantNectar dependency to module scope to avoid repeated imports
- lift poker benchmark and filesystem imports to module level in the simulation engine and update typing

## Testing
- python -m compileall core/collision_system.py core/simulation_engine.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d8837458833188fbe5490f377db5)