### PR TITLE
Add AI oceanographer narrative to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@ Currently: Phase 1 (Foundation) with Layer 2 evolution proven but not yet fully 
 
 ---
 
+## AI Oceanographer & Documentary Layer (Planned)
+
+Today, Tank World already combines an Alife engine with an AI code-evolution loop. A future layer is an AI “oceanographer” that
+ sits on top of all of this and talks to the user.
+
+The idea is to have an AI narrator – think Jacques Cousteau or a slightly stranger Steve Zissou cousin – whose job is to:
+
+- Explain what experiment is currently running in your tank
+- Point out interesting behaviors and evolutionary events as they happen
+- Connect visible behavior (“these blue predators discovered ambush tactics”) to underlying algorithm changes and fitness signal
+  s
+- Frame each tank run as a “mission” toward some goal, even if it’s a proxy task like optimizing an algorithm on a benchmark
+
+Over time, the tank becomes AI-generated documentary content about artificial ecosystems. Users aren’t just donating compute; th
+ey’re watching an ongoing nature series where the “creatures” are candidate algorithms and policies.
+
+We are deliberately conservative in claims here: most tanks will be working on proxy problems (e.g., algorithm tuning, synthetic
+ tasks), not directly curing diseases. The long-term goal is to make it easy, engaging, and honest to run Alife experiments tha
+t can gradually be mapped to real-world problem domains.
+
+---
+
 ## Current Features
 
 - **Algorithmic Evolution** - 58 unique parametrizable behavior strategies that evolve

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -67,6 +67,26 @@ The fish tank is just the first visualization. Future versions will allow the AI
 
 The goal is a system where the AI can propose: "This simulation would be more engaging if we added X" and generate both the simulation logic AND the visualization code.
 
+### AI Oceanographer Narration
+
+Visualization alone isn’t enough. Most people need a story.
+
+A planned layer for Tank World is an AI narrator that acts as an in-sim oceanographer. Its responsibilities:
+
+- **Explain experiments in plain language**  
+  “This tank is exploring energy-efficient foraging strategies under predation pressure,” instead of “we’re running an EA on fitness function F.”
+
+- **Call out emergent behavior**  
+  Highlight when new strategies appear, niches form, or species collapse – and tie those events back to changes in the underlying algorithms.
+
+- **Map tank activity to real-world frames**  
+  When appropriate, relate what the tank is doing to real domains: routing, scheduling, optimization, or (eventually) problem templates that users actually care about. Most of these will be proxy problems, and the system should be explicit about that.
+
+- **Experiment with formats**  
+  Short “episodes,” daily summaries, or longer-form “nature documentaries” built from logs and replay data – all generated automatically from the simulation history.
+
+This “AI oceanographer” doesn’t change the core two-layer evolution paradigm, but it makes the system legible and worth watching for non-experts. If people enjoy following the story of their tank, they will keep donating compute to the underlying research.
+
 ## Long-Term Goals
 
 ### Phase 1: Foundation (Current)


### PR DESCRIPTION
## Summary
- add a planned AI oceanographer and documentary layer section to the README
- extend the vision document with narration goals connecting experiments to real-world frames

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c4a5dc20833182926bafe35055e8)