### PR TITLE
Reduce local imports in entity modules

### DIFF
--- a/core/entities/predators.py
+++ b/core/entities/predators.py
@@ -1,7 +1,7 @@
 """Predator entity logic for crabs."""
 
-from typing import TYPE_CHECKING, Optional
 import random
+from typing import TYPE_CHECKING, Optional
 
 from core.constants import (
     CRAB_ATTACK_COOLDOWN,
@@ -12,10 +12,10 @@ from core.constants import (
 from core.entities.base import Agent
 from core.entities.fish import Fish
 from core.entities.resources import Food
+from core.genetics import Genome
 
 if TYPE_CHECKING:
     from core.environment import Environment
-    from core.genetics import Genome
 
 
 class Crab(Agent):
@@ -31,9 +31,6 @@ class Crab(Agent):
         screen_height: int = 600,
     ) -> None:
         """Initialize a crab."""
-        # Import here to avoid circular dependency
-        from core.genetics import Genome
-
         # Crabs are slower and less aggressive now
         self.genome: Genome = genome if genome is not None else Genome.random()
         base_speed = 1.5  # Much slower than before (was 2)

--- a/core/entities/resources.py
+++ b/core/entities/resources.py
@@ -4,6 +4,12 @@ import random
 from typing import TYPE_CHECKING, Optional
 
 from core.constants import (
+    AUTO_FOOD_HIGH_ENERGY_THRESHOLD_1,
+    AUTO_FOOD_HIGH_ENERGY_THRESHOLD_2,
+    AUTO_FOOD_HIGH_POP_THRESHOLD_1,
+    AUTO_FOOD_HIGH_POP_THRESHOLD_2,
+    AUTO_FOOD_LOW_ENERGY_THRESHOLD,
+    FOOD_SINK_ACCELERATION,
     FOOD_TYPES,
     PLANT_FOOD_PRODUCTION_ENERGY,
     PLANT_FOOD_PRODUCTION_INTERVAL,
@@ -70,14 +76,6 @@ class Plant(Agent):
         Returns:
             True if food should be produced
         """
-        from core.constants import (
-            AUTO_FOOD_HIGH_ENERGY_THRESHOLD_1,
-            AUTO_FOOD_HIGH_ENERGY_THRESHOLD_2,
-            AUTO_FOOD_HIGH_POP_THRESHOLD_1,
-            AUTO_FOOD_HIGH_POP_THRESHOLD_2,
-            AUTO_FOOD_LOW_ENERGY_THRESHOLD,
-        )
-
         # Update timer
         self.food_production_timer -= time_modifier
 
@@ -312,7 +310,6 @@ class Food(Agent):
         """Make the food sink at a rate based on its type."""
         if self.is_stationary:
             return
-        from core.constants import FOOD_SINK_ACCELERATION
 
         sink_rate = FOOD_SINK_ACCELERATION * self.food_properties["sink_multiplier"]
         self.vel.y += sink_rate


### PR DESCRIPTION
## Summary
- move plant production and food sink constants to module scope to avoid repeated local imports
- import crab genome dependency at module level instead of inside the constructor

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935a56013408331bd1540f897b15df6)