### PR TITLE
Prune fractal plant caches to reduce tank view memory use

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -126,6 +126,12 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
 
         // Prevent orientation cache from growing without bound when entities churn
         renderer.pruneEntityFacingCache(state.entities.map((entity) => entity.id));
+        // Keep fractal plant caches bounded as plants spawn and despawn
+        renderer.prunePlantCaches(
+            state.entities
+                .filter((entity) => entity.type === 'fractal_plant')
+                .map((entity) => entity.id)
+        );
 
         // Save context state
         ctx.save();

--- a/frontend/src/utils/fractalPlant.ts
+++ b/frontend/src/utils/fractalPlant.ts
@@ -83,6 +83,33 @@ const sonnetCache = new Map<number, PlantRenderCache>();
 const gptCodexCache = new Map<number, PlantRenderCache>();
 
 /**
+ * Remove cached plant geometry/texture entries for plants that no longer exist.
+ * Without pruning, the caches can grow unbounded when the simulation spawns
+ * and deletes many plants, eventually exhausting browser memory.
+ */
+export function pruneFractalPlantCache(activePlantIds: Iterable<number>): void {
+    const activeIds = new Set(activePlantIds);
+
+    const caches = [
+        plantCache,
+        mandelbrotCache,
+        claudeCache,
+        antigravityCache,
+        gptCache,
+        sonnetCache,
+        gptCodexCache,
+    ];
+
+    for (const cache of caches) {
+        for (const id of cache.keys()) {
+            if (!activeIds.has(id)) {
+                cache.delete(id);
+            }
+        }
+    }
+}
+
+/**
  * Create a stable signature for a genome so cache invalidation happens when traits change.
  */
 function getGenomeSignature(genome: PlantGenomeData): string {

--- a/frontend/src/utils/renderer.ts
+++ b/frontend/src/utils/renderer.ts
@@ -6,7 +6,12 @@
 import type { EntityData } from '../types/simulation';
 import { ImageLoader } from './ImageLoader';
 import { getFishPath, getEyePosition, type FishParams } from './fishTemplates';
-import { renderFractalPlant as renderFractalPlantUtil, renderPlantNectar as renderPlantNectarUtil, type PlantGenomeData } from './fractalPlant';
+import {
+    pruneFractalPlantCache,
+    renderFractalPlant as renderFractalPlantUtil,
+    renderPlantNectar as renderPlantNectarUtil,
+    type PlantGenomeData,
+} from './fractalPlant';
 
 // Animation constants
 const IMAGE_CHANGE_RATE = 500; // milliseconds
@@ -145,6 +150,13 @@ export class Renderer {
                 this.pokerEffectStartTime.delete(cachedId);
             }
         }
+    }
+
+    /**
+     * Trim plant render caches for plants that are no longer in the scene.
+     */
+    prunePlantCaches(activePlantIds: Iterable<number>) {
+        pruneFractalPlantCache(activePlantIds);
     }
 
     private getTimeOfDayPalette(timeOfDay?: string): TimeOfDayPalette {


### PR DESCRIPTION
## Summary
- add pruning for fractal plant rendering caches to avoid unbounded memory growth when plants churn
- expose renderer helper to clear unused plant cache entries and invoke it from the canvas render loop

## Testing
- `npm run lint` *(fails: existing react-hooks/static-components errors in EnergyEconomyPanel.tsx and a no-unused-vars warning in SizeHistogram.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ba2822208331b8e78b18eb48e28a)