### PR TITLE
Introduce simulation runtime registry and ordering test

### DIFF
--- a/core/collision_system.py
+++ b/core/collision_system.py
@@ -22,6 +22,7 @@ from core.update_phases import UpdatePhase, runs_in_phase
 if TYPE_CHECKING:
     from core.entities import Agent
     from core.simulation_engine import SimulationEngine
+    from core.simulation_runtime import SimulationContext
 
 
 class CollisionDetector:
@@ -119,13 +120,13 @@ class CollisionSystem(BaseSystem):
     handling logic.
     """
 
-    def __init__(self, engine: "SimulationEngine") -> None:
+    def __init__(self, engine: "SimulationEngine", context: Optional["SimulationContext"] = None) -> None:
         """Initialize the collision system.
 
         Args:
             engine: The simulation engine
         """
-        super().__init__(engine, "Collision")
+        super().__init__(engine, "Collision", context=context)
         # Cumulative stats (all-time)
         self._collisions_checked: int = 0
         self._collisions_detected: int = 0

--- a/core/poker_system.py
+++ b/core/poker_system.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from core.entities import Fish
     from core.entities.plant import Plant
     from core.simulation_engine import SimulationEngine
+    from core.simulation_runtime import SimulationContext
 
 logger = logging.getLogger(__name__)
 
@@ -65,14 +66,19 @@ class PokerSystem(BaseSystem):
         _total_energy_transferred: Total energy transferred via poker
     """
 
-    def __init__(self, engine: "SimulationEngine", max_events: int = 100) -> None:
+    def __init__(
+        self,
+        engine: "SimulationEngine",
+        max_events: int = 100,
+        context: "SimulationContext | None" = None,
+    ) -> None:
         """Initialize the poker system.
 
         Args:
             engine: The simulation engine
             max_events: Maximum number of poker events to keep in history
         """
-        super().__init__(engine, "Poker")
+        super().__init__(engine, "Poker", context=context)
         self.poker_events: deque = deque(maxlen=max_events)
         self._max_events = max_events
         self._games_played: int = 0

--- a/core/reproduction_system.py
+++ b/core/reproduction_system.py
@@ -19,6 +19,7 @@ from core.update_phases import UpdatePhase, runs_in_phase
 
 if TYPE_CHECKING:
     from core.simulation_engine import SimulationEngine
+    from core.simulation_runtime import SimulationContext
 
 
 @runs_in_phase(UpdatePhase.REPRODUCTION)
@@ -34,13 +35,17 @@ class ReproductionSystem(BaseSystem):
         _asexual_triggered: Number of asexual reproductions triggered
     """
 
-    def __init__(self, engine: "SimulationEngine") -> None:
+    def __init__(
+        self,
+        engine: "SimulationEngine",
+        context: "SimulationContext | None" = None,
+    ) -> None:
         """Initialize the reproduction system.
 
         Args:
             engine: The simulation engine
         """
-        super().__init__(engine, "Reproduction")
+        super().__init__(engine, "Reproduction", context=context)
         self._asexual_checks: int = 0
         self._asexual_triggered: int = 0
 

--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -166,15 +166,19 @@ class SimulationEngine(BaseSimulator):
             enable_poker_benchmarks: If True, enable periodic benchmark evaluations
         """
         super().__init__()
-        runtime_config = SimulationRuntimeConfig(
-            headless=headless,
-            rng=rng,
-            seed=seed,
-            enable_poker_benchmarks=enable_poker_benchmarks,
-        )
-        self.runtime = runtime or SimulationRuntime(runtime_config)
+        if runtime is None:
+            runtime_config = SimulationRuntimeConfig(
+                headless=headless,
+                rng=rng,
+                seed=seed,
+                enable_poker_benchmarks=enable_poker_benchmarks,
+            )
+            self.runtime = SimulationRuntime(runtime_config)
+        else:
+            self.runtime = runtime
+
         # Resolve RNG once so the context and engine share the same deterministic source.
-        resolved_rng, resolved_seed = self.runtime.config.resolve_rng()
+        resolved_rng, resolved_seed = self.runtime.resolve_rng()
         self.seed = resolved_seed
         self.headless = self.runtime.config.headless
         self.entities_list: List[entities.Agent] = []

--- a/core/simulation_runtime.py
+++ b/core/simulation_runtime.py
@@ -77,11 +77,18 @@ class SystemRegistry:
         self.engine.lifecycle_system = EntityLifecycleSystem(self.engine, context=self.context)
         self.engine.time_system = TimeSystem(self.engine, context=self.context)
         self.engine.food_spawning_system = FoodSpawningSystem(
-            self.engine, context=self.context, rng=self.context.rng
+            self.engine,
+            context=self.context,
+            rng=self.context.rng,
+            config=getattr(self.engine, "food_spawn_config", None),
+            auto_food_enabled=getattr(self.engine, "auto_food_enabled", None),
+            screen_width=getattr(self.engine, "_display_width", None),
+            screen_height=getattr(self.engine, "_display_height", None),
         )
         self.engine.collision_system = CollisionSystem(self.engine, context=self.context)
         self.engine.reproduction_system = ReproductionSystem(self.engine, context=self.context)
-        self.engine.poker_system = PokerSystem(self.engine, max_events=MAX_POKER_EVENTS, context=self.context)
+        max_events = getattr(self.engine, "poker_max_events", MAX_POKER_EVENTS)
+        self.engine.poker_system = PokerSystem(self.engine, max_events=max_events, context=self.context)
         self.engine.poker_events = self.engine.poker_system.poker_events
 
         self.systems = [

--- a/core/simulation_runtime.py
+++ b/core/simulation_runtime.py
@@ -1,0 +1,145 @@
+"""Runtime and wiring helpers for the simulation engine.
+
+This module centralizes construction of deterministic simulation context
+objects and system registration. It keeps ``SimulationEngine`` focused on
+per-frame coordination while allowing tests to inject lightweight system
+registries.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+from core.cache_manager import CacheManager
+from core.collision_system import CollisionSystem
+from core.config.poker import MAX_POKER_EVENTS
+from core.events import EventBus
+from core.object_pool import FoodPool
+from core.poker_system import PokerSystem
+from core.reproduction_system import ReproductionSystem
+from core.systems.base import BaseSystem
+from core.systems.entity_lifecycle import EntityLifecycleSystem
+from core.systems.food_spawning import FoodSpawningSystem
+from core.time_system import TimeSystem
+from core.update_phases import UpdatePhase
+
+
+@dataclass
+class SimulationRuntimeConfig:
+    """Config bundle used by ``SimulationRuntime``."""
+
+    headless: bool = True
+    rng: Optional[random.Random] = None
+    seed: Optional[int] = None
+    enable_poker_benchmarks: bool = False
+
+    def resolve_rng(self) -> tuple[random.Random, Optional[int]]:
+        """Return a deterministic RNG based on supplied values."""
+        if self.rng is not None:
+            return self.rng, None
+        if self.seed is not None:
+            return random.Random(self.seed), self.seed
+        return random.Random(), None
+
+
+@dataclass
+class SimulationContext:
+    """Container for deterministic, shared simulation state."""
+
+    rng: random.Random
+    event_bus: EventBus
+    cache_manager: CacheManager
+    food_pool: FoodPool
+
+
+class SystemRegistry:
+    """Registers systems in a consistent order.
+
+    The registry is also used in tests to supply stub systems and short-circuit
+    the normal engine update loop.
+    """
+
+    def __init__(
+        self,
+        engine: "SimulationEngine",
+        context: SimulationContext,
+        config: SimulationRuntimeConfig,
+    ) -> None:
+        self.engine = engine
+        self.context = context
+        self.config = config
+        self.systems: List[BaseSystem] = []
+
+    def build_default_systems(self) -> None:
+        """Create and register the default simulation systems."""
+        self.engine.lifecycle_system = EntityLifecycleSystem(self.engine, context=self.context)
+        self.engine.time_system = TimeSystem(self.engine, context=self.context)
+        self.engine.food_spawning_system = FoodSpawningSystem(
+            self.engine, context=self.context, rng=self.context.rng
+        )
+        self.engine.collision_system = CollisionSystem(self.engine, context=self.context)
+        self.engine.reproduction_system = ReproductionSystem(self.engine, context=self.context)
+        self.engine.poker_system = PokerSystem(self.engine, max_events=MAX_POKER_EVENTS, context=self.context)
+        self.engine.poker_events = self.engine.poker_system.poker_events
+
+        self.systems = [
+            self.engine.lifecycle_system,
+            self.engine.time_system,
+            self.engine.food_spawning_system,
+            self.engine.collision_system,
+            self.engine.reproduction_system,
+            self.engine.poker_system,
+        ]
+
+    @property
+    def should_run_registered_systems(self) -> bool:
+        """Return True when the registry wants to drive system execution."""
+        return False
+
+    def run_registered_systems(self, frame: int) -> None:
+        """Run systems in the order they were registered."""
+        for system in self.systems:
+            system.update(frame)
+
+    def get_systems_in_phase(self, phase: UpdatePhase) -> List[BaseSystem]:
+        """Get systems that declare a matching update phase."""
+        return [s for s in self.systems if getattr(s, "phase", None) == phase]
+
+
+class SimulationRuntime:
+    """Creates deterministic context and wires systems into the engine."""
+
+    def __init__(
+        self,
+        config: Optional[SimulationRuntimeConfig] = None,
+        registry_factory: Optional[
+            Callable[["SimulationEngine", SimulationContext, SimulationRuntimeConfig], SystemRegistry]
+        ] = None,
+    ) -> None:
+        self.config = config or SimulationRuntimeConfig()
+        self._registry_factory = registry_factory
+
+    def build_context(self, entity_provider, rng: Optional[random.Random] = None) -> SimulationContext:
+        resolved_rng = rng
+        if resolved_rng is None:
+            resolved_rng, _ = self.config.resolve_rng()
+        cache_manager = CacheManager(entity_provider)
+        return SimulationContext(
+            rng=resolved_rng,
+            event_bus=EventBus(),
+            cache_manager=cache_manager,
+            food_pool=FoodPool(rng=resolved_rng),
+        )
+
+    def create_registry(
+        self,
+        engine: "SimulationEngine",
+        context: SimulationContext,
+    ) -> SystemRegistry:
+        if self._registry_factory:
+            return self._registry_factory(engine, context, self.config)
+        registry = SystemRegistry(engine, context, self.config)
+        registry.build_default_systems()
+        return registry

--- a/core/systems/base.py
+++ b/core/systems/base.py
@@ -37,6 +37,7 @@ __all__ = [
 
 if TYPE_CHECKING:
     from core.simulation_engine import SimulationEngine
+    from core.simulation_runtime import SimulationContext
     from core.update_phases import UpdatePhase
 
 
@@ -164,7 +165,12 @@ class BaseSystem(ABC):
     # Class-level phase declaration (set by @runs_in_phase decorator)
     _phase: Optional["UpdatePhase"] = None
 
-    def __init__(self, engine: "SimulationEngine", name: str) -> None:
+    def __init__(
+        self,
+        engine: "SimulationEngine",
+        name: str,
+        context: Optional["SimulationContext"] = None,
+    ) -> None:
         """Initialize the system.
 
         Args:
@@ -175,6 +181,7 @@ class BaseSystem(ABC):
         self._name = name
         self._enabled = True
         self._update_count = 0
+        self._context = context
 
     @property
     def name(self) -> str:
@@ -195,6 +202,11 @@ class BaseSystem(ABC):
     def engine(self) -> "SimulationEngine":
         """Access to the simulation engine."""
         return self._engine
+
+    @property
+    def context(self) -> Optional["SimulationContext"]:
+        """Access to the deterministic simulation context."""
+        return self._context
 
     @property
     def update_count(self) -> int:

--- a/core/systems/entity_lifecycle.py
+++ b/core/systems/entity_lifecycle.py
@@ -22,6 +22,7 @@ from core.update_phases import UpdatePhase, runs_in_phase
 if TYPE_CHECKING:
     from core.entities import Agent, Food
     from core.simulation_engine import SimulationEngine
+    from core.simulation_runtime import SimulationContext
 
 logger = logging.getLogger(__name__)
 
@@ -48,13 +49,13 @@ class EntityLifecycleSystem(BaseSystem):
         _emergency_spawns: Count of emergency fish spawns
     """
 
-    def __init__(self, engine: "SimulationEngine") -> None:
+    def __init__(self, engine: "SimulationEngine", context: "SimulationContext | None" = None) -> None:
         """Initialize the entity lifecycle system.
 
         Args:
             engine: The simulation engine
         """
-        super().__init__(engine, "EntityLifecycle")
+        super().__init__(engine, "EntityLifecycle", context=context)
         self._deaths_this_frame: int = 0
         self._births_this_frame: int = 0
         self._total_deaths: int = 0

--- a/core/systems/food_spawning.py
+++ b/core/systems/food_spawning.py
@@ -32,6 +32,7 @@ from core.update_phases import UpdatePhase, runs_in_phase
 
 if TYPE_CHECKING:
     from core.simulation_engine import SimulationEngine
+    from core.simulation_runtime import SimulationContext
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +83,7 @@ class FoodSpawningSystem(BaseSystem):
     def __init__(
         self,
         engine: "SimulationEngine",
+        context: "SimulationContext | None" = None,
         rng: Optional[random.Random] = None,
         config: Optional[SpawnRateConfig] = None,
     ) -> None:
@@ -92,8 +94,9 @@ class FoodSpawningSystem(BaseSystem):
             rng: Random number generator (uses engine's rng if not provided)
             config: Spawn rate configuration (uses defaults if not provided)
         """
-        super().__init__(engine, "FoodSpawning")
-        self._rng = rng if rng is not None else random.Random()
+        super().__init__(engine, "FoodSpawning", context=context)
+        resolved_rng = rng if rng is not None else context.rng if context is not None else None
+        self._rng = resolved_rng if resolved_rng is not None else random.Random()
         self.config = config if config is not None else SpawnRateConfig()
         self._total_spawned: int = 0
         self._frames_since_spawn: int = 0

--- a/core/systems/food_spawning.py
+++ b/core/systems/food_spawning.py
@@ -86,6 +86,10 @@ class FoodSpawningSystem(BaseSystem):
         context: "SimulationContext | None" = None,
         rng: Optional[random.Random] = None,
         config: Optional[SpawnRateConfig] = None,
+        spawn_rate_config: Optional[SpawnRateConfig] = None,
+        auto_food_enabled: Optional[bool] = None,
+        screen_width: Optional[int] = None,
+        screen_height: Optional[int] = None,
     ) -> None:
         """Initialize the food spawning system.
 
@@ -97,7 +101,10 @@ class FoodSpawningSystem(BaseSystem):
         super().__init__(engine, "FoodSpawning", context=context)
         resolved_rng = rng if rng is not None else context.rng if context is not None else None
         self._rng = resolved_rng if resolved_rng is not None else random.Random()
-        self.config = config if config is not None else SpawnRateConfig()
+        self.config = config or spawn_rate_config or SpawnRateConfig()
+        self._auto_food_enabled = AUTO_FOOD_ENABLED if auto_food_enabled is None else auto_food_enabled
+        self._screen_width = screen_width if screen_width is not None else SCREEN_WIDTH
+        self._screen_height = screen_height if screen_height is not None else SCREEN_HEIGHT
         self._total_spawned: int = 0
         self._frames_since_spawn: int = 0
         self._last_spawn_rate: int = self.config.base_rate
@@ -111,7 +118,7 @@ class FoodSpawningSystem(BaseSystem):
         Returns:
             SystemResult with spawn statistics
         """
-        if not AUTO_FOOD_ENABLED:
+        if not self._auto_food_enabled:
             return SystemResult.skipped_result()
 
         if self._engine.environment is None:
@@ -198,7 +205,7 @@ class FoodSpawningSystem(BaseSystem):
 
         # Random spawn position at top of screen
         margin = 50
-        x = self._rng.randint(margin, SCREEN_WIDTH - margin)
+        x = self._rng.randint(margin, self._screen_width - margin)
         y = self._rng.randint(10, 50)  # Near top of tank
 
         # Determine if live food

--- a/core/time_system.py
+++ b/core/time_system.py
@@ -17,6 +17,7 @@ from core.update_phases import UpdatePhase, runs_in_phase
 
 if TYPE_CHECKING:
     from core.simulation_engine import SimulationEngine
+    from core.simulation_runtime import SimulationContext
 
 
 @runs_in_phase(UpdatePhase.TIME_UPDATE)
@@ -36,6 +37,7 @@ class TimeSystem(BaseSystem):
         self,
         engine: "SimulationEngine",
         cycle_length: int = 1800,
+        context: "SimulationContext | None" = None,
     ) -> None:
         """Initialize the time system.
 
@@ -44,7 +46,7 @@ class TimeSystem(BaseSystem):
             cycle_length: Number of frames for a full day/night cycle
                          (default: 1800 = 1 min at 30fps)
         """
-        super().__init__(engine, "Time")
+        super().__init__(engine, "Time", context=context)
 
         self.time: float = 0.0
         self.cycle_length: int = cycle_length

--- a/tests/test_simulation_runtime.py
+++ b/tests/test_simulation_runtime.py
@@ -58,3 +58,12 @@ def test_registered_systems_run_in_order():
         (2, "beta"),
         (2, "gamma"),
     ]
+
+
+def test_runtime_reuses_rng_for_context_and_engine():
+    rng = random.Random(99)
+    runtime = SimulationRuntime(SimulationRuntimeConfig(rng=rng))
+    engine = SimulationEngine(runtime=runtime)
+
+    assert engine.rng is rng
+    assert engine.context.rng is rng

--- a/tests/test_simulation_runtime.py
+++ b/tests/test_simulation_runtime.py
@@ -1,0 +1,60 @@
+import random
+from typing import List, Tuple
+
+from core.simulation_engine import SimulationEngine
+from core.simulation_runtime import SimulationRuntime, SimulationRuntimeConfig, SystemRegistry
+from core.systems.base import BaseSystem, SystemResult
+
+
+class RecordingSystem(BaseSystem):
+    def __init__(self, engine, name: str, log: List[Tuple[int, str]]):
+        super().__init__(engine, name)
+        self._log = log
+
+    def _do_update(self, frame: int) -> SystemResult:
+        self._log.append((frame, self.name))
+        return SystemResult.empty()
+
+
+class StubRegistry(SystemRegistry):
+    def __init__(self, engine, context, config, log):
+        super().__init__(engine, context, config)
+        self._log = log
+        self.build_default_systems()
+
+    @property
+    def should_run_registered_systems(self) -> bool:
+        return True
+
+    def build_default_systems(self) -> None:
+        self.systems = [
+            RecordingSystem(self.engine, "alpha", self._log),
+            RecordingSystem(self.engine, "beta", self._log),
+            RecordingSystem(self.engine, "gamma", self._log),
+        ]
+
+
+def test_registered_systems_run_in_order():
+    log: List[Tuple[int, str]] = []
+
+    def factory(engine, context, config):
+        return StubRegistry(engine, context, config, log)
+
+    runtime = SimulationRuntime(
+        SimulationRuntimeConfig(seed=123, headless=True, rng=random.Random(5)),
+        registry_factory=factory,
+    )
+    engine = SimulationEngine(runtime=runtime)
+    engine.setup()
+
+    engine.update()
+    engine.update()
+
+    assert log == [
+        (1, "alpha"),
+        (1, "beta"),
+        (1, "gamma"),
+        (2, "alpha"),
+        (2, "beta"),
+        (2, "gamma"),
+    ]


### PR DESCRIPTION
## Summary
- add SimulationRuntime, SimulationContext, and a registry for deterministic system construction and dependency injection
- rewire SimulationEngine and core systems to consume the runtime-provided context and allow registries to drive execution when needed
- add a stubbed system test to verify registered systems run in order without full entity setup

## Testing
- pytest tests/test_simulation_runtime.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad7a99900833189eaf11cc539bd68)