### PR TITLE
Add evolution smoke test harness and coverage

### DIFF
--- a/core/evolution/smoke_test.py
+++ b/core/evolution/smoke_test.py
@@ -1,0 +1,116 @@
+"""Lightweight helpers for exercising the evolution pipeline.
+
+These utilities intentionally avoid the full simulation stack and instead
+run a quick sequence of genome crossovers and mutations. The goal is to
+provide a fun, low-friction way to observe evolutionary drift without
+needing rendering or the full game loop.
+"""
+from __future__ import annotations
+
+import math
+import random
+from typing import Dict, List, Sequence
+
+from core.genetics import Genome
+
+
+def _summarize_population(population: Sequence[Genome]) -> Dict[str, float]:
+    """Calculate simple metrics for a population snapshot."""
+    speeds = [g.speed_modifier for g in population]
+    aggression = [g.aggression for g in population]
+    fertility = [g.fertility for g in population]
+    metabolism = [g.metabolism_rate for g in population]
+
+    def _mean(values: List[float]) -> float:
+        return sum(values) / len(values)
+
+    def _stdev(values: List[float]) -> float:
+        mu = _mean(values)
+        return math.sqrt(sum((v - mu) ** 2 for v in values) / len(values))
+
+    return {
+        "speed_min": min(speeds),
+        "speed_max": max(speeds),
+        "speed_mean": _mean(speeds),
+        "speed_spread": max(speeds) - min(speeds),
+        "speed_stdev": _stdev(speeds),
+        "aggression_mean": _mean(aggression),
+        "fertility_mean": _mean(fertility),
+        "metabolism_mean": _mean(metabolism),
+    }
+
+
+def run_evolution_smoke_test(
+    seed: int = 7,
+    population_size: int = 12,
+    generations: int = 6,
+) -> Dict[str, object]:
+    """Run a playful evolution loop over a handful of generations.
+
+    Returns a report dictionary that can be rendered for humans or asserted
+    against in tests.
+    """
+    rng = random.Random(seed)
+    population = [Genome.random(use_algorithm=False, rng=rng) for _ in range(population_size)]
+    generation_reports: List[Dict[str, float]] = []
+
+    for gen in range(generations):
+        snapshot = _summarize_population(population)
+        # Increase stress slowly so later generations mutate more aggressively
+        snapshot["population_stress"] = min(1.0, 0.25 + gen * 0.1)
+        snapshot["generation"] = gen
+        generation_reports.append(snapshot)
+
+        next_population: List[Genome] = []
+        for _ in range(population_size):
+            parent1, parent2 = rng.sample(population, 2)
+            child = Genome.from_parents(
+                parent1,
+                parent2,
+                population_stress=snapshot["population_stress"],
+                rng=rng,
+            )
+            next_population.append(child)
+        population = next_population
+
+    final_snapshot = _summarize_population(population)
+    champions = sorted(population, key=lambda g: g.speed_modifier, reverse=True)[:3]
+    champion_speeds = [round(c.speed_modifier, 3) for c in champions]
+
+    return {
+        "seed": seed,
+        "population_size": population_size,
+        "generations": generation_reports,
+        "final_population_stats": final_snapshot,
+        "champion_speeds": champion_speeds,
+    }
+
+
+def format_report(report: Dict[str, object]) -> str:
+    """Create a friendly multi-line string showing evolutionary drift."""
+    lines = [
+        "🚀 Evolution smoke test",
+        f"Seed: {report['seed']} | Population: {report['population_size']}",
+        "",
+        "Gen | speed μ  | spread | σ      | aggression μ | fertility μ",
+        "----+---------+--------+--------+--------------+------------",
+    ]
+
+    for gen_snapshot in report["generations"]:
+        lines.append(
+            f"{gen_snapshot['generation']:>3} | "
+            f"{gen_snapshot['speed_mean']:.3f} | "
+            f"{gen_snapshot['speed_spread']:.3f} | "
+            f"{gen_snapshot['speed_stdev']:.3f} | "
+            f"{gen_snapshot['aggression_mean']:.3f}     | "
+            f"{gen_snapshot['fertility_mean']:.3f}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "Top speeds in final generation: " + ", ".join(map(str, report["champion_speeds"])),
+            "(Higher spreads imply more evolutionary diversity across runs)",
+        ]
+    )
+    return "\n".join(lines)

--- a/scripts/run_evolution_smoke_test.py
+++ b/scripts/run_evolution_smoke_test.py
@@ -1,0 +1,7 @@
+"""Quick command-line harness for the evolution smoke test."""
+from core.evolution.smoke_test import format_report, run_evolution_smoke_test
+
+
+if __name__ == "__main__":
+    report = run_evolution_smoke_test()
+    print(format_report(report))

--- a/tests/test_evolution_smoke.py
+++ b/tests/test_evolution_smoke.py
@@ -1,0 +1,28 @@
+import re
+
+from core.evolution.smoke_test import format_report, run_evolution_smoke_test
+
+
+def test_smoke_test_generates_diversity_and_report():
+    report = run_evolution_smoke_test(seed=11, population_size=10, generations=5)
+
+    # Core structure should be present
+    assert report["seed"] == 11
+    assert len(report["generations"]) == 5
+    assert "final_population_stats" in report
+
+    # Evolution should change the mean speed over time
+    first_speed = report["generations"][0]["speed_mean"]
+    final_speed = report["generations"][-1]["speed_mean"]
+    assert abs(final_speed - first_speed) > 0.01
+
+    # Diversity should be visible through speed spread and champion speeds
+    spreads = [snapshot["speed_spread"] for snapshot in report["generations"]]
+    assert all(spread > 0 for spread in spreads)
+    assert len(report["champion_speeds"]) == 3
+
+    # The formatted report should include the header and generation rows
+    output = format_report(report)
+    assert output.startswith("🚀 Evolution smoke test")
+    assert re.search(r"Gen \|", output)
+    assert "Top speeds in final generation" in output


### PR DESCRIPTION
## Summary
- add a lightweight evolution smoke test helper to exercise genome crossover and mutation
- provide a CLI script to render a quick evolution report for humans
- cover the new helper with a pytest that ensures diversity and friendly reporting

## Testing
- pytest tests/test_evolution_smoke.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321bec3da88331bee66d8df14942dd)