### PR TITLE
Rename confusing function to clearer name

### DIFF
--- a/core/entities/fish.py
+++ b/core/entities/fish.py
@@ -475,7 +475,7 @@ class Fish(Agent):
             # We have overflow - route it productively
             overflow = new_energy - self.max_energy
             self._energy_component.energy = self.max_energy
-            self._handle_overflow_energy(overflow)
+            self._route_overflow_energy(overflow)
         else:
             self._energy_component.energy = new_energy
 
@@ -502,7 +502,7 @@ class Fish(Agent):
                 # We have overflow - try to use it productively
                 overflow = new_energy - self.max_energy
                 self._energy_component.energy = self.max_energy
-                self._handle_overflow_energy(overflow)
+                self._route_overflow_energy(overflow)
             else:
                 self._energy_component.energy = new_energy
         else:
@@ -517,7 +517,7 @@ class Fish(Agent):
 
         return self._energy_component.energy - old_energy
 
-    def _handle_overflow_energy(self, overflow: float) -> None:
+    def _route_overflow_energy(self, overflow: float) -> None:
         """Route overflow energy into reproduction bank.
 
         When a fish gains more energy than it can hold, this method banks


### PR DESCRIPTION
The old name "_handle_overflow_energy" used the generic verb "handle" which obscured the actual purpose of the method. The docstring and code clearly show the function routes excess energy in specific ways:

1. Banks the overflow into the reproduction bank (primary path)
2. If the bank is full, spawns overflow energy as food

The new name "_route_overflow_energy" is more descriptive and matches the docstring's explicit use of "Route overflow energy into reproduction bank." This makes the code more self-documenting and easier to understand at first glance.

All 895 tests pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)