### PR TITLE
Add energy and poker stats to network screen

### DIFF
--- a/backend/simulation_manager.py
+++ b/backend/simulation_manager.py
@@ -274,6 +274,7 @@ class SimulationManager:
                 "total_energy": world_stats.get("total_energy", 0.0),
                 "fish_energy": world_stats.get("fish_energy", 0.0),
                 "plant_energy": world_stats.get("plant_energy", 0.0),
+                "poker_stats": world_stats.get("poker_stats", {}),
             }
         except Exception as exc:  # pragma: no cover - defensive guard
             logger.warning("Failed to collect stats for tank %s: %s", self.tank_id, exc)

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -194,6 +194,16 @@ export interface TankStatsSummary {
     total_energy: number;
     fish_energy: number;
     plant_energy: number;
+    poker_stats?: {
+        total_games: number;
+        total_wins: number;
+        total_losses: number;
+        total_ties: number;
+        win_rate?: number;
+        net_energy: number;
+        total_energy_won: number;
+        total_energy_lost: number;
+    };
 }
 
 /**

--- a/frontend/src/pages/NetworkDashboard.tsx
+++ b/frontend/src/pages/NetworkDashboard.tsx
@@ -548,6 +548,7 @@ function TankCard({ tankStatus, onDelete, onRefresh }: TankCardProps) {
         total_energy: 0,
         fish_energy: 0,
         plant_energy: 0,
+        poker_stats: undefined,
     };
 
     const [actionLoading, setActionLoading] = useState(false);
@@ -671,6 +672,60 @@ function TankCard({ tankStatus, onDelete, onRefresh }: TankCardProps) {
                         </div>
                     </div>
                 </div>
+
+                {/* Energy Stats */}
+                <div style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(3, 1fr)',
+                    gap: '10px',
+                }}>
+                    <div style={{ background: '#1e293b', borderRadius: '6px', padding: '10px', border: '1px solid #334155' }}>
+                        <div style={{ fontSize: '10px', color: '#94a3b8', marginBottom: 3 }}>Total Energy</div>
+                        <div style={{ fontSize: '16px', color: '#22c55e', fontWeight: 700 }}>
+                            {stats.total_energy?.toFixed(0) ?? '0'}
+                        </div>
+                    </div>
+                    <div style={{ background: '#1e293b', borderRadius: '6px', padding: '10px', border: '1px solid #334155' }}>
+                        <div style={{ fontSize: '10px', color: '#94a3b8', marginBottom: 3 }}>Fish Energy</div>
+                        <div style={{ fontSize: '16px', color: '#3b82f6', fontWeight: 700 }}>
+                            {stats.fish_energy?.toFixed(0) ?? '0'}
+                        </div>
+                    </div>
+                    <div style={{ background: '#1e293b', borderRadius: '6px', padding: '10px', border: '1px solid #334155' }}>
+                        <div style={{ fontSize: '10px', color: '#94a3b8', marginBottom: 3 }}>Plant Energy</div>
+                        <div style={{ fontSize: '16px', color: '#10b981', fontWeight: 700 }}>
+                            {stats.plant_energy?.toFixed(0) ?? '0'}
+                        </div>
+                    </div>
+                </div>
+
+                {/* Poker Stats */}
+                {stats.poker_stats && stats.poker_stats.total_games > 0 && (
+                    <div style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'repeat(3, 1fr)',
+                        gap: '10px',
+                    }}>
+                        <div style={{ background: '#1e293b', borderRadius: '6px', padding: '10px', border: '1px solid #334155' }}>
+                            <div style={{ fontSize: '10px', color: '#94a3b8', marginBottom: 3 }}>Poker Games</div>
+                            <div style={{ fontSize: '16px', color: '#e2e8f0', fontWeight: 700 }}>
+                                {stats.poker_stats.total_games.toLocaleString()}
+                            </div>
+                        </div>
+                        <div style={{ background: '#1e293b', borderRadius: '6px', padding: '10px', border: '1px solid #334155' }}>
+                            <div style={{ fontSize: '10px', color: '#94a3b8', marginBottom: 3 }}>Win Rate</div>
+                            <div style={{ fontSize: '16px', color: stats.poker_stats.win_rate && stats.poker_stats.win_rate > 50 ? '#22c55e' : '#e2e8f0', fontWeight: 700 }}>
+                                {stats.poker_stats.win_rate != null ? `${stats.poker_stats.win_rate.toFixed(1)}%` : '—'}
+                            </div>
+                        </div>
+                        <div style={{ background: '#1e293b', borderRadius: '6px', padding: '10px', border: '1px solid #334155' }}>
+                            <div style={{ fontSize: '10px', color: '#94a3b8', marginBottom: 3 }}>Net Energy</div>
+                            <div style={{ fontSize: '16px', color: stats.poker_stats.net_energy > 0 ? '#22c55e' : stats.poker_stats.net_energy < 0 ? '#ef4444' : '#e2e8f0', fontWeight: 700 }}>
+                                {stats.poker_stats.net_energy > 0 ? '+' : ''}{stats.poker_stats.net_energy.toFixed(0)}
+                            </div>
+                        </div>
+                    </div>
+                )}
 
                 {/* Actions */}
                 <div style={{


### PR DESCRIPTION
Display key tank statistics on the network dashboard:
- Energy breakdown: total, fish, and plant energy with color-coded values
- Poker performance: games played, win rate, and net energy (when available)
- Energy stats always visible in 3-column grid
- Poker stats conditionally shown when games have been played
- Color-coded poker metrics (green for positive, red for negative)

Backend changes:
- Include poker_stats in tank status API response (simulation_manager.py:277)

Frontend changes:
- Update TankStatsSummary type to include poker_stats (config.ts:197-206)
- Add energy stats grid to NetworkDashboard tank cards (NetworkDashboard.tsx:676-699)
- Add conditional poker stats grid (NetworkDashboard.tsx:702-727)

🤖 Generated with [Claude Code](https://claude.com/claude-code)