### PR TITLE
Use windowed migration inflow stats

### DIFF
--- a/frontend/src/components/EcosystemStats.tsx
+++ b/frontend/src/components/EcosystemStats.tsx
@@ -52,7 +52,9 @@ export function EcosystemStats({ stats }: EcosystemStatsProps) {
 
     const sourceBirth = Math.round(energySourcesRecent.birth ?? safeStats.energy_from_birth ?? energySources.birth ?? 0);
     const sourceSoupSpawn = Math.round(energySourcesRecent.soup_spawn ?? safeStats.energy_from_soup_spawn ?? energySources.soup_spawn ?? 0);
-    const sourceMigrationIn = Math.round(safeStats.energy_from_migration_in ?? energySources.migration_in ?? 0);
+    const sourceMigrationIn = Math.round(
+        energySourcesRecent.migration_in ?? safeStats.energy_from_migration_in ?? energySources.migration_in ?? 0
+    );
 
 
     // Combined Base Metabolism (Existence + Base Rate)


### PR DESCRIPTION
## Summary
- use windowed migration-in energy totals when rendering the Energy Economy panel

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693535282fc08331938a118d70ba8e34)