### PR TITLE
Investigate transfer and migration log warnings

### DIFF
--- a/core/simulators/base_simulator.py
+++ b/core/simulators/base_simulator.py
@@ -545,15 +545,16 @@ class BaseSimulator(ABC):
             if len(ready_players) < 2:
                 continue
 
-            # IMPORTANT: Require at least 1 fish in the game
+            # Limit to max players FIRST, before checking fish count
+            # This prevents truncation from removing all fish after the check passed
+            if len(ready_players) > POKER_MAX_PLAYERS:
+                ready_players = ready_players[:POKER_MAX_PLAYERS]
+
+            # IMPORTANT: Require at least 1 fish in the game (after truncation)
             # Plant-only poker games are not allowed
             fish_in_group = [p for p in ready_players if isinstance(p, Fish) or hasattr(p, "fish_id")]
             if len(fish_in_group) < 1:
                 continue
-
-            # Limit to max players
-            if len(ready_players) > POKER_MAX_PLAYERS:
-                ready_players = ready_players[:POKER_MAX_PLAYERS]
 
             # Play mixed poker game
             try:


### PR DESCRIPTION
The fish count check was performed BEFORE truncating the player list to POKER_MAX_PLAYERS. This caused errors when fish were positioned at the end of the list and got truncated, leaving only plants:

Before: [Plant1..Plant6, Fish1] -> fish check passes -> truncate to 6 -> no fish!
After:  [Plant1..Plant6, Fish1] -> truncate to 6 -> fish check fails -> skip game

🤖 Generated with [Claude Code](https://claude.com/claude-code)