### PR TITLE
Remove epigenetics code and documentation

### DIFF
--- a/core/genetics/genome_codec.py
+++ b/core/genetics/genome_codec.py
@@ -81,7 +81,6 @@ def genome_to_dict(
         "mate_preferences": dict(genome.behavioral.mate_preferences.value),
         # Non-genetic (but persistable) state
         "learned_behaviors": dict(genome.learned_behaviors),
-        "epigenetic_modifiers": dict(genome.epigenetic_modifiers),
         "trait_meta": trait_meta,
     }
 
@@ -142,9 +141,6 @@ def genome_from_dict(
     learned = data.get("learned_behaviors")
     if isinstance(learned, dict):
         genome.learned_behaviors = {str(key): float(value) for key, value in learned.items()}
-    epigenetic = data.get("epigenetic_modifiers")
-    if isinstance(epigenetic, dict):
-        genome.epigenetic_modifiers = {str(key): float(value) for key, value in epigenetic.items()}
 
     # Algorithms
     try:
@@ -200,7 +196,6 @@ def genome_debug_snapshot(genome: Any) -> Dict[str, Any]:
         **values,
         "trait_meta": trait_meta,
         "learned_behaviors_count": len(getattr(genome, "learned_behaviors", {}) or {}),
-        "epigenetic_modifiers_count": len(getattr(genome, "epigenetic_modifiers", {}) or {}),
         "behavior_algorithm_type": _algo_name(
             genome.behavioral.behavior_algorithm.value
         ),

--- a/docs/archive/EVOLUTION_AND_BEHAVIOR_IMPROVEMENTS.md
+++ b/docs/archive/EVOLUTION_AND_BEHAVIOR_IMPROVEMENTS.md
@@ -59,14 +59,7 @@ Related traits now evolve together:
 - **Speed ↔ Metabolism**: Faster fish have higher metabolism (realistic trade-off)
 - Linked traits create more coherent evolutionary strategies
 
-### 5. Epigenetic Effects
-
-Environmental stress can affect offspring through epigenetic modifiers:
-- Modifiers decay by 50% each generation
-- Allow rapid adaptation to environmental changes
-- Effects are heritable but temporary
-
-### 6. Mate Preferences
+### 5. Mate Preferences
 
 Fish have evolvable mate preferences:
 - `prefer_high_fitness`: Attraction to successful individuals
@@ -327,7 +320,6 @@ offspring_genome = Genome.from_parents(
 
 # Offspring inherits:
 # - Recombined genes from parents
-# - Epigenetic modifiers
 # - Mate preferences
 # - Starts with 0 fitness (must earn it)
 ```
@@ -454,7 +446,6 @@ These improvements enable:
 
 ### Long-term Evolution (across generations)
 - **Trait linkage**: Coherent evolutionary strategies emerge
-- **Epigenetic adaptation**: Rapid response to environmental shifts
 - **Communication evolution**: Social behaviors can evolve and spread
 - **Predictive abilities**: Fish evolve better prediction parameters
 


### PR DESCRIPTION
- Remove epigenetic_modifiers field from Genome dataclass
- Remove _inherit_epigenetics helper function
- Remove epigenetic serialization/deserialization from genome_codec
- Remove epigenetic references from archived documentation

The epigenetics feature was unused and added unnecessary complexity to the inheritance system.