### PR TITLE
Add GPT-5.2-Codex-Max Poker Master solution (Elo 1386)

### DIFF
--- a/solutions/603bca97_20251229_185408.json
+++ b/solutions/603bca97_20251229_185408.json
@@ -1,0 +1,131 @@
+{
+  "behavior_algorithm": {
+    "food_approach": 1,
+    "parameters": {
+      "alignment_strength": 0.497185258448552,
+      "ambush_patience": 0.8823080996749849,
+      "ambush_strike_distance": 35.69304065423557,
+      "base_speed_multiplier": 0.5,
+      "burst_duration": 53.31096853315424,
+      "burst_speed": 1.3399572579811996,
+      "circle_radius": 50.300814354254896,
+      "circle_speed": 0.12780776517062087,
+      "cohesion_strength": 0.43894989264388745,
+      "energy_urgency_threshold": 0.3577442218465147,
+      "erratic_amplitude": 0.6340924706206376,
+      "flee_speed": 1.3173612091744171,
+      "flee_threshold": 179.2121783187247,
+      "follow_distance": 35.33454913176297,
+      "food_priority": 0.8610888466339117,
+      "freeze_distance": 81.40544886520368,
+      "intercept_skill": 0.7459756250195005,
+      "min_energy_for_poker": 0.3972697278742756,
+      "patrol_radius": 140.5133339539102,
+      "poker_avoid_radius": 130.51888555522115,
+      "poker_priority": 0.3693506247083573,
+      "poker_seek_radius": 197.78920851586872,
+      "pursuit_speed": 1.0337608779092093,
+      "rest_duration": 86.2371283150343,
+      "separation_distance": 36.867944620671096,
+      "social_distance": 40.776853318259995,
+      "social_priority": 0.11868149602330164,
+      "stealth_speed": 0.255269551046246,
+      "threat_priority": 0.7390995129575362,
+      "zigzag_amplitude": 0.9156188081576865,
+      "zigzag_frequency": 0.03787915867194397
+    },
+    "poker_engagement": 2,
+    "social_mode": 0,
+    "threat_response": 2,
+    "type": "ComposableBehavior"
+  },
+  "benchmark_result": {
+    "confidence_intervals": {
+      "always_fold": [
+        134.5387882343337,
+        141.9012117656663
+      ],
+      "balanced": [
+        -72.74453218435059,
+        115.61662300415912
+      ],
+      "loose_aggressive": [
+        2398.8762598764592,
+        3960.904914118139
+      ],
+      "loose_passive": [
+        -47.444259974702135,
+        12.152017929935038
+      ],
+      "maniac": [
+        1214.239256415673,
+        8817.493775692132
+      ],
+      "random": [
+        -129.0378543198036,
+        1391.1480069278855
+      ],
+      "tight_aggressive": [
+        -87.35439051137814,
+        310.21679102649136
+      ],
+      "tight_passive": [
+        43.23788229506913,
+        277.99826770493087
+      ]
+    },
+    "elo_rating": 1386.0745549651313,
+    "evaluated_at": "2025-12-29T18:54:39.229268",
+    "per_opponent": {
+      "always_fold": 138.22,
+      "balanced": 43.55251051893409,
+      "loose_aggressive": 2599.520606060606,
+      "loose_passive": -14.35623052959502,
+      "maniac": 5404.295066413662,
+      "random": 284.91765385726666,
+      "tight_aggressive": 120.58039470267462,
+      "tight_passive": 160.61807500000003
+    },
+    "skill_tier": "intermediate",
+    "total_hands_played": 24411,
+    "weighted_bb_per_100": 804.6934057088959
+  },
+  "capture_stats": {
+    "avg_hand_rank": 0.21159420289855072,
+    "best_hand_rank": 5,
+    "best_streak": 101,
+    "button_win_rate": 0.9715189873417721,
+    "current_streak": 1,
+    "fold_rate": 0.08405797101449275,
+    "losses": 37,
+    "net_energy": 3162.472966600678,
+    "non_button_win_rate": 0.034482758620689655,
+    "positional_advantage": 0.9370362287210825,
+    "recent_win_rate": 0.9,
+    "roi": 9.166588308987473,
+    "showdown_win_rate": 0.2,
+    "skill_trend": "stable",
+    "ties": 0,
+    "total_energy_lost": 1266.8680866426591,
+    "total_energy_won": 5869.242352730037,
+    "total_games": 345,
+    "win_rate": 0.8927536231884058,
+    "wins": 308,
+    "worst_streak": -9
+  },
+  "composable_behavior": null,
+  "metadata": {
+    "author": "GPT-5.2-Codex-Max",
+    "branch": "work",
+    "commit_sha": "46d55af0624a82d0c80c0e56a484593ad688ca11",
+    "description": "GPT-5.2-Codex-Max poker strategy evolved from 50k frame simulation - 345 games played",
+    "fish_id": 1121,
+    "generation": 15,
+    "name": "GPT-5.2-Codex-Max Poker Master",
+    "simulation_frames": 0,
+    "solution_id": "603bca97_20251229_185408",
+    "submitted_at": "2025-12-29T18:54:08.630927",
+    "version": "1.0.0"
+  },
+  "poker_strategy": {}
+}


### PR DESCRIPTION
### Motivation
- Capture and submit a high-performing poker strategy evolved from an extended simulation run so it can be added to the solutions leaderboard. 
- Preserve the best-evolved fish and its benchmark results as a reusable solution record.

### Description
- Add new solution file `solutions/603bca97_20251229_185408.json` containing the evolved `ComposableBehavior` parameters, `capture_stats`, and `benchmark_result` metadata. 
- Set solution metadata to name `GPT-5.2-Codex-Max Poker Master` and author `GPT-5.2-Codex-Max` with `solution_id` `603bca97_20251229_185408` and commit the file to the repository. 
- The included `benchmark_result` contains the evaluated Elo (≈1386), per-opponent stats, confidence intervals, and `weighted_bb_per_100` value.

### Testing
- Ran the extended simulation with `capture_sonnet_solution.py` (50,000 frames, seed 4545) which completed and produced a best poker fish capture. 
- Evaluated the captured solution with the full benchmark suite via `SolutionBenchmark` which produced an Elo ≈1386 and `weighted_bb_per_100` ≈804.69. 
- Saved the evaluated solution to `solutions/603bca97_20251229_185408.json` and committed the added file, and all automated steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ccb598288331bc7bd26fab30106f)