### PR TITLE
Fix fish exceeding maximum energy limit

### DIFF
--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -457,13 +457,12 @@ class SimulationRunner:
                 if fish_id is not None:
                     fish = next((e for e in self.world.entities_list
                                if isinstance(e, Fish) and e.fish_id == fish_id), None)
-                    if fish:
-                        reward = min(net_energy, fish.max_energy - fish.energy)
-                        if reward > 0:
-                            fish.energy += reward
-                            if fish.ecosystem is not None:
-                                fish.ecosystem.record_auto_eval_energy_gain(reward)
-                            logger.info(f"Auto-eval reward: Fish #{fish_id} gained {reward:.1f} energy")
+                    if fish and net_energy > 0:
+                        # Use modify_energy to properly cap at max and route overflow to reproduction/food
+                        actual_gain = fish.modify_energy(net_energy)
+                        if actual_gain > 0 and fish.ecosystem is not None:
+                            fish.ecosystem.record_auto_eval_energy_gain(actual_gain)
+                        logger.info(f"Auto-eval reward: Fish #{fish_id} gained {actual_gain:.1f} energy")
 
                 elif plant_id is not None:
                     plant = next((e for e in self.world.entities_list

--- a/core/fish_poker.py
+++ b/core/fish_poker.py
@@ -1044,8 +1044,8 @@ class PokerInteraction:
             house_cut = self.calculate_house_cut(winner_fish.size, net_gain)
 
             # Winner receives the pot minus house cut
-            # Use direct energy assignment to bypass max_energy cap (poker winnings can exceed capacity)
-            winner_fish.energy += total_pot - house_cut
+            # Use modify_energy to properly cap at max and route overflow to reproduction/food
+            winner_fish.modify_energy(total_pot - house_cut)
 
             # For reporting purposes, energy_transferred is the loser's loss (what they bet)
             # This is used for display and statistics tracking

--- a/core/mixed_poker.py
+++ b/core/mixed_poker.py
@@ -328,7 +328,8 @@ class MixedPokerInteraction:
         from core.entities.fractal_plant import FractalPlant
 
         if isinstance(player, Fish):
-            player.energy = max(0, player.energy + amount)
+            # Use modify_energy to properly cap at max and route overflow to reproduction/food
+            player.modify_energy(amount)
         elif isinstance(player, FractalPlant):
             if amount > 0:
                 player.gain_energy(amount)

--- a/core/reproduction_stats_manager.py
+++ b/core/reproduction_stats_manager.py
@@ -47,6 +47,18 @@ class ReproductionStatsManager:
         if not success:
             self.reproduction_stats.total_failed_attempts += 1
 
+    def record_reproduction_attempt(self, success: bool) -> None:
+        """Record a reproduction attempt (e.g., asexual reproduction from overflow).
+
+        This is separate from mating attempts - it tracks when fish attempt
+        reproduction via overflow energy routing.
+        """
+        # For now, just count it as a mating attempt since we want to track
+        # overall reproduction attempts
+        self.reproduction_stats.total_mating_attempts += 1
+        if not success:
+            self.reproduction_stats.total_failed_attempts += 1
+
     def update_pregnant_count(self, count: int) -> None:
         """Update the count of currently pregnant fish."""
         self.reproduction_stats.current_pregnant_fish = count

--- a/core/skill_game_system.py
+++ b/core/skill_game_system.py
@@ -317,19 +317,19 @@ class SkillGameSystem:
             if energy_change > 0:
                 # Fish1 wins, takes energy from fish2
                 actual_transfer = min(energy_change, fish2.energy * 0.5)  # Cap at 50% of loser's energy
-                fish1.energy += actual_transfer
-                fish2.energy -= actual_transfer
+                fish1.modify_energy(actual_transfer)  # Route overflow to reproduction/food
+                fish2.modify_energy(-actual_transfer)
                 return actual_transfer
             elif energy_change < 0:
                 # Fish1 loses, gives energy to fish2
                 actual_transfer = min(-energy_change, fish1.energy * 0.5)
-                fish1.energy -= actual_transfer
-                fish2.energy += actual_transfer
+                fish1.modify_energy(-actual_transfer)
+                fish2.modify_energy(actual_transfer)  # Route overflow to reproduction/food
                 return -actual_transfer
         else:
             # Single-player: energy from environment
             # Winners gain, losers lose (energy conservation not required)
-            fish1.energy += energy_change
+            fish1.modify_energy(energy_change)  # Route overflow to reproduction/food
 
         return energy_change
 


### PR DESCRIPTION
Poker wins, skill game rewards, and auto-eval rewards were directly assigning energy without capping to max_energy. This allowed fish to accumulate energy far beyond their genetic capacity (e.g., 589 when max was 87).

Now all energy additions go through modify_energy() which properly caps at max_energy and routes overflow to reproduction or food drops.

Files changed:
- fish_poker.py: Use modify_energy() for poker winnings
- mixed_poker.py: Use modify_energy() in _modify_player_energy()
- skill_game_system.py: Use modify_energy() for all energy transfers
- simulation_runner.py: Use modify_energy() for auto-eval rewards