### PR TITLE
Add simulation tracing and CLI trace export support

### DIFF
--- a/core/config/simulation_config.py
+++ b/core/config/simulation_config.py
@@ -1,4 +1,4 @@
-"""Simulation configuration for headless and tracing options."""
+"""Lightweight simulation configuration helpers."""
 
 from dataclasses import dataclass
 from typing import Optional

--- a/core/debug_trace.py
+++ b/core/debug_trace.py
@@ -1,0 +1,89 @@
+"""Debug tracing utilities wired through the EventBus."""
+
+import time
+from collections import defaultdict
+from typing import Any, Callable, Dict, List
+
+from core.events import (
+    EntityBornEvent,
+    EntityDiedEvent,
+    EventBus,
+    PhaseTransitionEvent,
+    PokerGameEvent,
+)
+
+
+class DebugTraceSink:
+    """Collects lightweight trace data from simulation events.
+
+    Records:
+        - Phase timings (start/end)
+        - Birth/death counters
+        - Poker outcomes (winner/loser summaries)
+    """
+
+    def __init__(self, event_bus: EventBus) -> None:
+        self.phase_timings: Dict[str, List[float]] = defaultdict(list)
+        self.lifecycle_counts: Dict[str, int] = defaultdict(int)
+        self.poker_outcomes: List[Dict[str, Any]] = []
+        self._start_times: Dict[str, float] = {}
+        self._unsubscribes: List[Callable[[], None]] = []
+        self._attach(event_bus)
+
+    def _attach(self, event_bus: EventBus) -> None:
+        self._unsubscribes.append(event_bus.subscribe(PhaseTransitionEvent, self._on_phase_event))
+        self._unsubscribes.append(event_bus.subscribe(EntityBornEvent, self._on_entity_born))
+        self._unsubscribes.append(event_bus.subscribe(EntityDiedEvent, self._on_entity_died))
+        self._unsubscribes.append(event_bus.subscribe(PokerGameEvent, self._on_poker_event))
+
+    def close(self) -> None:
+        """Unsubscribe from all events."""
+        for unsubscribe in self._unsubscribes:
+            unsubscribe()
+        self._unsubscribes.clear()
+
+    def _on_phase_event(self, event: PhaseTransitionEvent) -> None:
+        if event.status == "start":
+            self._start_times[event.phase] = time.perf_counter()
+        elif event.status == "end":
+            start = self._start_times.pop(event.phase, None)
+            if start is not None:
+                elapsed_ms = (time.perf_counter() - start) * 1000.0
+                self.phase_timings[event.phase].append(elapsed_ms)
+
+    def _on_entity_born(self, event: EntityBornEvent) -> None:
+        key = f"{event.entity_type}_born"
+        self.lifecycle_counts[key] += 1
+
+    def _on_entity_died(self, event: EntityDiedEvent) -> None:
+        key = f"{event.entity_type}_died"
+        self.lifecycle_counts[key] += 1
+
+    def _on_poker_event(self, event: PokerGameEvent) -> None:
+        self.poker_outcomes.append(
+            {
+                "frame": event.frame,
+                "winner_id": event.winner_id,
+                "winner_type": event.winner_type,
+                "loser_ids": event.loser_ids,
+                "loser_types": event.loser_types,
+                "energy_transferred": event.energy_transferred,
+                "is_tie": event.is_tie,
+                "house_cut": event.house_cut,
+            }
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize collected trace data."""
+        return {
+            "phase_timings_ms": {
+                phase: {
+                    "count": len(samples),
+                    "avg_ms": sum(samples) / len(samples) if samples else 0.0,
+                    "samples": samples,
+                }
+                for phase, samples in self.phase_timings.items()
+            },
+            "lifecycle_counts": dict(self.lifecycle_counts),
+            "poker_outcomes": self.poker_outcomes,
+        }

--- a/core/events.py
+++ b/core/events.py
@@ -117,12 +117,23 @@ class PokerGameEvent(Event):
     """Emitted when a poker game completes."""
 
     winner_id: int = 0
-    loser_id: int = 0
+    loser_ids: List[int] = None  # type: ignore[assignment]
     winner_type: str = "fish"  # "fish" or "plant"
-    loser_type: str = "fish"
+    loser_types: List[str] = None  # type: ignore[assignment]
     energy_transferred: float = 0.0
     winner_hand: str = ""
-    loser_hand: str = ""
+    loser_hands: List[str] = None  # type: ignore[assignment]
+    is_tie: bool = False
+    house_cut: float = 0.0
+
+    def __post_init__(self) -> None:
+        # Normalize list defaults
+        if self.loser_ids is None:
+            self.loser_ids = []
+        if self.loser_types is None:
+            self.loser_types = []
+        if self.loser_hands is None:
+            self.loser_hands = []
 
 
 @dataclass
@@ -143,6 +154,14 @@ class SystemStateEvent(Event):
     system: str = ""  # "time", "weather", etc.
     state: str = ""  # "day", "night", etc.
     value: float = 0.0  # Optional numeric value
+
+
+@dataclass
+class PhaseTransitionEvent(Event):
+    """Emitted at the start and end of each simulation phase."""
+
+    phase: str = ""
+    status: str = "start"  # "start" or "end"
 
 
 # ============================================================================

--- a/core/simulation_config.py
+++ b/core/simulation_config.py
@@ -1,0 +1,25 @@
+"""Simulation configuration for headless and tracing options."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class SimulationConfig:
+    """Configuration toggles for simulation runtime behavior.
+
+    Attributes:
+        headless: Whether to run without UI dependencies.
+        trace_mode: Enable detailed tracing via DebugTraceSink.
+        trace_output: Optional JSON path for persisted traces.
+    """
+
+    headless: bool = True
+    trace_mode: bool = False
+    trace_output: Optional[str] = None
+
+    def enable_tracing(self, output_path: Optional[str] = None) -> None:
+        """Enable trace mode and optionally set an output path."""
+        self.trace_mode = True
+        if output_path:
+            self.trace_output = output_path

--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -34,6 +34,7 @@ from core.config.poker import (
     MAX_POKER_EVENTS,
     POKER_EVENT_MAX_AGE_FRAMES,
 )
+from core.config.simulation_config import SimulationConfig
 from core.ecosystem import EcosystemManager
 from core.entities.plant import Plant, PlantNectar
 from core.entity_factory import create_initial_population
@@ -45,7 +46,6 @@ from core.events import (
     PhaseTransitionEvent,
     PokerGameEvent,
 )
-from core.simulation_config import SimulationConfig
 from core.poker_interaction import PokerInteraction
 from core.genetics import Genome
 from core.object_pool import FoodPool
@@ -164,7 +164,7 @@ class SimulationEngine(BaseSimulator):
 
     def __init__(
         self,
-        headless: bool = True,
+        headless: Optional[bool] = None,
         rng: Optional[random.Random] = None,
         seed: Optional[int] = None,
         enable_poker_benchmarks: bool = False,
@@ -179,7 +179,14 @@ class SimulationEngine(BaseSimulator):
             simulation_config: Optional SimulationConfig to control tracing/headless modes
         """
         super().__init__()
-        self.simulation_config = simulation_config or SimulationConfig(headless=headless)
+        headless_value = (
+            headless
+            if headless is not None
+            else (simulation_config.headless if simulation_config is not None else True)
+        )
+        self.simulation_config = simulation_config or SimulationConfig(headless=headless_value)
+        # Ensure headless matches any explicit override
+        self.simulation_config.headless = headless_value
         self.headless = self.simulation_config.headless
         # Backwards-compatible RNG handling: prefer explicit rng, then seed, then fresh RNG
         if rng is not None:

--- a/core/simulation_engine.py
+++ b/core/simulation_engine.py
@@ -4,6 +4,7 @@ This module provides a headless simulation engine that can run the fish tank
 simulation without any visualization code.
 """
 
+import json
 import logging
 import os
 import random
@@ -39,7 +40,12 @@ from core.entity_factory import create_initial_population
 from core.events import (
     EnergyChangedEvent,
     EventBus,
+    EntityBornEvent,
+    EntityDiedEvent,
+    PhaseTransitionEvent,
+    PokerGameEvent,
 )
+from core.simulation_config import SimulationConfig
 from core.poker_interaction import PokerInteraction
 from core.genetics import Genome
 from core.object_pool import FoodPool
@@ -56,6 +62,7 @@ from core.simulators.base_simulator import BaseSimulator
 from core.systems.base import BaseSystem
 from core.systems.entity_lifecycle import EntityLifecycleSystem
 from core.systems.food_spawning import FoodSpawningSystem
+from core.debug_trace import DebugTraceSink
 from core.time_system import TimeSystem
 from core.update_phases import PHASE_DESCRIPTIONS, UpdatePhase
 
@@ -161,6 +168,7 @@ class SimulationEngine(BaseSimulator):
         rng: Optional[random.Random] = None,
         seed: Optional[int] = None,
         enable_poker_benchmarks: bool = False,
+        simulation_config: Optional[SimulationConfig] = None,
     ) -> None:
         """Initialize the simulation engine.
 
@@ -168,9 +176,11 @@ class SimulationEngine(BaseSimulator):
             headless: If True, run without any visualization
             rng: Shared random number generator for deterministic runs
             enable_poker_benchmarks: If True, enable periodic benchmark evaluations
+            simulation_config: Optional SimulationConfig to control tracing/headless modes
         """
         super().__init__()
-        self.headless = headless
+        self.simulation_config = simulation_config or SimulationConfig(headless=headless)
+        self.headless = self.simulation_config.headless
         # Backwards-compatible RNG handling: prefer explicit rng, then seed, then fresh RNG
         if rng is not None:
             self.rng: random.Random = rng
@@ -192,6 +202,9 @@ class SimulationEngine(BaseSimulator):
 
         # Event bus for decoupled communication between components
         self.event_bus = EventBus()
+        self.trace_sink: Optional[DebugTraceSink] = None
+        if self.simulation_config.trace_mode:
+            self._ensure_trace_sink()
 
         # Systems - all extend BaseSystem for consistent interface
         self.collision_system = CollisionSystem(self)
@@ -388,6 +401,91 @@ class SimulationEngine(BaseSimulator):
         """
         self.event_bus.emit(event)
 
+    def enable_tracing(self, output_path: Optional[str] = None) -> None:
+        """Enable trace mode and attach a DebugTraceSink."""
+        self.simulation_config.enable_tracing(output_path)
+        self._ensure_trace_sink()
+
+    def _ensure_trace_sink(self) -> None:
+        if self.trace_sink is None:
+            self.trace_sink = DebugTraceSink(self.event_bus)
+
+    def _emit_phase_transition(self, phase: UpdatePhase, status: str) -> None:
+        self.event_bus.emit(
+            PhaseTransitionEvent(frame=self.frame_count, phase=phase.name, status=status)
+        )
+
+    def _emit_entity_born(self, entity: entities.Agent) -> None:
+        entity_type = self._get_entity_type(entity)
+        entity_id = self._get_entity_id(entity)
+        parent_id = getattr(entity, "parent_id", None)
+        generation = getattr(entity, "generation", 0)
+        self.event_bus.emit(
+            EntityBornEvent(
+                frame=self.frame_count,
+                entity_id=entity_id,
+                entity_type=entity_type,
+                parent_id=parent_id,
+                generation=generation,
+                position=(getattr(entity.pos, "x", 0.0), getattr(entity.pos, "y", 0.0)),
+            )
+        )
+
+    def _emit_entity_death(self, entity: entities.Agent, cause: str = "unknown") -> None:
+        entity_type = self._get_entity_type(entity)
+        entity_id = self._get_entity_id(entity)
+        generation = getattr(entity, "generation", 0)
+        age = getattr(getattr(entity, "_lifecycle_component", None), "age", 0)
+        self.event_bus.emit(
+            EntityDiedEvent(
+                frame=self.frame_count,
+                entity_id=entity_id,
+                entity_type=entity_type,
+                cause=cause,
+                age=age,
+                generation=generation,
+            )
+        )
+
+    def _emit_poker_outcome(self, result) -> None:
+        if result is None:
+            return
+        loser_ids = getattr(result, "loser_ids", []) or []
+        loser_types = getattr(result, "loser_types", []) or []
+        loser_hands = getattr(result, "loser_hands", []) or []
+        self.event_bus.emit(
+            PokerGameEvent(
+                frame=self.frame_count,
+                winner_id=getattr(result, "winner_id", 0),
+                loser_ids=list(loser_ids) if loser_ids is not None else [],
+                winner_type=getattr(result, "winner_type", "fish"),
+                loser_types=list(loser_types) if loser_types is not None else [],
+                energy_transferred=getattr(result, "energy_transferred", 0.0),
+                winner_hand=str(getattr(result, "winner_hand", "")),
+                loser_hands=[str(hand) for hand in loser_hands],
+                is_tie=getattr(result, "is_tie", False),
+                house_cut=getattr(result, "house_cut", 0.0),
+            )
+        )
+
+    def _get_entity_type(self, entity: entities.Agent) -> str:
+        if isinstance(entity, entities.Fish):
+            return "fish"
+        if isinstance(entity, Plant):
+            return "plant"
+        if isinstance(entity, PlantNectar):
+            return "nectar"
+        if isinstance(entity, entities.Food):
+            return "food"
+        return entity.__class__.__name__.lower()
+
+    def _get_entity_id(self, entity: entities.Agent) -> int:
+        if hasattr(entity, "fish_id"):
+            return int(getattr(entity, "fish_id", 0))
+        if hasattr(entity, "plant_id"):
+            return int(getattr(entity, "plant_id", 0))
+        return int(getattr(entity, "id", 0) or 0)
+
     def get_event_bus_stats(self) -> Dict[str, Any]:
         """Get statistics about the event bus.
 
@@ -471,6 +569,7 @@ class SimulationEngine(BaseSimulator):
             self.root_spot_manager.block_spots_for_entity(entity, padding=10.0)
         # Invalidate cached lists
         self._cache_manager.invalidate_entity_caches("entity added")
+        self._emit_entity_born(entity)
 
     def remove_entity(self, entity: entities.Agent) -> None:
         """Remove an entity from the simulation."""
@@ -524,6 +623,8 @@ class SimulationEngine(BaseSimulator):
         """Delegate poker result processing to the poker system."""
         super().handle_poker_result(poker)
         self.poker_system.handle_poker_result(poker)
+        if getattr(poker, "result", None) is not None:
+            self._emit_poker_outcome(poker.result)
 
     def handle_mixed_poker_games(self) -> None:
         """Delegate mixed poker games to the poker system."""
@@ -553,6 +654,7 @@ class SimulationEngine(BaseSimulator):
 
         # ===== PHASE: FRAME_START =====
         self._current_phase = UpdatePhase.FRAME_START
+        self._emit_phase_transition(self._current_phase, "start")
         self.frame_count += 1
 
         # Update lifecycle system first to reset per-frame counters
@@ -562,15 +664,19 @@ class SimulationEngine(BaseSimulator):
         # Delegates to PlantManager which tracks its own interval.
         if self.plant_manager is not None:
             self.plant_manager.reconcile_plants(self.entities_list, self.frame_count)
+        self._emit_phase_transition(self._current_phase, "end")
 
         # ===== PHASE: TIME_UPDATE =====
         self._current_phase = UpdatePhase.TIME_UPDATE
+        self._emit_phase_transition(self._current_phase, "start")
         self.time_system.update(self.frame_count)
         time_modifier = self.time_system.get_activity_modifier()
         time_of_day = self.time_system.get_time_of_day()
+        self._emit_phase_transition(self._current_phase, "end")
 
         # ===== PHASE: ENVIRONMENT =====
         self._current_phase = UpdatePhase.ENVIRONMENT
+        self._emit_phase_transition(self._current_phase, "start")
         # Advance ecosystem frame early so any energy/events recorded during this frame
         # are attributed to the correct frame number.
         ecosystem = self.ecosystem
@@ -580,9 +686,11 @@ class SimulationEngine(BaseSimulator):
         # Performance: Update cached detection modifier once per frame
         if self.environment is not None:
             self.environment.update_detection_modifier()
+        self._emit_phase_transition(self._current_phase, "end")
 
         # ===== PHASE: ENTITY_ACT =====
         self._current_phase = UpdatePhase.ENTITY_ACT
+        self._emit_phase_transition(self._current_phase, "start")
         new_entities: List[entities.Agent] = []
         entities_to_remove: List[entities.Agent] = []
 
@@ -626,24 +734,30 @@ class SimulationEngine(BaseSimulator):
                     entity.die()  # Release root spot
                     entities_to_remove.append(entity)
                     logger.debug(f"Plant #{entity.plant_id} died at age {entity.age}")
+                    self._emit_entity_death(entity, cause="natural")
                 elif isinstance(entity, PlantNectar):
                      # Nectar consumed or invalid
                      entities_to_remove.append(entity)
+                     self._emit_entity_death(entity, cause="consumed")
 
             # Handle removal conditions for Food
             elif isinstance(entity, Food):
                  if isinstance(entity, LiveFood):
                      if entity.is_expired():
                          entities_to_remove.append(entity)
+                         self._emit_entity_death(entity, cause="expired")
                  else:
                      # Standard food sinks
                      if entity.pos.y >= SCREEN_HEIGHT - entity.height:
                          entities_to_remove.append(entity)
+                         self._emit_entity_death(entity, cause="sunk")
 
             self.keep_entity_on_screen(entity)
+        self._emit_phase_transition(self._current_phase, "end")
 
         # ===== PHASE: LIFECYCLE =====
         self._current_phase = UpdatePhase.LIFECYCLE
+        self._emit_phase_transition(self._current_phase, "start")
         # Batch entity removals (more efficient than removing during iteration)
         for entity in entities_to_remove:
             self.remove_entity(entity)
@@ -653,9 +767,11 @@ class SimulationEngine(BaseSimulator):
 
         for new_entity in new_entities:
             self.add_entity(new_entity)
+        self._emit_phase_transition(self._current_phase, "end")
 
         # ===== PHASE: SPAWN =====
         self._current_phase = UpdatePhase.SPAWN
+        self._emit_phase_transition(self._current_phase, "start")
         # Delegate to food spawning system (respects AUTO_FOOD_ENABLED internally)
         self.food_spawning_system.update(self.frame_count)
 
@@ -665,14 +781,18 @@ class SimulationEngine(BaseSimulator):
             update_position = self.environment.update_agent_position
             for entity in self.entities_list:
                 update_position(entity)
+        self._emit_phase_transition(self._current_phase, "end")
 
         # ===== PHASE: COLLISION =====
         self._current_phase = UpdatePhase.COLLISION
+        self._emit_phase_transition(self._current_phase, "start")
         # Uses spatial grid for efficiency
         self.handle_collisions()
+        self._emit_phase_transition(self._current_phase, "end")
 
         # ===== PHASE: REPRODUCTION =====
         self._current_phase = UpdatePhase.REPRODUCTION
+        self._emit_phase_transition(self._current_phase, "start")
         # Mate finding (Legacy/Poker based reproduction handling)
         self.handle_reproduction()
 
@@ -715,9 +835,11 @@ class SimulationEngine(BaseSimulator):
                 for f in fish_list
             )
             ecosystem.record_energy_snapshot(total_fish_energy, len(fish_list))
+        self._emit_phase_transition(self._current_phase, "end")
 
         # ===== PHASE: FRAME_END =====
         self._current_phase = UpdatePhase.FRAME_END
+        self._emit_phase_transition(self._current_phase, "start")
 
         # Periodic poker benchmark evaluation
         if self.benchmark_evaluator is not None:
@@ -729,6 +851,7 @@ class SimulationEngine(BaseSimulator):
             self._rebuild_caches()
 
         # Clear phase tracking at end of frame
+        self._emit_phase_transition(self._current_phase, "end")
         self._current_phase = None
 
 
@@ -878,6 +1001,7 @@ class SimulationEngine(BaseSimulator):
         max_frames: int = 10000,
         stats_interval: int = 300,
         export_json: Optional[str] = None,
+        trace_output: Optional[str] = None,
     ) -> None:
         """Run the simulation in headless mode without visualization.
 
@@ -885,6 +1009,7 @@ class SimulationEngine(BaseSimulator):
             max_frames: Maximum number of frames to simulate
             stats_interval: Print stats every N frames
             export_json: Optional filename to export JSON stats for LLM analysis
+            trace_output: Optional filename to export trace data
         """
         logger.info("=" * SEPARATOR_WIDTH)
         logger.info("HEADLESS FISH TANK SIMULATION")
@@ -895,6 +1020,10 @@ class SimulationEngine(BaseSimulator):
         logger.info(f"Stats will be printed every {stats_interval} frames")
         if export_json:
             logger.info(f"Stats will be exported to: {export_json}")
+        active_trace_output = trace_output or self.simulation_config.trace_output
+        if active_trace_output or self.simulation_config.trace_mode:
+            logger.info("Trace mode enabled%s", f" -> {active_trace_output}" if active_trace_output else "")
+            self.enable_tracing(active_trace_output)
         logger.info("=" * SEPARATOR_WIDTH)
 
         self.setup()
@@ -937,6 +1066,18 @@ class SimulationEngine(BaseSimulator):
                 logger.info("EXPORTING JSON STATISTICS FOR LLM ANALYSIS...")
                 logger.info("=" * SEPARATOR_WIDTH)
                 self.export_stats_json(export_json)
+
+        if active_trace_output:
+            self._write_trace(active_trace_output)
+
+    def _write_trace(self, output_path: str) -> None:
+        """Persist trace data collected by DebugTraceSink."""
+        if self.trace_sink is None:
+            return
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        with open(output_path, "w") as f:
+            json.dump(self.trace_sink.to_dict(), f, indent=2)
+        logger.info("Trace data exported to %s", output_path)
 
     def run_collect_stats(self, max_frames: int = 100) -> Dict[str, Any]:
         """Run the engine for `max_frames` frames and return final stats.

--- a/core/simulators/base_simulator.py
+++ b/core/simulators/base_simulator.py
@@ -45,6 +45,7 @@ from core.config.display import (
     SCREEN_HEIGHT,
     SCREEN_WIDTH,
 )
+from core.events import EntityDiedEvent
 from core.config.server import (
     POKER_ACTIVITY_ENABLED,
 )
@@ -204,6 +205,19 @@ class BaseSimulator(ABC):
                 fish.genome,
                 algorithm_id=algorithm_id,
                 remaining_energy=total_energy_lost,
+            )
+
+        event_bus = getattr(self, "event_bus", None)
+        if event_bus is not None:
+            event_bus.emit(
+                EntityDiedEvent(
+                    frame=getattr(self, "frame_count", 0),
+                    entity_id=fish.fish_id,
+                    entity_type="fish",
+                    cause=death_cause,
+                    age=fish._lifecycle_component.age,
+                    generation=fish.generation,
+                )
             )
 
         # Don't remove fish yet - stay in simulation for death effect to render
@@ -972,4 +986,3 @@ class BaseSimulator(ABC):
             Number of fish entities
         """
         return len(self.get_fish_list())
-

--- a/core/tank_world.py
+++ b/core/tank_world.py
@@ -25,7 +25,7 @@ from core.config.display import (
     SCREEN_HEIGHT,
     SCREEN_WIDTH,
 )
-from core.simulation_config import SimulationConfig
+from core.config.simulation_config import SimulationConfig
 
 logger = logging.getLogger(__name__)
 

--- a/core/tank_world.py
+++ b/core/tank_world.py
@@ -25,6 +25,7 @@ from core.config.display import (
     SCREEN_HEIGHT,
     SCREEN_WIDTH,
 )
+from core.simulation_config import SimulationConfig
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,8 @@ class TankWorldConfig:
 
     # Headless mode
     headless: bool = True
+    trace_mode: bool = False
+    trace_output: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert config to dictionary."""
@@ -63,6 +66,8 @@ class TankWorldConfig:
             "auto_food_spawn_rate": self.auto_food_spawn_rate,
             "auto_food_enabled": self.auto_food_enabled,
             "headless": self.headless,
+            "trace_mode": self.trace_mode,
+            "trace_output": self.trace_output,
         }
 
     @classmethod
@@ -115,7 +120,14 @@ class TankWorld:
         # Create the simulation engine
         # For now, we pass headless flag to engine
         # Later we can refactor engine to use config directly
-        self.engine = SimulationEngine(headless=self.config.headless, rng=self.rng)
+        self.simulation_config = SimulationConfig(
+            headless=self.config.headless,
+            trace_mode=self.config.trace_mode,
+            trace_output=self.config.trace_output,
+        )
+        self.engine = SimulationEngine(
+            headless=self.config.headless, rng=self.rng, simulation_config=self.simulation_config
+        )
 
     def setup(self) -> None:
         """Setup the simulation.
@@ -176,7 +188,11 @@ class TankWorld:
         self.engine.export_stats_json(filename)
 
     def run_headless(
-        self, max_frames: int = 10000, stats_interval: int = 300, export_json: Optional[str] = None
+        self,
+        max_frames: int = 10000,
+        stats_interval: int = 300,
+        export_json: Optional[str] = None,
+        trace_output: Optional[str] = None,
     ) -> None:
         """Run simulation in headless mode.
 
@@ -184,9 +200,15 @@ class TankWorld:
             max_frames: Maximum number of frames to simulate
             stats_interval: Print stats every N frames
             export_json: Optional filename to export JSON stats
+            trace_output: Optional filename to export trace data
         """
+        if trace_output:
+            self.simulation_config.trace_output = trace_output
         self.engine.run_headless(
-            max_frames=max_frames, stats_interval=stats_interval, export_json=export_json
+            max_frames=max_frames,
+            stats_interval=stats_interval,
+            export_json=export_json,
+            trace_output=trace_output,
         )
 
     # Expose commonly used properties

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ def run_web_server():
         sys.exit(1)
 
 
-def run_headless(max_frames: int, stats_interval: int, seed=None, export_stats=None):
+def run_headless(max_frames: int, stats_interval: int, seed=None, export_stats=None, trace_output=None):
     """Run the simulation in headless mode (no visualization).
 
     Args:
@@ -68,17 +68,25 @@ def run_headless(max_frames: int, stats_interval: int, seed=None, export_stats=N
         stats_interval: Print stats every N frames
         seed: Optional random seed for deterministic behavior
         export_stats: Optional filename to export JSON stats for LLM analysis
+        trace_output: Optional filename to export debug trace data
     """
     from core.tank_world import TankWorld, TankWorldConfig
 
     # Create configuration for headless mode
-    config = TankWorldConfig(headless=True)
+    config = TankWorldConfig(
+        headless=True,
+        trace_mode=bool(trace_output),
+        trace_output=trace_output,
+    )
 
     # Create TankWorld with optional seed
     world = TankWorld(config=config, seed=seed)
     # Note: run_headless() calls setup() internally
     world.run_headless(
-        max_frames=max_frames, stats_interval=stats_interval, export_json=export_stats
+        max_frames=max_frames,
+        stats_interval=stats_interval,
+        export_json=export_stats,
+        trace_output=trace_output,
     )
 
 
@@ -136,6 +144,14 @@ Examples:
         help="Export comprehensive stats to JSON file for LLM analysis (e.g., results.json)",
     )
 
+    parser.add_argument(
+        "--trace-json",
+        type=str,
+        default=None,
+        metavar="TRACEFILE",
+        help="Dump debug traces to JSON for offline analysis",
+    )
+
     args = parser.parse_args()
 
     if args.headless:
@@ -145,9 +161,15 @@ Examples:
         )
         if args.export_stats:
             logger.info("Stats will be exported to: %s", args.export_stats)
+        if args.trace_json:
+            logger.info("Trace output will be saved to: %s", args.trace_json)
         logger.info("")
         run_headless(
-            args.max_frames, args.stats_interval, seed=args.seed, export_stats=args.export_stats
+            args.max_frames,
+            args.stats_interval,
+            seed=args.seed,
+            export_stats=args.export_stats,
+            trace_output=args.trace_json,
         )
     else:
         run_web_server()


### PR DESCRIPTION
## Summary
- emit phase, lifecycle, and poker outcome events on the EventBus and add a DebugTraceSink to collect lightweight traces
- introduce SimulationConfig trace mode and hook tracing into SimulationEngine/TankWorld with JSON export support
- add a headless CLI flag (`--trace-json`) to toggle tracing and dump trace files for offline analysis

## Testing
- python -m pytest tests/test_headless_equivalence.py::test_headless_mode_architecture tests/test_headless_equivalence.py::test_mode_independence

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad7cacf408331ab96dd99ce4db793)