### PR TITLE
refactor: Improve naming conventions and remove dead code

### DIFF
--- a/core/entities/plant.py
+++ b/core/entities/plant.py
@@ -110,7 +110,7 @@ class Plant(Agent):
         # Add random offset to prevent synchronized migrations
         self.migration_check_interval = 300
         self.migration_timer = random.randint(0, self.migration_check_interval)
-        self._migrated = False  # Set to True when plant migrates
+        self._marked_for_removal = False  # Set to True when plant should be removed (e.g., after migration)
 
         # Statistics
         self.age = 0
@@ -380,7 +380,7 @@ class Plant(Agent):
         Returns:
             True if plant should be removed
         """
-        return self._migrated or self.energy < PLANT_DEATH_ENERGY
+        return self._marked_for_removal or self.energy < PLANT_DEATH_ENERGY
 
     def get_size_multiplier(self) -> float:
         """Get current size multiplier for rendering.
@@ -520,7 +520,7 @@ class Plant(Agent):
 
             if success:
                 # Mark this plant for removal from source tank
-                self._migrated = True
+                self._marked_for_removal = True
                 logger.info(f"Plant #{self.plant_id} successfully migrated {direction}")
 
             return success

--- a/tests/test_migration_protocol.py
+++ b/tests/test_migration_protocol.py
@@ -35,7 +35,7 @@ def test_fish_migration_returns_false_without_handler() -> None:
     fish = _make_fish(env)
 
     assert fish._attempt_migration("left") is False
-    assert fish._migrated is False
+    assert fish._marked_for_removal is False
 
 
 def test_fish_migration_returns_false_without_tank_id() -> None:
@@ -44,10 +44,10 @@ def test_fish_migration_returns_false_without_tank_id() -> None:
     fish = _make_fish(env)
 
     assert fish._attempt_migration("left") is False
-    assert fish._migrated is False
+    assert fish._marked_for_removal is False
 
 
-def test_fish_migration_marks_migrated_on_success() -> None:
+def test_fish_migration_marks_for_removal_on_success() -> None:
     env = Environment(width=800, height=600)
     env.tank_id = "tank-123"
     handler = FakeMigrationHandler(result=True)
@@ -55,5 +55,5 @@ def test_fish_migration_marks_migrated_on_success() -> None:
     fish = _make_fish(env)
 
     assert fish._attempt_migration("right") is True
-    assert fish._migrated is True
+    assert fish._marked_for_removal is True
     assert handler.last_call == ("Fish", "right", "tank-123")


### PR DESCRIPTION
- Rename _migrated to _marked_for_removal in Fish and Plant classes The flag indicates the entity should be removed, not that migration already occurred. The new name is more accurate.

- Rename _is_dead_cached to _cached_is_dead in Fish class Follows clearer pattern of "cached_[method_name]" convention.

- Remove orphaned dead code in Fish.get_energy_ratio() Dead docstring and code block that appeared after a return statement (remnants of a deleted remember_food_location method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)