### PR TITLE
Add simulation configuration presets

### DIFF
--- a/core/config/simulation_config.py
+++ b/core/config/simulation_config.py
@@ -1,0 +1,191 @@
+"""Aggregate simulation configuration dataclasses.
+
+This module centralizes configuration that was previously scattered across
+multiple modules. The ``SimulationConfig`` dataclass groups ecosystem,
+display, server, poker, and food parameters so experiments can be reproduced
+with a single object.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from typing import Dict, List
+
+from core.config.display import (
+    FILES,
+    FRAME_RATE,
+    INIT_POS,
+    SCREEN_HEIGHT,
+    SCREEN_WIDTH,
+    SEPARATOR_WIDTH,
+)
+from core.config.ecosystem import (
+    CRITICAL_POPULATION_THRESHOLD,
+    EMERGENCY_SPAWN_COOLDOWN,
+    MAX_POPULATION,
+    NUM_SCHOOLING_FISH,
+    SPAWN_MARGIN_PIXELS,
+    TOTAL_ALGORITHM_COUNT,
+    TOTAL_SPECIES_COUNT,
+)
+from core.config.food import (
+    AUTO_FOOD_ENABLED,
+    AUTO_FOOD_HIGH_ENERGY_THRESHOLD_1,
+    AUTO_FOOD_HIGH_ENERGY_THRESHOLD_2,
+    AUTO_FOOD_HIGH_POP_THRESHOLD_1,
+    AUTO_FOOD_HIGH_POP_THRESHOLD_2,
+    AUTO_FOOD_LOW_ENERGY_THRESHOLD,
+    AUTO_FOOD_SPAWN_RATE,
+    AUTO_FOOD_ULTRA_LOW_ENERGY_THRESHOLD,
+    LIVE_FOOD_SPAWN_CHANCE,
+)
+from core.config.poker import MAX_POKER_EVENTS, POKER_EVENT_MAX_AGE_FRAMES
+from core.config.server import DEFAULT_API_PORT, PLANTS_ENABLED, POKER_ACTIVITY_ENABLED
+from core.poker.evaluation.benchmark_eval import BenchmarkEvalConfig
+
+
+@dataclass
+class EcosystemConfig:
+    """Configuration for population dynamics and spawning."""
+
+    max_population: int = MAX_POPULATION
+    num_schooling_fish: int = NUM_SCHOOLING_FISH
+    critical_population_threshold: int = CRITICAL_POPULATION_THRESHOLD
+    emergency_spawn_cooldown: int = EMERGENCY_SPAWN_COOLDOWN
+    spawn_margin_pixels: int = SPAWN_MARGIN_PIXELS
+    total_algorithm_count: int = TOTAL_ALGORITHM_COUNT
+    total_species_count: int = TOTAL_SPECIES_COUNT
+
+
+@dataclass
+class DisplayConfig:
+    """Configuration for screen and asset settings."""
+
+    screen_width: int = SCREEN_WIDTH
+    screen_height: int = SCREEN_HEIGHT
+    frame_rate: int = FRAME_RATE
+    separator_width: int = SEPARATOR_WIDTH
+    files: Dict[str, List[str]] = field(default_factory=lambda: deepcopy(FILES))
+    init_pos: Dict[str, tuple] = field(default_factory=lambda: deepcopy(INIT_POS))
+
+
+@dataclass
+class ServerConfig:
+    """Server and feature flag configuration."""
+
+    default_api_port: int = DEFAULT_API_PORT
+    poker_activity_enabled: bool = POKER_ACTIVITY_ENABLED
+    plants_enabled: bool = PLANTS_ENABLED
+
+
+@dataclass
+class PokerConfig:
+    """Poker-related runtime configuration."""
+
+    max_poker_events: int = MAX_POKER_EVENTS
+    poker_event_max_age_frames: int = POKER_EVENT_MAX_AGE_FRAMES
+    enable_periodic_benchmarks: bool = False
+    benchmark_config: BenchmarkEvalConfig = field(default_factory=BenchmarkEvalConfig)
+
+
+@dataclass
+class FoodConfig:
+    """Food spawning configuration."""
+
+    auto_food_enabled: bool = AUTO_FOOD_ENABLED
+    spawn_rate: int = AUTO_FOOD_SPAWN_RATE
+    ultra_low_energy_threshold: float = AUTO_FOOD_ULTRA_LOW_ENERGY_THRESHOLD
+    low_energy_threshold: float = AUTO_FOOD_LOW_ENERGY_THRESHOLD
+    high_energy_threshold_1: float = AUTO_FOOD_HIGH_ENERGY_THRESHOLD_1
+    high_energy_threshold_2: float = AUTO_FOOD_HIGH_ENERGY_THRESHOLD_2
+    high_pop_threshold_1: int = AUTO_FOOD_HIGH_POP_THRESHOLD_1
+    high_pop_threshold_2: int = AUTO_FOOD_HIGH_POP_THRESHOLD_2
+    live_food_chance: float = LIVE_FOOD_SPAWN_CHANCE
+
+
+@dataclass
+class SimulationConfig:
+    """Aggregate configuration for running a simulation."""
+
+    ecosystem: EcosystemConfig = field(default_factory=EcosystemConfig)
+    display: DisplayConfig = field(default_factory=DisplayConfig)
+    server: ServerConfig = field(default_factory=ServerConfig)
+    poker: PokerConfig = field(default_factory=PokerConfig)
+    food: FoodConfig = field(default_factory=FoodConfig)
+    headless: bool = True
+    enable_phase_debug: bool = False
+
+    def validate(self) -> None:
+        """Validate the configuration for conflicting settings."""
+        errors = []
+
+        if not self.server.poker_activity_enabled and self.poker.enable_periodic_benchmarks:
+            errors.append("Poker benchmarks require poker activity to be enabled.")
+
+        if errors:
+            raise ValueError("; ".join(errors))
+
+    @classmethod
+    def production(cls, *, headless: bool = False) -> "SimulationConfig":
+        """Preset matching production defaults."""
+        return cls(headless=headless)
+
+    @classmethod
+    def headless_fast(cls) -> "SimulationConfig":
+        """Preset optimized for fast, deterministic tests."""
+        return cls(
+            headless=True,
+            ecosystem=EcosystemConfig(
+                max_population=60,
+                critical_population_threshold=5,
+                emergency_spawn_cooldown=90,
+                spawn_margin_pixels=SPAWN_MARGIN_PIXELS,
+                total_algorithm_count=TOTAL_ALGORITHM_COUNT,
+                total_species_count=TOTAL_SPECIES_COUNT,
+            ),
+            server=ServerConfig(
+                default_api_port=DEFAULT_API_PORT,
+                poker_activity_enabled=False,
+                plants_enabled=False,
+            ),
+            poker=PokerConfig(
+                max_poker_events=5,
+                poker_event_max_age_frames=POKER_EVENT_MAX_AGE_FRAMES,
+                enable_periodic_benchmarks=False,
+            ),
+            food=FoodConfig(
+                auto_food_enabled=True,
+                spawn_rate=max(1, AUTO_FOOD_SPAWN_RATE // 2),
+                ultra_low_energy_threshold=AUTO_FOOD_ULTRA_LOW_ENERGY_THRESHOLD,
+                low_energy_threshold=AUTO_FOOD_LOW_ENERGY_THRESHOLD,
+                high_energy_threshold_1=AUTO_FOOD_HIGH_ENERGY_THRESHOLD_1,
+                high_energy_threshold_2=AUTO_FOOD_HIGH_ENERGY_THRESHOLD_2,
+                high_pop_threshold_1=AUTO_FOOD_HIGH_POP_THRESHOLD_1,
+                high_pop_threshold_2=AUTO_FOOD_HIGH_POP_THRESHOLD_2,
+                live_food_chance=LIVE_FOOD_SPAWN_CHANCE,
+            ),
+        )
+
+    @classmethod
+    def debug_trace(cls) -> "SimulationConfig":
+        """Preset for deep debugging and tracing."""
+        return cls(
+            headless=True,
+            enable_phase_debug=True,
+            server=ServerConfig(
+                default_api_port=DEFAULT_API_PORT,
+                poker_activity_enabled=True,
+                plants_enabled=True,
+            ),
+            poker=PokerConfig(
+                max_poker_events=MAX_POKER_EVENTS,
+                poker_event_max_age_frames=POKER_EVENT_MAX_AGE_FRAMES,
+                enable_periodic_benchmarks=True,
+                benchmark_config=BenchmarkEvalConfig(),
+            ),
+        )
+
+    def with_overrides(self, **kwargs) -> "SimulationConfig":
+        """Return a copy of the config with updated fields."""
+        return replace(self, **kwargs)

--- a/core/entity_factory.py
+++ b/core/entity_factory.py
@@ -8,14 +8,8 @@ import random
 from typing import List, Optional
 
 from core import entities, environment, movement_strategy
-from core.config.display import (
-    FILES,
-    INIT_POS,
-    SCREEN_HEIGHT,
-    SCREEN_WIDTH,
-)
+from core.config.simulation_config import DisplayConfig, EcosystemConfig
 from core.config.fish import FISH_BASE_SPEED
-from core.config.ecosystem import NUM_SCHOOLING_FISH
 from core.ecosystem import EcosystemManager
 from core.genetics import Genome
 
@@ -23,8 +17,8 @@ from core.genetics import Genome
 def create_initial_population(
     env: environment.Environment,
     ecosystem: EcosystemManager,
-    screen_width: int = SCREEN_WIDTH,
-    screen_height: int = SCREEN_HEIGHT,
+    display_config: Optional[DisplayConfig] = None,
+    ecosystem_config: Optional[EcosystemConfig] = None,
     rng: Optional[random.Random] = None,
 ) -> List[entities.Agent]:
     """Create initial population for simulation.
@@ -39,26 +33,28 @@ def create_initial_population(
     Args:
         env: Environment instance for spatial queries
         ecosystem: EcosystemManager for population tracking
-        screen_width: Screen width for boundary constraints
-        screen_height: Screen height for boundary constraints
+        display_config: Display configuration for asset selection and bounds
+        ecosystem_config: Ecosystem configuration controlling initial population size
 
     Returns:
         List of Entity objects representing the initial population
     """
+    display_config = display_config or DisplayConfig()
+    ecosystem_config = ecosystem_config or EcosystemConfig()
     population = []
     rng = rng if rng is not None else random.Random()
     # These fish use the algorithmic evolution system with diverse genomes
     for _i in range(
-        NUM_SCHOOLING_FISH
-    ):  # Start with NUM_SCHOOLING_FISH algorithmic fish for better evolution and sustainability
-        x = INIT_POS["school"][0] + rng.randint(-100, 100)
-        y = INIT_POS["school"][1] + rng.randint(-60, 60)
+        ecosystem_config.num_schooling_fish
+    ):  # Start with configured algorithmic fish for better evolution and sustainability
+        x = display_config.init_pos["school"][0] + rng.randint(-100, 100)
+        y = display_config.init_pos["school"][1] + rng.randint(-60, 60)
         # Create genome with behavior algorithm
         genome = Genome.random(use_algorithm=True, rng=rng)
         fish = entities.Fish(
             env,
             movement_strategy.AlgorithmicMovement(),
-            FILES["schooling_fish"][0],
+            display_config.files["schooling_fish"][0],
             x,
             y,
             FISH_BASE_SPEED,
@@ -75,14 +71,14 @@ def create_initial_population(
     # Spawn 8 food items at various locations so fish have immediate targets
     initial_food = []
     food_positions = [
-        (screen_width * 0.25, screen_height * 0.3),  # Upper left area
-        (screen_width * 0.5, screen_height * 0.25),  # Upper middle
-        (screen_width * 0.75, screen_height * 0.35),  # Upper right area
-        (screen_width * 0.2, screen_height * 0.5),  # Middle left
-        (screen_width * 0.6, screen_height * 0.45),  # Middle right
-        (screen_width * 0.3, screen_height * 0.65),  # Lower left
-        (screen_width * 0.7, screen_height * 0.6),  # Lower right
-        (screen_width * 0.5, screen_height * 0.55),  # Lower middle
+        (display_config.screen_width * 0.25, display_config.screen_height * 0.3),  # Upper left area
+        (display_config.screen_width * 0.5, display_config.screen_height * 0.25),  # Upper middle
+        (display_config.screen_width * 0.75, display_config.screen_height * 0.35),  # Upper right area
+        (display_config.screen_width * 0.2, display_config.screen_height * 0.5),  # Middle left
+        (display_config.screen_width * 0.6, display_config.screen_height * 0.45),  # Middle right
+        (display_config.screen_width * 0.3, display_config.screen_height * 0.65),  # Lower left
+        (display_config.screen_width * 0.7, display_config.screen_height * 0.6),  # Lower right
+        (display_config.screen_width * 0.5, display_config.screen_height * 0.55),  # Lower middle
     ]
     for x, y in food_positions:
         food = entities.Food(
@@ -96,8 +92,8 @@ def create_initial_population(
         initial_food.append(food)
 
     # Create crab and castle
-    crab = entities.Crab(env, None, *INIT_POS["crab"])
-    castle = entities.Castle(env, *INIT_POS["castle"])
+    crab = entities.Crab(env, None, *display_config.init_pos["crab"])
+    castle = entities.Castle(env, *display_config.init_pos["castle"])
 
     # Add all non-fish entities
     population.extend(initial_food + [crab, castle])

--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -14,25 +14,7 @@ from core import entities, environment, movement_strategy
 from core.algorithms.registry import get_algorithm_index
 from core.cache_manager import CacheManager
 from core.collision_system import CollisionSystem
-from core.config.ecosystem import (
-    CRITICAL_POPULATION_THRESHOLD,
-    EMERGENCY_SPAWN_COOLDOWN,
-    MAX_POPULATION,
-    SPAWN_MARGIN_PIXELS,
-    TOTAL_ALGORITHM_COUNT,
-)
-from core.config.display import (
-    FILES,
-    FRAME_RATE,
-    SCREEN_HEIGHT,
-    SCREEN_WIDTH,
-    SEPARATOR_WIDTH,
-)
-from core.config.server import PLANTS_ENABLED
-from core.config.poker import (
-    MAX_POKER_EVENTS,
-    POKER_EVENT_MAX_AGE_FRAMES,
-)
+from core.config.simulation_config import SimulationConfig
 from core.ecosystem import EcosystemManager
 from core.entities.plant import Plant, PlantNectar
 from core.entity_factory import create_initial_population
@@ -45,7 +27,6 @@ from core.genetics import Genome
 from core.object_pool import FoodPool
 from core.genetics import PlantGenome
 from core.plant_manager import PlantManager
-from core.poker.evaluation.benchmark_eval import BenchmarkEvalConfig
 from core.poker.evaluation.periodic_benchmark import PeriodicBenchmarkEvaluator
 from core.poker_system import PokerSystem
 from core.reproduction_system import ReproductionSystem
@@ -55,7 +36,7 @@ from core.simulation_stats_exporter import SimulationStatsExporter
 from core.simulators.base_simulator import BaseSimulator
 from core.systems.base import BaseSystem
 from core.systems.entity_lifecycle import EntityLifecycleSystem
-from core.systems.food_spawning import FoodSpawningSystem
+from core.systems.food_spawning import FoodSpawningSystem, SpawnRateConfig
 from core.time_system import TimeSystem
 from core.update_phases import PHASE_DESCRIPTIONS, UpdatePhase
 
@@ -157,20 +138,32 @@ class SimulationEngine(BaseSimulator):
 
     def __init__(
         self,
-        headless: bool = True,
+        config: Optional[SimulationConfig] = None,
+        *,
+        headless: Optional[bool] = None,
         rng: Optional[random.Random] = None,
         seed: Optional[int] = None,
-        enable_poker_benchmarks: bool = False,
+        enable_poker_benchmarks: Optional[bool] = None,
     ) -> None:
         """Initialize the simulation engine.
 
         Args:
-            headless: If True, run without any visualization
+            config: Aggregate simulation configuration
+            headless: Override headless mode (for backward compatibility)
             rng: Shared random number generator for deterministic runs
-            enable_poker_benchmarks: If True, enable periodic benchmark evaluations
+            seed: Optional seed (used if rng is not provided)
+            enable_poker_benchmarks: Override poker benchmark toggle
         """
         super().__init__()
-        self.headless = headless
+        self.config = config or SimulationConfig.production(headless=True)
+        if headless is not None:
+            self.config = self.config.with_overrides(headless=headless)
+        if enable_poker_benchmarks is not None:
+            poker_config = self.config.poker
+            poker_config.enable_periodic_benchmarks = enable_poker_benchmarks
+            self.config.poker = poker_config
+        self.config.validate()
+        self.headless = self.config.headless
         # Backwards-compatible RNG handling: prefer explicit rng, then seed, then fresh RNG
         if rng is not None:
             self.rng: random.Random = rng
@@ -187,7 +180,7 @@ class SimulationEngine(BaseSimulator):
         self.time_system: TimeSystem = TimeSystem(self)
         self.start_time: float = time.time()
         self.last_emergency_spawn_frame: int = (
-            -EMERGENCY_SPAWN_COOLDOWN
+            -self.config.ecosystem.emergency_spawn_cooldown
         )  # Allow immediate first spawn
 
         # Event bus for decoupled communication between components
@@ -196,7 +189,8 @@ class SimulationEngine(BaseSimulator):
         # Systems - all extend BaseSystem for consistent interface
         self.collision_system = CollisionSystem(self)
         self.reproduction_system = ReproductionSystem(self)
-        self.poker_system = PokerSystem(self, max_events=MAX_POKER_EVENTS)
+        self.poker_system = PokerSystem(self, max_events=self.config.poker.max_poker_events)
+        self.poker_system.enabled = self.config.server.poker_activity_enabled
         self.poker_events = self.poker_system.poker_events
         self.lifecycle_system = EntityLifecycleSystem(self)
 
@@ -215,9 +209,9 @@ class SimulationEngine(BaseSimulator):
 
         # Periodic poker benchmark evaluation
         self.benchmark_evaluator: Optional[PeriodicBenchmarkEvaluator] = None
-        if enable_poker_benchmarks:
+        if self.config.poker.enable_periodic_benchmarks:
             self.benchmark_evaluator = PeriodicBenchmarkEvaluator(
-                BenchmarkEvalConfig()
+                self.config.poker.benchmark_config
             )
 
         # Services
@@ -228,7 +222,7 @@ class SimulationEngine(BaseSimulator):
 
         # Phase tracking for debugging and monitoring
         self._current_phase: Optional[UpdatePhase] = None
-        self._phase_debug_enabled: bool = False
+        self._phase_debug_enabled: bool = self.config.enable_phase_debug
 
     @property
     def root_spot_manager(self) -> Optional[RootSpotManager]:
@@ -240,11 +234,15 @@ class SimulationEngine(BaseSimulator):
     def setup(self) -> None:
         """Setup the simulation."""
         # Initialize managers
-        self.environment = environment.Environment(self.entities_list, SCREEN_WIDTH, SCREEN_HEIGHT, self.time_system)
-        self.ecosystem = EcosystemManager(max_population=MAX_POPULATION)
+        display = self.config.display
+        eco_config = self.config.ecosystem
+        self.environment = environment.Environment(
+            self.entities_list, display.screen_width, display.screen_height, self.time_system
+        )
+        self.ecosystem = EcosystemManager(max_population=eco_config.max_population)
 
         # Initialize plant management system
-        if PLANTS_ENABLED:
+        if self.config.server.plants_enabled:
             self.plant_manager = PlantManager(
                 environment=self.environment,
                 ecosystem=self.ecosystem,
@@ -253,7 +251,13 @@ class SimulationEngine(BaseSimulator):
             )
 
         # Initialize food spawning system (uses engine's rng for deterministic behavior)
-        self.food_spawning_system = FoodSpawningSystem(self, rng=self.rng)
+        self.food_spawning_system = FoodSpawningSystem(
+            self,
+            rng=self.rng,
+            spawn_rate_config=self._build_spawn_rate_config(),
+            auto_food_enabled=self.config.food.auto_food_enabled,
+            display_config=display,
+        )
 
         # Register systems in execution order
         # Order matters: lifecycle first for per-frame reset, time affects behavior,
@@ -276,6 +280,20 @@ class SimulationEngine(BaseSimulator):
         if self.plant_manager is not None:
             self._block_root_spots_with_obstacles()
             self.plant_manager.create_initial_plants(self.entities_list)
+
+    def _build_spawn_rate_config(self) -> SpawnRateConfig:
+        """Translate SimulationConfig food settings into SpawnRateConfig."""
+        food_cfg = self.config.food
+        return SpawnRateConfig(
+            base_rate=food_cfg.spawn_rate,
+            ultra_low_energy_threshold=food_cfg.ultra_low_energy_threshold,
+            low_energy_threshold=food_cfg.low_energy_threshold,
+            high_energy_threshold_1=food_cfg.high_energy_threshold_1,
+            high_energy_threshold_2=food_cfg.high_energy_threshold_2,
+            high_pop_threshold_1=food_cfg.high_pop_threshold_1,
+            high_pop_threshold_2=food_cfg.high_pop_threshold_2,
+            live_food_chance=food_cfg.live_food_chance,
+        )
 
     # =========================================================================
     # System Registry Methods
@@ -406,8 +424,13 @@ class SimulationEngine(BaseSimulator):
             return
 
         # Use centralized factory function for initial population
+        display = self.config.display
         population = create_initial_population(
-            self.environment, self.ecosystem, SCREEN_WIDTH, SCREEN_HEIGHT, rng=self.rng
+            self.environment,
+            self.ecosystem,
+            display_config=display,
+            ecosystem_config=self.config.ecosystem,
+            rng=self.rng,
         )
         for entity in population:
             self.agents.add(entity)
@@ -637,7 +660,7 @@ class SimulationEngine(BaseSimulator):
                          entities_to_remove.append(entity)
                  else:
                      # Standard food sinks
-                     if entity.pos.y >= SCREEN_HEIGHT - entity.height:
+                     if entity.pos.y >= self.config.display.screen_height - entity.height:
                          entities_to_remove.append(entity)
 
             self.keep_entity_on_screen(entity)
@@ -681,14 +704,15 @@ class SimulationEngine(BaseSimulator):
             # Do this BEFORE taking the energy snapshot so the snapshot matches true end-of-frame state.
             fish_list = self.get_fish_list()
             fish_count = len(fish_list)
-            if fish_count < MAX_POPULATION:
+            eco_cfg = self.config.ecosystem
+            if fish_count < eco_cfg.max_population:
                 frames_since_last_spawn = self.frame_count - self.last_emergency_spawn_frame
-                if frames_since_last_spawn >= EMERGENCY_SPAWN_COOLDOWN:
-                    if fish_count < CRITICAL_POPULATION_THRESHOLD:
+                if frames_since_last_spawn >= eco_cfg.emergency_spawn_cooldown:
+                    if fish_count < eco_cfg.critical_population_threshold:
                         spawn_probability = 1.0
                     else:
-                        population_ratio = (fish_count - CRITICAL_POPULATION_THRESHOLD) / (
-                            MAX_POPULATION - CRITICAL_POPULATION_THRESHOLD
+                        population_ratio = (fish_count - eco_cfg.critical_population_threshold) / (
+                            eco_cfg.max_population - eco_cfg.critical_population_threshold
                         )
                         spawn_probability = (1.0 - population_ratio) ** 2 * 0.3
 
@@ -696,7 +720,7 @@ class SimulationEngine(BaseSimulator):
                         self.spawn_emergency_fish()
                         self.last_emergency_spawn_frame = self.frame_count
                         fish_list = self.get_fish_list()
-                        if fish_count < CRITICAL_POPULATION_THRESHOLD:
+                        if fish_count < eco_cfg.critical_population_threshold:
                             # Only log at INFO level when population is critically low
                             logger.info(f"Emergency fish spawned! fish_count now: {len(fish_list)}")
 
@@ -748,14 +772,15 @@ class SimulationEngine(BaseSimulator):
         # Random spawn position (avoid edges)
         bounds = self.environment.get_bounds()
         (min_x, min_y), (max_x, max_y) = bounds
-        x = self.rng.randint(int(min_x) + SPAWN_MARGIN_PIXELS, int(max_x) - SPAWN_MARGIN_PIXELS)
-        y = self.rng.randint(int(min_y) + SPAWN_MARGIN_PIXELS, int(max_y) - SPAWN_MARGIN_PIXELS)
+        spawn_margin = self.config.ecosystem.spawn_margin_pixels
+        x = self.rng.randint(int(min_x) + spawn_margin, int(max_x) - spawn_margin)
+        y = self.rng.randint(int(min_y) + spawn_margin, int(max_y) - spawn_margin)
 
         # Create the new fish
         new_fish = entities.Fish(
             self.environment,
             movement_strategy.AlgorithmicMovement(),
-            FILES["schooling_fish"][0],
+            self.config.display.files["schooling_fish"][0],
             x,
             y,
             4,
@@ -794,10 +819,11 @@ class SimulationEngine(BaseSimulator):
         self.poker_system.add_poker_event(poker)
 
     def get_recent_poker_events(
-        self, max_age_frames: int = POKER_EVENT_MAX_AGE_FRAMES
+        self, max_age_frames: Optional[int] = None
     ) -> List[Dict[str, Any]]:
         """Get recent poker events (within max_age_frames)."""
-        return self.poker_system.get_recent_poker_events(max_age_frames)
+        max_age = max_age_frames or self.config.poker.poker_event_max_age_frames
+        return self.poker_system.get_recent_poker_events(max_age)
 
     def get_stats(self) -> Dict[str, Any]:
         """Get current simulation statistics.
@@ -817,21 +843,22 @@ class SimulationEngine(BaseSimulator):
     def print_stats(self) -> None:
         """Print current simulation statistics to console."""
         stats = self.get_stats()
+        sep = self.config.display.separator_width
 
         logger.info("")
-        logger.info("=" * SEPARATOR_WIDTH)
+        logger.info("=" * sep)
         logger.info(f"Frame: {stats.get('frame_count', 0)}")
         logger.info(f"Time: {stats.get('time_string', 'N/A')}")
         logger.info(f"Real Time: {stats.get('elapsed_real_time', 0):.1f}s")
         logger.info(f"Simulation Speed: {stats.get('simulation_speed', 0):.2f}x")
-        logger.info("-" * SEPARATOR_WIDTH)
+        logger.info("-" * sep)
         max_pop = self.ecosystem.max_population if self.ecosystem else "N/A"
         logger.info(f"Population: {stats.get('total_population', 0)}/{max_pop}")
         logger.info(f"Generation: {stats.get('current_generation', 0)}")
         logger.info(f"Total Births: {stats.get('total_births', 0)}")
         logger.info(f"Total Deaths: {stats.get('total_deaths', 0)}")
         logger.info(f"Capacity: {stats.get('capacity_usage', 'N/A')}")
-        logger.info("-" * SEPARATOR_WIDTH)
+        logger.info("-" * sep)
         logger.info(f"Fish: {stats.get('fish_count', 0)}")
         logger.info(f"Food: {stats.get('food_count', 0)}")
         logger.info(f"Plants: {stats.get('plant_count', 0)}")
@@ -839,7 +866,7 @@ class SimulationEngine(BaseSimulator):
         # Death causes
         death_causes = stats.get("death_causes", {})
         if death_causes:
-            logger.info("-" * SEPARATOR_WIDTH)
+            logger.info("-" * sep)
             logger.info("Death Causes:")
             for cause, count in death_causes.items():
                 logger.info(f"  {cause}: {count}")
@@ -847,7 +874,7 @@ class SimulationEngine(BaseSimulator):
         # Reproduction stats
         repro_stats = stats.get("reproduction_stats", {})
         if repro_stats:
-            logger.info("-" * SEPARATOR_WIDTH)
+            logger.info("-" * sep)
             logger.info("Reproduction Stats:")
             logger.info(f"  Total Reproductions: {repro_stats.get('total_reproductions', 0)}")
             logger.info(f"  Mating Attempts: {repro_stats.get('total_mating_attempts', 0)}")
@@ -859,19 +886,21 @@ class SimulationEngine(BaseSimulator):
         # Genetic diversity stats
         diversity_stats = stats.get("diversity_stats", {})
         if diversity_stats:
-            logger.info("-" * SEPARATOR_WIDTH)
+            logger.info("-" * sep)
             logger.info("Genetic Diversity:")
             logger.info(
-                f"  Unique Algorithms: {diversity_stats.get('unique_algorithms', 0)}/{TOTAL_ALGORITHM_COUNT}"
+                f"  Unique Algorithms: {diversity_stats.get('unique_algorithms', 0)}/{self.config.ecosystem.total_algorithm_count}"
             )
-            logger.info(f"  Unique Species: {diversity_stats.get('unique_species', 0)}/4")
+            logger.info(
+                f"  Unique Species: {diversity_stats.get('unique_species', 0)}/{self.config.ecosystem.total_species_count}"
+            )
             logger.info(f"  Diversity Score: {diversity_stats.get('diversity_score_pct', 'N/A')}")
             logger.info(f"  Color Variance: {diversity_stats.get('color_variance', 0):.4f}")
             logger.info(f"  Speed Variance: {diversity_stats.get('speed_variance', 0):.4f}")
             logger.info(f"  Size Variance: {diversity_stats.get('size_variance', 0):.4f}")
             logger.info(f"  Vision Variance: {diversity_stats.get('vision_variance', 0):.4f}")
 
-        logger.info("=" * SEPARATOR_WIDTH)
+        logger.info("=" * sep)
 
     def run_headless(
         self,
@@ -886,16 +915,17 @@ class SimulationEngine(BaseSimulator):
             stats_interval: Print stats every N frames
             export_json: Optional filename to export JSON stats for LLM analysis
         """
-        logger.info("=" * SEPARATOR_WIDTH)
+        sep = self.config.display.separator_width
+        logger.info("=" * sep)
         logger.info("HEADLESS FISH TANK SIMULATION")
-        logger.info("=" * SEPARATOR_WIDTH)
+        logger.info("=" * sep)
         logger.info(
-            f"Running for {max_frames} frames ({max_frames / FRAME_RATE:.1f} seconds of sim time)"
+            f"Running for {max_frames} frames ({max_frames / self.config.display.frame_rate:.1f} seconds of sim time)"
         )
         logger.info(f"Stats will be printed every {stats_interval} frames")
         if export_json:
             logger.info(f"Stats will be exported to: {export_json}")
-        logger.info("=" * SEPARATOR_WIDTH)
+        logger.info("=" * sep)
 
         self.setup()
 
@@ -908,17 +938,17 @@ class SimulationEngine(BaseSimulator):
 
         # Print final stats
         logger.info("")
-        logger.info("=" * SEPARATOR_WIDTH)
+        logger.info("=" * sep)
         logger.info("SIMULATION COMPLETE - Final Statistics")
-        logger.info("=" * SEPARATOR_WIDTH)
+        logger.info("=" * sep)
         self.print_stats()
 
         # Generate algorithm performance report if available
         if self.ecosystem is not None:
             logger.info("")
-            logger.info("=" * SEPARATOR_WIDTH)
+            logger.info("=" * sep)
             logger.info("GENERATING ALGORITHM PERFORMANCE REPORT...")
-            logger.info("=" * SEPARATOR_WIDTH)
+            logger.info("=" * sep)
             report = self.ecosystem.get_algorithm_performance_report()
             logger.info(f"{report}")
 
@@ -933,9 +963,9 @@ class SimulationEngine(BaseSimulator):
             # Export JSON stats if requested
             if export_json:
                 logger.info("")
-                logger.info("=" * SEPARATOR_WIDTH)
+                logger.info("=" * sep)
                 logger.info("EXPORTING JSON STATISTICS FOR LLM ANALYSIS...")
-                logger.info("=" * SEPARATOR_WIDTH)
+                logger.info("=" * sep)
                 self.export_stats_json(export_json)
 
     def run_collect_stats(self, max_frames: int = 100) -> Dict[str, Any]:
@@ -984,7 +1014,7 @@ class HeadlessSimulator(SimulationEngine):
             max_frames: Maximum number of frames to simulate
             stats_interval: Print stats every N frames (0 = no stats during run)
         """
-        super().__init__(headless=True)
+        super().__init__(config=SimulationConfig.headless_fast())
         self.max_frames = max_frames
         self.stats_interval = stats_interval if stats_interval > 0 else max_frames + 1
 

--- a/core/tank_world.py
+++ b/core/tank_world.py
@@ -9,9 +9,10 @@ including configuration and random number generation, making it easy to:
 
 import logging
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Dict, List, Optional
 
+from core.config.simulation_config import SimulationConfig
 from core.config.food import (
     AUTO_FOOD_ENABLED,
     AUTO_FOOD_SPAWN_RATE,
@@ -70,6 +71,28 @@ class TankWorldConfig:
         """Create config from dictionary."""
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 
+    def to_simulation_config(self) -> SimulationConfig:
+        """Convert legacy TankWorldConfig to SimulationConfig."""
+        sim_cfg = SimulationConfig.production(headless=self.headless)
+        sim_cfg.display = replace(
+            sim_cfg.display,
+            screen_width=self.screen_width,
+            screen_height=self.screen_height,
+            frame_rate=self.frame_rate,
+        )
+        sim_cfg.ecosystem = replace(
+            sim_cfg.ecosystem,
+            max_population=self.max_population,
+            critical_population_threshold=self.critical_population_threshold,
+        )
+        sim_cfg.food = replace(
+            sim_cfg.food,
+            spawn_rate=self.auto_food_spawn_rate,
+            auto_food_enabled=self.auto_food_enabled,
+        )
+        sim_cfg.validate()
+        return sim_cfg
+
 
 class TankWorld:
     """Main simulation wrapper that encapsulates all global state.
@@ -87,6 +110,7 @@ class TankWorld:
     def __init__(
         self,
         config: Optional[TankWorldConfig] = None,
+        simulation_config: Optional[SimulationConfig] = None,
         rng: Optional[random.Random] = None,
         seed: Optional[int] = None,
     ):
@@ -94,11 +118,13 @@ class TankWorld:
 
         Args:
             config: Simulation configuration (uses defaults if None)
+            simulation_config: New aggregate SimulationConfig (overrides config if provided)
             rng: Random number generator instance (creates new if None)
             seed: Random seed (only used if rng is None)
         """
         # Store configuration
         self.config = config if config is not None else TankWorldConfig()
+        self.simulation_config = simulation_config or self.config.to_simulation_config()
 
         # Setup RNG
         if rng is not None:
@@ -113,9 +139,7 @@ class TankWorld:
         from core.simulation_engine import SimulationEngine
 
         # Create the simulation engine
-        # For now, we pass headless flag to engine
-        # Later we can refactor engine to use config directly
-        self.engine = SimulationEngine(headless=self.config.headless, rng=self.rng)
+        self.engine = SimulationEngine(config=self.simulation_config, rng=self.rng)
 
     def setup(self) -> None:
         """Setup the simulation.


### PR DESCRIPTION
## Summary
- introduce a SimulationConfig dataclass with production, headless-fast, and debug_trace presets plus validation for conflicting toggles
- refactor SimulationEngine, TankWorld, and entity/food setup to consume SimulationConfig instead of module-level constants
- make poker toggles and spawn configuration deterministic through shared config-driven construction

## Testing
- python -m pytest tests/test_simulation.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad7b0438083319d78a1f1bc452fa1)