### PR TITLE
Add regular food to energy economy inflows

### DIFF
--- a/frontend/src/components/EnergyEconomyPanel.tsx
+++ b/frontend/src/components/EnergyEconomyPanel.tsx
@@ -115,6 +115,7 @@ export function EnergyEconomyPanel({ data, className }: EnergyEconomyPanelProps)
                     </div>
 
                     <FlowBar label="Live Food Eaten" value={data.liveFood} color="#22c55e" icon="🦐" total={totalIn} />
+                    <FlowBar label="Food Eaten" value={data.fallingFood} color="#f59e0b" icon="🍽️" total={totalIn} />
                     <FlowBar label="Plant Nectar" value={data.plantNectar} color="#10b981" icon="🌿" total={totalIn} />
                     <FlowBar label="Soup Spawns" value={data.soupSpawn} color="#a3e635" icon="🥣" total={totalIn} />
                     <FlowBar label="Migration In" value={data.migrationIn} color="#86efac" icon="🛬" total={totalIn} />


### PR DESCRIPTION
The fallingFood data was already being tracked by the backend and included in the totalIn calculation, but the FlowBar component was never rendered for it. Added the missing FlowBar with an orange color and plate emoji.