### PR TITLE
Fix migration value jumping to high value

### DIFF
--- a/frontend/src/components/EcosystemStats.tsx
+++ b/frontend/src/components/EcosystemStats.tsx
@@ -42,9 +42,12 @@ export function EcosystemStats({ stats }: EcosystemStatsProps) {
 
     // Note: burnReproduction and sourceBirth are intentionally not tracked here
     // because reproduction is an internal transfer (parent→baby), not an external flow
-    const sourceSoupSpawn = Math.round(energySourcesRecent.soup_spawn ?? safeStats.energy_from_soup_spawn ?? energySources.soup_spawn ?? 0);
+    // FIX: Don't fall back to cumulative energySources - only use windowed values
+    // energySources contains lifetime totals, which would cause value to spike when
+    // there's no recent activity in the windowed period
+    const sourceSoupSpawn = Math.round(energySourcesRecent.soup_spawn ?? safeStats.energy_from_soup_spawn ?? 0);
     const sourceMigrationIn = Math.round(
-        energySourcesRecent.migration_in ?? safeStats.energy_from_migration_in ?? energySources.migration_in ?? 0
+        energySourcesRecent.migration_in ?? safeStats.energy_from_migration_in ?? 0
     );
 
 


### PR DESCRIPTION
…dowed

When there was no recent migration or soup spawn activity within the 300-frame window, the fallback chain was incorrectly using the cumulative lifetime totals from energySources instead of showing 0.

This caused the Migration In value to spike to very high numbers (like +130,342) when displaying what should be recent (windowed) statistics.

Removed the fallback to energySources.migration_in and energySources.soup_spawn, so these values now correctly show 0 when there's no recent activity.