### PR TITLE
Fix fish energy accounting display issues

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -696,6 +696,7 @@ class SimulationRunner:
             energy_from_auto_eval=stats.get("energy_from_auto_eval", 0.0),
             energy_burn_recent=stats.get("energy_burn_recent", {}),
             energy_burn_total=stats.get("energy_burn_total", 0.0),
+            energy_delta=stats.get("energy_delta", {}),
             avg_fish_energy=stats.get("avg_fish_energy", 0.0),
             min_fish_energy=stats.get("min_fish_energy", 0.0),
 

--- a/backend/state_payloads.py
+++ b/backend/state_payloads.py
@@ -221,6 +221,8 @@ class StatsPayload:
     energy_from_auto_eval: float = 0.0
     energy_burn_recent: Dict[str, float] = field(default_factory=dict)
     energy_burn_total: float = 0.0
+    # Energy delta (true change in fish population energy over window)
+    energy_delta: Dict[str, Any] = field(default_factory=dict)
     # Fish energy distribution
     avg_fish_energy: float = 0.0
     min_fish_energy: float = 0.0
@@ -283,6 +285,7 @@ class StatsPayload:
             "energy_from_auto_eval": self.energy_from_auto_eval,
             "energy_burn_recent": self.energy_burn_recent,
             "energy_burn_total": self.energy_burn_total,
+            "energy_delta": self.energy_delta,
             "avg_fish_energy": self.avg_fish_energy,
             "min_fish_energy": self.min_fish_energy,
             "max_fish_energy": self.max_fish_energy,

--- a/core/ecosystem_population.py
+++ b/core/ecosystem_population.py
@@ -257,6 +257,7 @@ def get_summary_stats(
     energy_summary = ecosystem.get_energy_source_summary()
     recent_energy = ecosystem.get_recent_energy_breakdown(window_frames=ENERGY_STATS_WINDOW_FRAMES)
     recent_energy_burn = ecosystem.get_recent_energy_burn(window_frames=ENERGY_STATS_WINDOW_FRAMES)
+    energy_delta = ecosystem.get_energy_delta(window_frames=ENERGY_STATS_WINDOW_FRAMES)
 
     total_energy = 0.0
     if entities is not None:
@@ -297,6 +298,8 @@ def get_summary_stats(
         "energy_from_migration_in": recent_energy.get("migration_in", 0.0),
         "energy_burn_recent": recent_energy_burn,
         "energy_burn_total": sum(recent_energy_burn.values()),
+        "energy_sources_recent": recent_energy,
+        "energy_delta": energy_delta,
         "reproduction_stats": ecosystem.get_reproduction_summary(),
         "diversity_stats": ecosystem.get_diversity_summary(),
     }

--- a/core/entities/fish.py
+++ b/core/entities/fish.py
@@ -721,9 +721,11 @@ class Fish(Agent):
         # (This is fine - survival of the fittest)
         self.energy -= energy_to_transfer  # Parent pays the energy cost
 
-        # Note: We don't record reproduction_cost as an outflow because the energy
-        # goes directly to the baby - it's an internal transfer within the fish
-        # population, not energy leaving the system.
+        # Record reproduction energy for visibility in stats
+        # While it's an internal transfer (parent→baby), showing it helps users
+        # understand population dynamics and where energy goes during births.
+        if self.ecosystem is not None:
+            self.ecosystem.record_reproduction_energy(energy_to_transfer, energy_to_transfer)
 
         # Create offspring near parent
         offset_x = random.uniform(-30, 30)

--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -589,6 +589,11 @@ class SimulationEngine(BaseSimulator):
             ecosystem.update_population_stats(fish_list)
             ecosystem.update(self.frame_count)
 
+            # Record energy snapshot for delta calculations
+            # Sum total fish energy for historical tracking
+            total_fish_energy = sum(f.energy for f in fish_list)
+            ecosystem.record_energy_snapshot(total_fish_energy, len(fish_list))
+
             # Auto-spawn fish based on population level (more likely at low populations)
             fish_count = len(fish_list)
             if fish_count < MAX_POPULATION:

--- a/frontend/src/components/EcosystemStats.tsx
+++ b/frontend/src/components/EcosystemStats.tsx
@@ -40,8 +40,10 @@ export function EcosystemStats({ stats }: EcosystemStatsProps) {
     const burnTurning = energyBurnRecent.turning ?? 0;
     const burnMigration = energyBurnRecent.migration ?? 0;
 
-    // Note: burnReproduction and sourceBirth are intentionally not tracked here
-    // because reproduction is an internal transfer (parent→baby), not an external flow
+    // Reproduction costs and birth energy (now visible to help users understand energy flow)
+    const burnReproduction = energyBurnRecent.reproduction_cost ?? 0;
+    const sourceBirth = energySourcesRecent.birth ?? 0;
+
     // FIX: Don't fall back to cumulative energySources - only use windowed values
     // energySources contains lifetime totals, which would cause value to spike when
     // there's no recent activity in the windowed period
@@ -49,6 +51,9 @@ export function EcosystemStats({ stats }: EcosystemStatsProps) {
     const sourceMigrationIn = Math.round(
         energySourcesRecent.migration_in ?? safeStats.energy_from_migration_in ?? 0
     );
+
+    // Energy delta (true change in fish population energy over window)
+    const energyDelta = safeStats.energy_delta;
 
 
     // Combined Base Metabolism (Existence + Base Rate)
@@ -218,6 +223,13 @@ export function EcosystemStats({ stats }: EcosystemStatsProps) {
                         plantPokerNet: plantPokerNetRecent,
                         soupSpawn: Math.max(0, sourceSoupSpawn),
                         migrationIn: Math.max(0, sourceMigrationIn),
+
+                        // Reproduction (internal transfer, but visible for understanding)
+                        reproductionCost: Math.max(0, burnReproduction),
+                        birthEnergy: Math.max(0, sourceBirth),
+
+                        // True energy delta
+                        energyDelta: energyDelta?.energy_delta ?? 0,
                     }}
                 />
             </div>

--- a/frontend/src/components/EnergyEconomyPanel.tsx
+++ b/frontend/src/components/EnergyEconomyPanel.tsx
@@ -17,13 +17,17 @@ interface EnergyFlowData {
     fishDeaths: number;
     migrationOut: number; // Energy leaving tank via fish migration
 
-    // Note: Reproduction is NOT tracked here because it's an internal transfer
-    // (parent energy -> baby energy) that doesn't change total fish population energy
+    // Reproduction (internal transfer - visible for understanding)
+    reproductionCost: number; // Energy spent by parents
+    birthEnergy: number; // Energy given to babies
 
     // Poker Economy (only external flows)
     pokerTotalPot: number;
     pokerHouseCut: number; // Energy lost to house cut
     plantPokerNet: number; // Net fish↔plant transfer (positive = fish won)
+
+    // True energy delta (actual change in fish population energy)
+    energyDelta: number;
 }
 
 interface EnergyEconomyPanelProps {
@@ -40,7 +44,10 @@ export function EnergyEconomyPanel({ data, className }: EnergyEconomyPanelProps)
 
     const totalIn = data.fallingFood + data.liveFood + data.plantNectar + plantGain + data.soupSpawn + data.migrationIn;
     const totalOut = data.baseMetabolism + data.traitMaintenance + data.movementCost + data.turningCost + data.fishDeaths + data.migrationOut + data.pokerHouseCut + plantLoss;
-    const netChange = totalIn - totalOut;
+    const netExternalFlow = totalIn - totalOut;
+
+    // True energy delta - what actually happened to fish population energy
+    const trueDelta = data.energyDelta;
 
     const formatVal = (val: number) => Math.round(val).toLocaleString();
 
@@ -75,20 +82,26 @@ export function EnergyEconomyPanel({ data, className }: EnergyEconomyPanelProps)
 
     return (
         <div className={`glass-panel ${className}`} style={{ padding: '16px', position: 'relative', overflow: 'hidden' }}>
-            {/* Header */}
+            {/* Header with two metrics */}
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
                 <h3 style={{ margin: 0, fontSize: '13px', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--color-text-muted)', display: 'flex', alignItems: 'center', gap: '8px' }}>
                     <span>🔋</span> Energy Economy
                 </h3>
-                <div style={{
-                    fontSize: '12px',
-                    fontWeight: 700,
-                    color: netChange >= 0 ? 'var(--color-success)' : 'var(--color-danger)',
-                    background: netChange >= 0 ? 'rgba(34, 197, 94, 0.1)' : 'rgba(239, 68, 68, 0.1)',
-                    padding: '2px 8px',
-                    borderRadius: '4px'
-                }}>
-                    {netChange > 0 ? '+' : ''}{formatVal(netChange)}⚡ Net
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                    {/* True Delta - the actual change in fish energy */}
+                    <div
+                        style={{
+                            fontSize: '12px',
+                            fontWeight: 700,
+                            color: trueDelta >= 0 ? 'var(--color-success)' : 'var(--color-danger)',
+                            background: trueDelta >= 0 ? 'rgba(34, 197, 94, 0.1)' : 'rgba(239, 68, 68, 0.1)',
+                            padding: '2px 8px',
+                            borderRadius: '4px',
+                        }}
+                        title="Actual change in total fish energy over the last 60 seconds"
+                    >
+                        {trueDelta > 0 ? '+' : ''}{formatVal(trueDelta)}⚡ Net
+                    </div>
                 </div>
             </div>
 
@@ -103,7 +116,6 @@ export function EnergyEconomyPanel({ data, className }: EnergyEconomyPanelProps)
                     <FlowBar label="Live Food Eaten" value={data.liveFood} color="#22c55e" icon="🦐" total={totalIn} />
                     <FlowBar label="Plant Nectar" value={data.plantNectar} color="#10b981" icon="🌿" total={totalIn} />
                     <FlowBar label="Soup Spawns" value={data.soupSpawn} color="#a3e635" icon="🥣" total={totalIn} />
-                    <FlowBar label="Plant Net (Won)" value={plantGain} color="#059669" icon="🎋" total={totalIn} />
                     <FlowBar label="Migration In" value={data.migrationIn} color="#86efac" icon="🛬" total={totalIn} />
 
                     {/* Empty State */}
@@ -123,12 +135,24 @@ export function EnergyEconomyPanel({ data, className }: EnergyEconomyPanelProps)
                     <FlowBar label="Trait Upkeep" value={data.traitMaintenance} color="#f472b6" icon="🧬" total={totalOut} isOut />
                     <FlowBar label="Movement" value={data.movementCost} color="#fb7185" icon="💨" total={totalOut} isOut />
                     <FlowBar label="Turning" value={data.turningCost} color="#f97316" icon="🔄" total={totalOut} isOut />
-                    <FlowBar label="Deaths" value={data.fishDeaths} color="#ef4444" icon="💀" total={totalOut} isOut />
                     <FlowBar label="Poker House Cut" value={data.pokerHouseCut} color="#94a3b8" icon="🏛️" total={totalOut} isOut />
                     <FlowBar label="Plant Net (Lost)" value={plantLoss} color="#be185d" icon="🥀" total={totalOut} isOut />
                     <FlowBar label="Migration" value={data.migrationOut} color="#8b5cf6" icon="✈️" total={totalOut} isOut />
                 </div>
             </div>
+
+            {/* Reproduction Section - Internal transfers */}
+            {(data.reproductionCost > 0 || data.birthEnergy > 0) && (
+                <div style={{ marginTop: '16px', paddingTop: '12px', borderTop: '1px solid rgba(255,255,255,0.05)' }}>
+                    <div style={{ fontSize: '10px', color: 'var(--color-text-muted)', textTransform: 'uppercase', marginBottom: '8px' }}>
+                        Reproduction (Internal Transfer)
+                    </div>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', color: 'var(--color-text-dim)' }}>
+                        <span>👶 Parent→Baby Transfer</span>
+                        <span style={{ color: '#a78bfa' }}>{formatVal(data.birthEnergy)}⚡</span>
+                    </div>
+                </div>
+            )}
 
             {/* Poker Economy Highlight */}
             {(data.pokerTotalPot > 0) && (

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -212,6 +212,15 @@ export interface StatsData {
     energy_from_migration_in?: number;
     energy_burn_recent?: Record<string, number>;
     energy_burn_total?: number;
+    // Energy delta (true change in fish population energy over window)
+    energy_delta?: {
+        energy_delta: number;  // Change in total fish energy
+        energy_now: number;    // Current total fish energy
+        energy_then: number;   // Total fish energy at window start
+        fish_count_now: number;
+        fish_count_then: number;
+        avg_energy_delta: number;  // Change in average energy per fish
+    };
     // Fish energy distribution
     avg_fish_energy: number;
     min_fish_energy: number;

--- a/tests/test_life_evolution_flow.py
+++ b/tests/test_life_evolution_flow.py
@@ -47,6 +47,10 @@ class MiniEcosystem:
         """Stub for energy gain tracking."""
         pass
 
+    def record_reproduction_energy(self, parent_cost: float, baby_energy: float) -> None:
+        """Stub for reproduction energy tracking."""
+        pass
+
 
 class MiniEnvironment:
     """Simple environment stub exposing only what Fish requires."""


### PR DESCRIPTION
Addresses user confusion about "Net" energy not matching actual fish energy:

**Root Cause:**
The "Net" metric showed external energy flow rate (inflows - outflows), not the actual change in total fish energy. Users expected Net +3000 to mean fish gained 3000 energy, but that's not what it represented.

**Architectural Improvements:**

1. **Historical Energy Snapshots** (core/ecosystem.py)
   - Add energy_history deque to track total fish energy over time
   - record_energy_snapshot() called every 30 frames with population energy
   - get_energy_delta() calculates true ΔEnergy over a time window

2. **Reproduction Energy Tracking** (core/entities/fish.py)
   - Add record_reproduction_energy() to make internal transfers visible
   - Track parent→baby energy flow as both "reproduction_cost" burn and "birth" source
   - Helps users understand where energy goes during reproduction

3. **Energy Delta in Stats** (core/ecosystem_population.py)
   - Include energy_delta dict in get_summary_stats()
   - Contains: energy_delta, energy_now, energy_then, fish counts, avg_energy_delta

4. **Backend Payload Updates** (backend/)
   - Add energy_delta field to StatsPayload
   - Pass through to frontend via WebSocket

5. **Frontend Updates** (frontend/)
   - Display true "Net" as the actual change in fish energy (energyDelta)
   - Show reproduction as a visible internal transfer section
   - Updated TypeScript types for energy_delta

The "Net" indicator now shows what users expect: the actual change in fish population energy over the last 60 seconds.