### PR TITLE
Add GPT-5.2-Codex-Max capture defaults and submit Balanced Challenger solution

### DIFF
--- a/scripts/capture_gpt_5_2_solution.py
+++ b/scripts/capture_gpt_5_2_solution.py
@@ -24,8 +24,8 @@ from core.entities import Fish
 from core.solutions import SolutionRecord, SolutionTracker
 from core.tank_world import TankWorld, TankWorldConfig
 
-AUTHOR = "GPT-5.2"
-DEFAULT_NAME = "GPT-5.2 Tournament Hunter"
+AUTHOR = "GPT-5.2-Codex-Max"
+DEFAULT_NAME = "GPT-5.2-Codex-Max Tournament Hunter"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -121,10 +121,11 @@ def main() -> int:
     parser.add_argument(
         "--tournament-json",
         default=os.path.join(".tmp", f"{AUTHOR}_baseline.json"),
-        help="Tournament JSON artifact (default: .tmp/GPT-5.2_baseline.json)",
+        help=f"Tournament JSON artifact (default: .tmp/{AUTHOR}_baseline.json)",
     )
     parser.add_argument("--solutions-dir", default="solutions", help="Solutions directory (default: solutions)")
     parser.add_argument("--name", default=DEFAULT_NAME, help=f"Solution name (default: {DEFAULT_NAME!r})")
+    parser.add_argument("--author", default=AUTHOR, help=f"Solution author (default: {AUTHOR!r})")
     parser.add_argument("--frames", type=int, default=100_000, help="Frames per simulation seed (default: 100000)")
     parser.add_argument(
         "--seeds",
@@ -148,7 +149,7 @@ def main() -> int:
     parser.add_argument(
         "--output-json",
         default=os.path.join(".tmp", f"{AUTHOR}_capture.json"),
-        help="Optional capture summary JSON path (default: .tmp/GPT-5.2_capture.json)",
+        help=f"Optional capture summary JSON path (default: .tmp/{AUTHOR}_capture.json)",
     )
 
     args = parser.parse_args()
@@ -204,7 +205,7 @@ def main() -> int:
             fish,
             name=args.name,
             description=description,
-            author=AUTHOR,
+            author=args.author,
         )
 
         results.append(
@@ -236,10 +237,15 @@ def main() -> int:
 
     filepath = tracker.save_solution(best.solution)
     logger.info("Saved best solution to %s", filepath)
-    logger.info("solution_id=%s author=%s name=%s", best.solution.metadata.solution_id, AUTHOR, best.solution.metadata.name)
+    logger.info(
+        "solution_id=%s author=%s name=%s",
+        best.solution.metadata.solution_id,
+        best.solution.metadata.author,
+        best.solution.metadata.name,
+    )
 
     out_payload: Dict[str, Any] = {
-        "author": AUTHOR,
+        "author": best.solution.metadata.author,
         "name": best.solution.metadata.name,
         "solution_id": best.solution.metadata.solution_id,
         "saved_path": filepath,
@@ -280,4 +286,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/solutions/0e4e7b3c_20251230_185924.json
+++ b/solutions/0e4e7b3c_20251230_185924.json
@@ -1,0 +1,305 @@
+{
+  "metadata": {
+    "solution_id": "0e4e7b3c_20251230_185924",
+    "name": "GPT-5.2-Codex-Max Balanced Challenger",
+    "description": "GPT-5.2-Codex-Max Balanced Challenger captured from headless TankWorld poker evolution.\nSelected via tournament-aware head-to-head vs 10 opponents loaded from .tmp/GPT-5.2-Codex-Max_baseline.json.\nSelection score: avg_wr=0.9085 with hands_per_matchup=200 candidate_pool=8 min_games=80.\nRepro: frames_per_seed=40000 seeds_tried=[11111, 22222] chosen_seed=11111.\nFish: id=928 generation=44 poker_games=83.",
+    "author": "GPT-5.2-Codex-Max",
+    "submitted_at": "2025-12-30T18:59:24.785402",
+    "version": "1.0.0",
+    "generation": 44,
+    "simulation_frames": 0,
+    "fish_id": 928,
+    "commit_sha": "efbc4152e835f1bb286d8220fbc27de4ac7638ba",
+    "branch": "work"
+  },
+  "behavior_algorithm": {
+    "type": "ComposableBehavior",
+    "threat_response": 1,
+    "food_approach": 1,
+    "social_mode": 0,
+    "poker_engagement": 1,
+    "parameters": {
+      "alignment_strength": 0.5587454023624796,
+      "ambush_patience": 0.8903427726859752,
+      "ambush_strike_distance": 46.14532491929073,
+      "base_speed_multiplier": 0.6540292094645542,
+      "burst_duration": 56.61603992557672,
+      "burst_speed": 1.4564762136143972,
+      "circle_radius": 56.52952685263146,
+      "circle_speed": 0.05332600544269092,
+      "cohesion_strength": 0.4077339808714479,
+      "energy_urgency_threshold": 0.6,
+      "erratic_amplitude": 0.4348926864216972,
+      "flee_speed": 0.8180695223515992,
+      "flee_threshold": 108.16449173315293,
+      "follow_distance": 43.62160171745893,
+      "food_priority": 0.7945642883312298,
+      "freeze_distance": 63.776684900932594,
+      "intercept_skill": 0.5566520994490717,
+      "min_energy_for_poker": 0.3573864134121174,
+      "patrol_radius": 73.88181314418648,
+      "poker_avoid_radius": 109.41330117396058,
+      "poker_priority": 0.7139554211050001,
+      "poker_seek_radius": 190.49134940069177,
+      "pursuit_speed": 0.964472303381717,
+      "rest_duration": 89.2954776914344,
+      "separation_distance": 28.279801328827922,
+      "social_distance": 80.0,
+      "social_priority": 0.423202227394755,
+      "stealth_speed": 0.4338856777322254,
+      "threat_priority": 0.8391002037215067,
+      "zigzag_amplitude": 0.45694136774569705,
+      "zigzag_frequency": 0.02477194088428468
+    }
+  },
+  "poker_strategy": {
+    "type": "ComposablePokerStrategy",
+    "strategy_id": "composable",
+    "hand_selection": 2,
+    "betting_style": 1,
+    "bluffing_approach": 1,
+    "position_awareness": 2,
+    "showdown_tendency": 1,
+    "parameters": {
+      "bluff_frequency": 0.35183672913570313,
+      "bluff_sizing": 0.6214070136969458,
+      "continuation_bet_freq": 0.5383790687484911,
+      "desperation_threshold": 0.24633885619167106,
+      "ip_aggression_boost": 0.256537002311372,
+      "oop_tightening": 0.11899198239783808,
+      "opponent_model_weight": 0.17750872863935202,
+      "playable_threshold": 0.29870417715236613,
+      "position_range_expand": 0.16747502428530864,
+      "pot_odds_sensitivity": 1.337112059485678,
+      "premium_threshold": 0.9055612453599757,
+      "risk_tolerance": 0.2737416453383106,
+      "semibluff_threshold": 0.22646587259825343,
+      "value_bet_sizing": 1.1845090280217534
+    },
+    "learning_rate": 1.0,
+    "regret": {
+      "2:4:OOP:0": {
+        "fold": 0.0,
+        "call": 7.767328932830904,
+        "raise_small": 15.53465786566181,
+        "raise_big": 23.301986798492713
+      },
+      "1:4:OOP:0": {
+        "fold": 0.0,
+        "call": 3.0,
+        "raise_small": 6.0,
+        "raise_big": 9.0
+      },
+      "3:1:IP:0": {
+        "fold": -263.3838742554541,
+        "call": -6.501761233982769,
+        "raise_small": 1.4454000000000011,
+        "raise_big": 9.39256123398276
+      },
+      "1:0:OOP:0": {
+        "fold": 0.0,
+        "call": 20.14077141191025,
+        "raise_small": 40.281542823820516,
+        "raise_big": 60.42231423573075
+      },
+      "2:1:OOP:0": {
+        "fold": 0.0,
+        "call": 7.999999999999999,
+        "raise_small": 16.0,
+        "raise_big": 24.0
+      },
+      "1:1:OOP:0": {
+        "fold": 0.0,
+        "call": 15.65294079236603,
+        "raise_small": 31.305881584732056,
+        "raise_big": 46.95882237709808
+      },
+      "0:1:IP:0": {
+        "fold": -183.0496152334521,
+        "call": -5.571060828384759,
+        "raise_small": 0.7227000000000006,
+        "raise_big": 7.01646082838475
+      },
+      "0:1:OOP:0": {
+        "fold": 0.0,
+        "call": 9.599999999999998,
+        "raise_small": 19.2,
+        "raise_big": 28.8
+      },
+      "2:0:OOP:0": {
+        "fold": 0.0,
+        "call": 7.999999999999999,
+        "raise_small": 16.000000000000004,
+        "raise_big": 24.0
+      },
+      "0:0:OOP:0": {
+        "fold": 0.0,
+        "call": 19.641407974126643,
+        "raise_small": 39.28281594825329,
+        "raise_big": 58.92422392237992
+      },
+      "2:0:IP:0": {
+        "fold": -143.71869250790482,
+        "call": -1.7666000000000004,
+        "raise_small": 2.890800000000006,
+        "raise_big": 7.548200000000001
+      }
+    },
+    "strategy_sum": {
+      "2:4:OOP:0": {
+        "fold": 0.0,
+        "call": 0.8333333333333334,
+        "raise_small": 1.666666666666667,
+        "raise_big": 2.5
+      },
+      "1:4:OOP:0": {
+        "fold": 0.0,
+        "call": 0.5,
+        "raise_small": 1.0,
+        "raise_big": 1.5
+      },
+      "3:1:IP:0": {
+        "fold": 0.0,
+        "call": 0.0,
+        "raise_small": 0.9608054018309864,
+        "raise_big": 4.039194598169013
+      },
+      "1:0:OOP:0": {
+        "fold": 0.0,
+        "call": 1.6666666666666665,
+        "raise_small": 3.3333333333333344,
+        "raise_big": 5.0
+      },
+      "2:1:OOP:0": {
+        "fold": 0.0,
+        "call": 0.6666666666666666,
+        "raise_small": 1.3333333333333333,
+        "raise_big": 2.0
+      },
+      "1:1:OOP:0": {
+        "fold": 0.0,
+        "call": 0.8333333333333333,
+        "raise_small": 1.6666666666666665,
+        "raise_big": 2.5
+      },
+      "0:1:IP:0": {
+        "fold": 0.0,
+        "call": 0.0,
+        "raise_small": 0.20132424078277011,
+        "raise_big": 2.7986757592172298
+      },
+      "0:1:OOP:0": {
+        "fold": 0.0,
+        "call": 0.6666666666666666,
+        "raise_small": 1.3333333333333335,
+        "raise_big": 2.0
+      },
+      "2:0:OOP:0": {
+        "fold": 0.0,
+        "call": 0.6666666666666666,
+        "raise_small": 1.3333333333333335,
+        "raise_big": 2.0
+      },
+      "0:0:OOP:0": {
+        "fold": 0.0,
+        "call": 1.5,
+        "raise_small": 3.000000000000001,
+        "raise_big": 4.5
+      },
+      "2:0:IP:0": {
+        "fold": 0.0,
+        "call": 0.0,
+        "raise_small": 0.9595745739040886,
+        "raise_big": 4.040425426095911
+      }
+    },
+    "visit_count": {
+      "2:4:OOP:0": 5,
+      "1:4:OOP:0": 3,
+      "3:1:IP:0": 5,
+      "1:0:OOP:0": 10,
+      "2:1:OOP:0": 4,
+      "1:1:OOP:0": 5,
+      "0:1:IP:0": 3,
+      "0:1:OOP:0": 4,
+      "2:0:OOP:0": 4,
+      "0:0:OOP:0": 9,
+      "2:0:IP:0": 5
+    }
+  },
+  "composable_behavior": null,
+  "capture_stats": {
+    "total_games": 83,
+    "wins": 28,
+    "losses": 55,
+    "ties": 0,
+    "win_rate": 0.3373493975903614,
+    "total_energy_won": 882.9106879347828,
+    "total_energy_lost": 850.9901504142726,
+    "net_energy": -184.68395254568193,
+    "roi": -2.2251078619961677,
+    "current_streak": 1,
+    "best_streak": 3,
+    "worst_streak": -10,
+    "showdown_win_rate": 0.6,
+    "fold_rate": 0.6385542168674698,
+    "best_hand_rank": 6,
+    "avg_hand_rank": 0.18072289156626506,
+    "button_win_rate": 0.3541666666666667,
+    "non_button_win_rate": 0.3142857142857143,
+    "positional_advantage": 0.039880952380952406,
+    "recent_win_rate": 0.1,
+    "skill_trend": "declining"
+  },
+  "benchmark_result": {
+    "per_opponent": {
+      "always_fold": 282.3016333333333,
+      "random": 3607.6899328859063,
+      "loose_passive": 3282.630952380952,
+      "tight_passive": 91.46368911552663,
+      "tight_aggressive": 2806.8436823104694,
+      "loose_aggressive": 3623.2596491228073,
+      "balanced": 861.4054301075269,
+      "maniac": 3639.847096774193
+    },
+    "weighted_bb_per_100": 2183.402469019149,
+    "total_hands_played": 16727,
+    "elo_rating": 1570.7763812881867,
+    "confidence_intervals": {
+      "always_fold": [
+        281.5678471452115,
+        283.03541952145514
+      ],
+      "random": [
+        3290.5258913962243,
+        5621.9798958771935
+      ],
+      "loose_passive": [
+        3030.268470967633,
+        5085.80003182247
+      ],
+      "tight_passive": [
+        35.53525877732264,
+        125.1335738591466
+      ],
+      "tight_aggressive": [
+        2351.6497922848657,
+        5371.54859677265
+      ],
+      "loose_aggressive": [
+        512.8244847364085,
+        8074.840142033802
+      ],
+      "balanced": [
+        627.700141995597,
+        1640.6529662006317
+      ],
+      "maniac": [
+        -4205.75891214302,
+        8930.07613096164
+      ]
+    },
+    "skill_tier": "expert",
+    "evaluated_at": "2025-12-30T19:05:30.511075"
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure the GPT-5.2 capture tooling supports the `GPT-5.2-Codex-Max` author/name and allow overriding the author at capture time.
- Provide a reproducible, tournament-aware capture workflow to produce balanced poker solutions under the updated fair button rotation.
- Preserve a captured candidate in `solutions/` for benchmarking and inclusion in tournament runs.
- Make output/help text clearer by using the selected author name in filenames and logs.

### Description
- Updated `scripts/capture_gpt_5_2_solution.py` to set `AUTHOR = "GPT-5.2-Codex-Max"` and `DEFAULT_NAME = "GPT-5.2-Codex-Max Tournament Hunter"` and added a `--author` CLI flag to override the author.
- Improved help strings to include the selected `AUTHOR` in default paths and adjusted logging to use `best.solution.metadata.author` when reporting saved captures.
- Emit the chosen author in the capture JSON payload (`out_payload['author'] = best.solution.metadata.author`).
- Added a new captured solution JSON `solutions/0e4e7b3c_20251230_185924.json` (GPT-5.2-Codex-Max Balanced Challenger) to the repository.

### Testing
- Ran tournament baseline: `PYTHONPATH=. python scripts/run_ai_tournament.py --benchmark-hands 60 --benchmark-duplicates 3 --matchup-hands 200 --json-output .tmp/GPT-5.2-Codex-Max_baseline.json` and it completed successfully.
- Ran capture: `PYTHONPATH=. python scripts/capture_gpt_5_2_solution.py --tournament-json .tmp/GPT-5.2-Codex-Max_baseline.json --frames 40000 --seeds 11111,22222 --candidate-pool 8 --matchup-hands 200 --min-games 80 --name "GPT-5.2-Codex-Max Balanced Challenger"` which completed and saved `0e4e7b3c_20251230_185924`.
- Evaluated the captured solution: `PYTHONPATH=. python scripts/submit_solution.py evaluate 0e4e7b3c_20251230_185924 --hands 300 --duplicates 10` and it returned `Elo: 1571`, `Skill Tier: expert`, `bb/100: +2183.40` (hands played: 16,727); capture stats show `button_win_rate: 0.354` and `non_button_win_rate: 0.314`.
- Re-ran tournament report with the new solution: `PYTHONPATH=. python scripts/run_ai_tournament.py --benchmark-hands 60 --benchmark-duplicates 3 --matchup-hands 200 --output .tmp/GPT-5.2-Codex-Max_tournament.txt --json-output .tmp/GPT-5.2-Codex-Max_final.json` and it completed successfully (report and JSON saved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69541e1423c48331b7c00197c39dd000)