### PR TITLE
Lower reproduction energy threshold

### DIFF
--- a/core/fish/reproduction_component.py
+++ b/core/fish/reproduction_component.py
@@ -29,7 +29,7 @@ class ReproductionComponent:
     """
 
     # Reproduction constants
-    REPRODUCTION_ENERGY_PERCENTAGE = 1.0  # Require full energy before any reproduction path
+    REPRODUCTION_ENERGY_PERCENTAGE = 0.9  # Require ~90% energy before any reproduction path
     REPRODUCTION_COOLDOWN = 180  # 6 seconds (reduced for better breeding and faster generations)
     PREGNANCY_DURATION = 240  # 8 seconds (reduced for faster generations)
     MATING_DISTANCE = 60.0  # Maximum distance for mating


### PR DESCRIPTION
## Summary
- align reproduction energy requirement with documented 90% threshold instead of requiring full energy

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390a33c3cc8331b4634a8b7e064509)