### PR TITLE
Improve simulation logging and import hygiene

### DIFF
--- a/core/algorithms/food_seeking.py
+++ b/core/algorithms/food_seeking.py
@@ -69,6 +69,7 @@ from core.constants import (
 )
 from core.entities import Crab, Food
 from core.entities import Fish as FishClass
+from core.predictive_movement import predict_intercept_point
 
 
 @dataclass
@@ -115,8 +116,6 @@ class GreedyFoodSeeker(BehaviorAlgorithm):
             if distance < max_chase_distance:
                 # NEW: Use predictive interception for moving food
                 if hasattr(nearest_food, "vel") and nearest_food.vel.length() > FOOD_VELOCITY_THRESHOLD:
-                    from core.predictive_movement import predict_intercept_point
-
                     intercept_point, _ = predict_intercept_point(
                         fish.pos, fish.speed, nearest_food.pos, nearest_food.vel
                     )

--- a/core/algorithms/schooling.py
+++ b/core/algorithms/schooling.py
@@ -358,8 +358,6 @@ class BoidsBehavior(BehaviorAlgorithm):
         return cls()
 
     def execute(self, fish: "Fish") -> Tuple[float, float]:
-        import math
-
         # Use spatial query to only check nearby fish (O(N) instead of O(N²))
         # Use 200 radius to match predator detection range and boid interaction range
         QUERY_RADIUS = 200

--- a/core/collision_system.py
+++ b/core/collision_system.py
@@ -3,8 +3,10 @@
 This module provides collision detection for entity objects in the simulation.
 """
 
+import random
 from typing import TYPE_CHECKING
 
+from core.config.plants import FRACTAL_PLANT_SPROUTING_CHANCE
 from core.constants import FRACTAL_PLANTS_ENABLED
 from core.entities.fractal_plant import PlantNectar
 
@@ -120,9 +122,6 @@ class CollisionSystem:
                 parent_y = food.source_plant.pos.y if food.source_plant else food.pos.y
 
                 # Check sprouting chance
-                import random
-                from core.config.plants import FRACTAL_PLANT_SPROUTING_CHANCE
-                
                 if random.random() < FRACTAL_PLANT_SPROUTING_CHANCE:
                     self.engine.sprout_new_plant(parent_genome, parent_x, parent_y)
                 

--- a/core/entities/fish.py
+++ b/core/entities/fish.py
@@ -1,5 +1,6 @@
 """Fish entity logic and genetics handling."""
 
+import logging
 import random
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
@@ -25,6 +26,9 @@ from core.constants import (
 )
 from core.entities.base import Agent, LifeStage
 from core.math_utils import Vector2
+
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from core.ecosystem import EcosystemManager
@@ -419,10 +423,6 @@ class Fish(Agent):
         Returns:
             True if migration successful, False if no migration handler or migration failed
         """
-        import logging
-
-        logger = logging.getLogger(__name__)
-
         # Check if environment provides migration handler (dependency injection)
         if not hasattr(self.environment, "migration_handler"):
             logger.debug(f"Fish #{self.fish_id}: No migration_handler in environment")

--- a/core/entities/fractal_plant.py
+++ b/core/entities/fractal_plant.py
@@ -5,6 +5,7 @@ collect energy passively, produce nectar for reproduction, and
 can play poker against fish.
 """
 
+import logging
 import random
 from typing import TYPE_CHECKING, Optional
 
@@ -29,6 +30,9 @@ from core.constants import (
     FRACTAL_PLANT_NECTAR_COOLDOWN,
     FRACTAL_PLANT_POKER_COOLDOWN,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class FractalPlant(Agent):
@@ -466,10 +470,6 @@ class FractalPlant(Agent):
         Returns:
             True if migration successful, False otherwise
         """
-        import logging
-
-        logger = logging.getLogger(__name__)
-
         # Check if environment provides migration handler (dependency injection)
         if not hasattr(self.environment, "migration_handler"):
             return False


### PR DESCRIPTION
## Summary
- move local imports in core collision handling and behavior algorithms to module scope to reduce call overhead
- add shared module-level loggers for fish and fractal plant migration flows
- reuse configured constants for plant sprouting without repeated dynamic imports

## Testing
- python -m compileall core


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929fc6a76508331977e6d08083bbccb)