### PR TITLE
Remove unused fertility trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ MAX_FOOD_CAPACITY = 8  # per plant
 ## 🧬 Genetics & Evolution
 
 ### Heritable Traits
-- **Physical traits**: Speed, size, vision range, metabolism, max energy, fertility
+- **Physical traits**: Speed, size, vision range, metabolism, max energy
 - **Visual traits**: Body shape, fin size, tail size, color pattern
 - **Behavior algorithm**: One of 58 parametrizable algorithms (inherited from parent)
 - **Algorithm parameters**: Tunable values that control algorithm behavior

--- a/backend/entity_transfer.py
+++ b/backend/entity_transfer.py
@@ -91,7 +91,6 @@ def finalize_fish_serialization(fish: Any, mutable_state: Dict[str, Any]) -> Dic
         "parent_id": fish.parent_id if hasattr(fish, "parent_id") else None,
         "genome_data": {
             "size_modifier": fish.genome.size_modifier,
-            "fertility": fish.genome.fertility,
             "color_hue": fish.genome.color_hue,
             "aggression": fish.genome.aggression,
             "social_tendency": fish.genome.social_tendency,
@@ -232,7 +231,6 @@ def _deserialize_fish(data: Dict[str, Any], target_world: Any) -> Optional[Any]:
         # Create genome using random() then override with saved values
         genome = Genome.random()
         genome.size_modifier = genome_data.get("size_modifier", 1.0)
-        genome.fertility = genome_data.get("fertility", 1.0)
         genome.color_hue = genome_data.get("color_hue", 0.5)
         genome.aggression = genome_data.get("aggression", 0.5)
         genome.social_tendency = genome_data.get("social_tendency", 0.5)

--- a/core/evolution/smoke_test.py
+++ b/core/evolution/smoke_test.py
@@ -18,7 +18,6 @@ def _summarize_population(population: Sequence[Genome]) -> Dict[str, float]:
     """Calculate simple metrics for a population snapshot."""
     speeds = [g.speed_modifier for g in population]
     aggression = [g.aggression for g in population]
-    fertility = [g.fertility for g in population]
     metabolism = [g.metabolism_rate for g in population]
 
     def _mean(values: List[float]) -> float:
@@ -35,7 +34,6 @@ def _summarize_population(population: Sequence[Genome]) -> Dict[str, float]:
         "speed_spread": max(speeds) - min(speeds),
         "speed_stdev": _stdev(speeds),
         "aggression_mean": _mean(aggression),
-        "fertility_mean": _mean(fertility),
         "metabolism_mean": _mean(metabolism),
     }
 
@@ -92,8 +90,8 @@ def format_report(report: Dict[str, object]) -> str:
         "🚀 Evolution smoke test",
         f"Seed: {report['seed']} | Population: {report['population_size']}",
         "",
-        "Gen | speed μ  | spread | σ      | aggression μ | fertility μ",
-        "----+---------+--------+--------+--------------+------------",
+        "Gen | speed μ  | spread | σ      | aggression μ",
+        "----+---------+--------+--------+--------------",
     ]
 
     for gen_snapshot in report["generations"]:
@@ -102,8 +100,7 @@ def format_report(report: Dict[str, object]) -> str:
             f"{gen_snapshot['speed_mean']:.3f} | "
             f"{gen_snapshot['speed_spread']:.3f} | "
             f"{gen_snapshot['speed_stdev']:.3f} | "
-            f"{gen_snapshot['aggression_mean']:.3f}     | "
-            f"{gen_snapshot['fertility_mean']:.3f}"
+            f"{gen_snapshot['aggression_mean']:.3f}"
         )
 
     lines.extend(

--- a/core/genetics.py
+++ b/core/genetics.py
@@ -124,7 +124,6 @@ class GeneticTrait(Generic[T]):
 class PhysicalTraits:
     """Physical attributes of the fish."""
     size_modifier: GeneticTrait[float]
-    fertility: GeneticTrait[float]
     color_hue: GeneticTrait[float]
     template_id: GeneticTrait[int]
     fin_size: GeneticTrait[float]
@@ -138,7 +137,6 @@ class PhysicalTraits:
     def random(cls, rng: pyrandom.Random) -> "PhysicalTraits":
         return cls(
             size_modifier=GeneticTrait(rng.uniform(0.7, 1.3)),
-            fertility=GeneticTrait(rng.uniform(0.6, 1.4)),
             color_hue=GeneticTrait(rng.random()),
             template_id=GeneticTrait(rng.randint(0, FISH_TEMPLATE_COUNT - 1)),
             fin_size=GeneticTrait(rng.uniform(0.6, 1.4)),
@@ -224,11 +222,6 @@ class Genome:
     def size_modifier(self) -> float: return self.physical.size_modifier.value
     @size_modifier.setter
     def size_modifier(self, v: float): self.physical.size_modifier.value = v
-
-    @property
-    def fertility(self) -> float: return self.physical.fertility.value
-    @fertility.setter
-    def fertility(self, v: float): self.physical.fertility.value = v
 
     @property
     def color_hue(self) -> float: return self.physical.color_hue.value
@@ -418,16 +411,6 @@ class Genome:
                 parent2.physical.size_modifier,
                 min_val=0.7,
                 max_val=1.3,
-                weight1=parent1_weight,
-                base_mutation_rate=adaptive_rate,
-                base_mutation_strength=adaptive_strength,
-                rng=rng,
-            ),
-            fertility=_inherit_trait_with_metadata(
-                parent1.physical.fertility,
-                parent2.physical.fertility,
-                min_val=0.6,
-                max_val=1.4,
                 weight1=parent1_weight,
                 base_mutation_rate=adaptive_rate,
                 base_mutation_strength=adaptive_strength,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,7 +73,7 @@ tank/
   - Age progression
 
 - **genetics.py**: Genetic system
-  - Genome with 7 traits (speed, size, vision, metabolism, fertility, color, lifespan)
+  - Genome with traits (speed, size, vision, metabolism, color, lifespan)
   - Mutation with configurable rates
   - Sexual reproduction via crossover
   - Algorithm inheritance

--- a/tests/test_evolution_comprehensive.py
+++ b/tests/test_evolution_comprehensive.py
@@ -153,7 +153,6 @@ class TestEdgeCasesAndBoundaries:
         genome = Genome(
             physical=PhysicalTraits(
                 size_modifier=GeneticTrait(0.7),  # Min (valid range is 0.7-1.3)
-                fertility=GeneticTrait(1.0),
                 color_hue=GeneticTrait(0.5),
                 template_id=GeneticTrait(1),      # Streamlined (1.2x speed)
                 fin_size=GeneticTrait(1.4),       # Max fins
@@ -342,7 +341,6 @@ class TestPokerEvolution:
         winner = Genome(
             physical=PhysicalTraits(
                 size_modifier=GeneticTrait(1.0),
-                fertility=GeneticTrait(1.0),
                 color_hue=GeneticTrait(0.5),
                 template_id=GeneticTrait(0),
                 fin_size=GeneticTrait(1.0),
@@ -372,7 +370,6 @@ class TestPokerEvolution:
         loser = Genome(
             physical=PhysicalTraits(
                 size_modifier=GeneticTrait(1.0),
-                fertility=GeneticTrait(1.0),
                 color_hue=GeneticTrait(0.5),
                 template_id=GeneticTrait(0),
                 fin_size=GeneticTrait(1.0),
@@ -611,7 +608,6 @@ class TestComplexIntegration:
         fish1 = Genome(
             physical=PhysicalTraits(
                 size_modifier=GeneticTrait(1.0),
-                fertility=GeneticTrait(1.0),
                 color_hue=GeneticTrait(0.5),
                 template_id=GeneticTrait(0),
                 fin_size=GeneticTrait(1.0),
@@ -642,7 +638,6 @@ class TestComplexIntegration:
         fish2 = Genome(
             physical=PhysicalTraits(
                 size_modifier=GeneticTrait(1.0),
-                fertility=GeneticTrait(1.0),
                 color_hue=GeneticTrait(0.51),
                 template_id=GeneticTrait(0),
                 fin_size=GeneticTrait(1.0),
@@ -673,7 +668,6 @@ class TestComplexIntegration:
         fish3 = Genome(
             physical=PhysicalTraits(
                 size_modifier=GeneticTrait(1.3),  # Changed from 1.5 to valid range
-                fertility=GeneticTrait(1.0),
                 color_hue=GeneticTrait(0.0),
                 template_id=GeneticTrait(0),
                 fin_size=GeneticTrait(0.6),
@@ -715,7 +709,6 @@ class TestComplexIntegration:
         # Use numeric values for learned behaviors (not strings)
         parent1_physical = PhysicalTraits(
             size_modifier=GeneticTrait(1.0),
-            fertility=GeneticTrait(1.0),
             color_hue=GeneticTrait(0.5),
             template_id=GeneticTrait(0),
             fin_size=GeneticTrait(1.0),
@@ -751,7 +744,6 @@ class TestComplexIntegration:
         parent2 = Genome(
             physical=PhysicalTraits(
                 size_modifier=GeneticTrait(parent1_physical.size_modifier.value),
-                fertility=GeneticTrait(parent1_physical.fertility.value),
                 color_hue=GeneticTrait(parent1_physical.color_hue.value),
                 template_id=GeneticTrait(parent1_physical.template_id.value),
                 fin_size=GeneticTrait(parent1_physical.fin_size.value),
@@ -778,7 +770,6 @@ class TestComplexIntegration:
         offspring = Genome(
             physical=PhysicalTraits(
                 size_modifier=GeneticTrait(parent1_physical.size_modifier.value),
-                fertility=GeneticTrait(parent1_physical.fertility.value),
                 color_hue=GeneticTrait(parent1_physical.color_hue.value),
                 template_id=GeneticTrait(parent1_physical.template_id.value),
                 fin_size=GeneticTrait(parent1_physical.fin_size.value),

--- a/tests/test_genetics_refactor.py
+++ b/tests/test_genetics_refactor.py
@@ -50,13 +50,10 @@ class TestGeneticsRefactor:
         """Test random generation of PhysicalTraits."""
         rng = random.Random(123)
         phys = PhysicalTraits.random(rng)
-        
+
         assert isinstance(phys.size_modifier, GeneticTrait)
         assert 0.7 <= phys.size_modifier.value <= 1.3
-        
-        assert isinstance(phys.fertility, GeneticTrait)
-        assert 0.6 <= phys.fertility.value <= 1.4
-        
+
         assert isinstance(phys.template_id, GeneticTrait)
         assert isinstance(phys.template_id.value, int)
         assert 0 <= phys.template_id.value <= 5


### PR DESCRIPTION
## Summary
- remove the unused fertility trait from genetics definitions, crossover logic, and serialization
- update documentation and tests to reflect the reduced physical trait set and adjusted reporting

## Testing
- pytest tests/test_genetics_refactor.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693221db7f888331b2c9ffb53a10537c)