### PR TITLE
Fix Energy Economy panel net calculation

### DIFF
--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -814,11 +814,12 @@ class SimulationEngine(BaseSimulator):
 
         stats = self.ecosystem.get_summary_stats(self.get_all_entities())
         
-        # Add energy breakdown stats
+        # Add cumulative energy sources (lifetime totals)
+        # Note: energy_sources_recent and energy_burn_recent are already set by
+        # get_summary_stats() with ENERGY_STATS_WINDOW_FRAMES (1800 frames = 60s),
+        # matching the window used for energy_delta. Don't override them here.
         stats.update({
             "energy_sources": self.ecosystem.get_energy_source_summary(),
-            "energy_sources_recent": self.ecosystem.get_recent_energy_breakdown(window_frames=300),
-            "energy_burn_recent": self.ecosystem.get_recent_energy_burn(window_frames=300),
         })
 
         stats["frame_count"] = self.frame_count


### PR DESCRIPTION
The energy economy panel was showing a large discrepancy between calculated net (inflows - outflows) and actual net (energy_delta).

Root cause: simulation_engine.py was overriding energy_sources_recent and energy_burn_recent with 300-frame (10 second) window data, but energy_delta uses 1800-frame (60 second) window from get_summary_stats().

Fix: Remove the override so all values consistently use the 1800-frame window defined in ENERGY_STATS_WINDOW_FRAMES. The get_summary_stats() function already provides these values with the correct window size.

Note: Some discrepancy will remain due to untracked flows:
- Energy capping when fish eat but are already full
- Internal transfers (fish-to-fish poker, reproduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)