### PR TITLE
Fix fish energy economy calculations

### DIFF
--- a/core/fish_poker.py
+++ b/core/fish_poker.py
@@ -540,10 +540,10 @@ class PokerInteraction:
 
         # Winner pays the energy cost
         winner_fish.modify_energy(-energy_to_transfer)
-        
-        # Track reproduction cost in ecosystem stats
-        if winner_fish.ecosystem is not None:
-            winner_fish.ecosystem.record_energy_burn("reproduction_cost", energy_to_transfer)
+
+        # Note: We don't record reproduction_cost as an outflow because the energy
+        # goes directly to the baby - it's an internal transfer within the fish
+        # population, not energy leaving the system.
 
         # Set reproduction cooldown for both parents
         winner_fish.reproduction_cooldown = REPRODUCTION_COOLDOWN

--- a/frontend/src/components/EcosystemStats.tsx
+++ b/frontend/src/components/EcosystemStats.tsx
@@ -47,10 +47,10 @@ export function EcosystemStats({ stats }: EcosystemStatsProps) {
 
     // New energy flows
     const burnTurning = energyBurnRecent.turning ?? 0;
-    const burnReproduction = energyBurnRecent.reproduction_cost ?? 0;
     const burnMigration = energyBurnRecent.migration ?? 0;
 
-    const sourceBirth = Math.round(energySourcesRecent.birth ?? safeStats.energy_from_birth ?? energySources.birth ?? 0);
+    // Note: burnReproduction and sourceBirth are intentionally not tracked here
+    // because reproduction is an internal transfer (parent→baby), not an external flow
     const sourceSoupSpawn = Math.round(energySourcesRecent.soup_spawn ?? safeStats.energy_from_soup_spawn ?? energySources.soup_spawn ?? 0);
     const sourceMigrationIn = Math.round(
         energySourcesRecent.migration_in ?? safeStats.energy_from_migration_in ?? energySources.migration_in ?? 0
@@ -229,14 +229,12 @@ export function EcosystemStats({ stats }: EcosystemStatsProps) {
                         traitMaintenance: Math.max(0, burnTraits),
                         movementCost: Math.max(0, burnMovement),
                         turningCost: Math.max(0, burnTurning),
-                        reproductionCost: Math.max(0, burnReproduction),
                         fishDeaths: fishDeathEnergyLoss,
                         migrationOut: Math.max(0, burnMigration),
 
                         pokerTotalPot: Math.max(0, pokerLoopVolume),
                         pokerHouseCut: pokerHouseCutRecent + burnPokerHouseCut,
                         plantPokerNet: energyFromPokerPlant - burnPokerPlantLoss,
-                        birthEnergy: Math.max(0, sourceBirth),
                         soupSpawn: Math.max(0, sourceSoupSpawn),
                         migrationIn: Math.max(0, sourceMigrationIn),
                     }}

--- a/frontend/src/components/EnergyEconomyPanel.tsx
+++ b/frontend/src/components/EnergyEconomyPanel.tsx
@@ -2,22 +2,23 @@
 
 
 interface EnergyFlowData {
-    // Sources (In)
+    // Sources (In) - True external inflows only
     fallingFood: number;
     liveFood: number;
     plantNectar: number;
-    birthEnergy: number; // Energy babies are created with (from reproduction)
-    soupSpawn: number; // Energy from spontaneous/system fish spawns
+    soupSpawn: number; // Energy from spontaneous/system fish spawns (true inflow)
     migrationIn: number; // Energy entering tank via fish migration
 
-    // Sinks (Out)
+    // Sinks (Out) - True external outflows only
     baseMetabolism: number;
     traitMaintenance: number; // Eyes, fins, etc.
     movementCost: number;
     turningCost: number; // Energy spent on direction changes
-    reproductionCost: number; // Energy parents spend creating babies
     fishDeaths: number;
     migrationOut: number; // Energy leaving tank via fish migration
+
+    // Note: Reproduction is NOT tracked here because it's an internal transfer
+    // (parent energy -> baby energy) that doesn't change total fish population energy
 
     // Poker Economy (only external flows)
     pokerTotalPot: number;
@@ -37,8 +38,8 @@ export function EnergyEconomyPanel({ data, className }: EnergyEconomyPanelProps)
     const plantGain = Math.max(0, data.plantPokerNet);
     const plantLoss = Math.max(0, -data.plantPokerNet);
 
-    const totalIn = data.fallingFood + data.liveFood + data.plantNectar + plantGain + data.birthEnergy + data.soupSpawn + data.migrationIn;
-    const totalOut = data.baseMetabolism + data.traitMaintenance + data.movementCost + data.turningCost + data.reproductionCost + data.fishDeaths + data.migrationOut + data.pokerHouseCut + plantLoss;
+    const totalIn = data.fallingFood + data.liveFood + data.plantNectar + plantGain + data.soupSpawn + data.migrationIn;
+    const totalOut = data.baseMetabolism + data.traitMaintenance + data.movementCost + data.turningCost + data.fishDeaths + data.migrationOut + data.pokerHouseCut + plantLoss;
     const netChange = totalIn - totalOut;
 
     const formatVal = (val: number) => Math.round(val).toLocaleString();
@@ -101,7 +102,6 @@ export function EnergyEconomyPanel({ data, className }: EnergyEconomyPanelProps)
 
                     <FlowBar label="Live Food Eaten" value={data.liveFood} color="#22c55e" icon="🦐" total={totalIn} />
                     <FlowBar label="Plant Nectar" value={data.plantNectar} color="#10b981" icon="🌿" total={totalIn} />
-                    <FlowBar label="Baby Energy" value={data.birthEnergy} color="#4ade80" icon="👶" total={totalIn} />
                     <FlowBar label="Soup Spawns" value={data.soupSpawn} color="#a3e635" icon="🥣" total={totalIn} />
                     <FlowBar label="Plant Net (Won)" value={plantGain} color="#059669" icon="🎋" total={totalIn} />
                     <FlowBar label="Migration In" value={data.migrationIn} color="#86efac" icon="🛬" total={totalIn} />
@@ -123,7 +123,6 @@ export function EnergyEconomyPanel({ data, className }: EnergyEconomyPanelProps)
                     <FlowBar label="Trait Upkeep" value={data.traitMaintenance} color="#f472b6" icon="🧬" total={totalOut} isOut />
                     <FlowBar label="Movement" value={data.movementCost} color="#fb7185" icon="💨" total={totalOut} isOut />
                     <FlowBar label="Turning" value={data.turningCost} color="#f97316" icon="🔄" total={totalOut} isOut />
-                    <FlowBar label="Reproduction" value={data.reproductionCost} color="#d946ef" icon="🥚" total={totalOut} isOut />
                     <FlowBar label="Deaths" value={data.fishDeaths} color="#ef4444" icon="💀" total={totalOut} isOut />
                     <FlowBar label="Poker House Cut" value={data.pokerHouseCut} color="#94a3b8" icon="🏛️" total={totalOut} isOut />
                     <FlowBar label="Plant Net (Lost)" value={plantLoss} color="#be185d" icon="🥀" total={totalOut} isOut />


### PR DESCRIPTION
Reproduction is an internal transfer within the fish population - parent energy goes directly to baby energy. This doesn't change the total energy in the fish population, so tracking it as both an inflow (Baby Energy) and outflow (Reproduction) was misleading and caused the energy economy to not add up.

Changes:
- Remove birth energy recording for reproduction babies (only soup spawns are true inflows of new energy into the system)
- Remove reproduction_cost recording (energy stays in fish population)
- Update frontend to remove Baby Energy and Reproduction from display
- Keep Soup Spawns as the only birth-related inflow (true external energy)

The net energy shown now accurately reflects actual energy entering and leaving the fish population through food, deaths, metabolism, etc.