### PR TITLE
Rename confusing function to clearer name

### DIFF
--- a/core/entities/fish.py
+++ b/core/entities/fish.py
@@ -530,9 +530,9 @@ class Fish(Agent):
 
         # If the bank is full, spill the remainder as food to maintain energy conservation.
         if remainder > 0:
-            self._drop_overflow_as_food(remainder)
+            self._spawn_overflow_food(remainder)
 
-    def _drop_overflow_as_food(self, overflow: float) -> None:
+    def _spawn_overflow_food(self, overflow: float) -> None:
         """Convert overflow energy into a food drop near the fish.
 
         Args:


### PR DESCRIPTION
The previous name '_drop_overflow_as_food' was misleading because "drop" suggests food falls passively from the fish. The function actually creates and spawns a new Food entity at the fish's location.

The new name '_spawn_overflow_food' more accurately describes the action: actively creating and adding a food entity to the environment when the reproduction energy bank overflows.

This improves code clarity for readers who might otherwise be confused about what this function does.