### PR TITLE
Create tank world via core WorldRegistry and add adapter compatibility shims

### DIFF
--- a/backend/world_registry.py
+++ b/backend/world_registry.py
@@ -130,14 +130,13 @@ def _create_tank_world(
         **kwargs: Additional configuration options
 
     Returns:
-        Tuple of (TankWorld, TankSnapshotBuilder)
+        Tuple of (TankWorldBackendAdapter, TankSnapshotBuilder)
     """
-    from core.tank_world import TankWorld, TankWorldConfig
     from backend.snapshots.tank_snapshot_builder import TankSnapshotBuilder
+    from core.worlds.registry import WorldRegistry
 
-    config = TankWorldConfig(headless=headless)
-    world = TankWorld(config=config, seed=seed)
-    world.setup()
+    world = WorldRegistry.create_world("tank", seed=seed, headless=headless, **kwargs)
+    world.reset(seed=seed)
 
     snapshot_builder = TankSnapshotBuilder()
 

--- a/core/worlds/tank/backend.py
+++ b/core/worlds/tank/backend.py
@@ -94,6 +94,38 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             info={"frame": self._current_frame, "seed": reset_seed},
         )
 
+    @property
+    def frame_count(self) -> int:
+        """Current frame count for compatibility with legacy world runners."""
+        if self._world is None:
+            return 0
+        return self._world.frame_count
+
+    @property
+    def paused(self) -> bool:
+        """Whether the simulation is paused (compatibility shim)."""
+        if self._world is None:
+            return False
+        return self._world.paused
+
+    @paused.setter
+    def paused(self, value: bool) -> None:
+        """Set paused state on the underlying TankWorld when available."""
+        if self._world is None:
+            return
+        self._world.paused = value
+
+    @property
+    def entities_list(self) -> List[Any]:
+        """Expose entities list for snapshot builders."""
+        if self._world is None:
+            return []
+        return self._world.entities_list
+
+    def setup(self) -> None:
+        """Initialize the world using the backend reset."""
+        self.reset(seed=self._seed)
+
     def step(self, actions_by_agent: Optional[Dict[str, Any]] = None) -> StepResult:
         """Advance the tank world by one time step.
 
@@ -124,6 +156,14 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             done=done,
             info={"frame": self._current_frame},
         )
+
+    def update(self) -> None:
+        """Advance the simulation by one step (compatibility shim)."""
+        self.step()
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Return current metrics for legacy callers."""
+        return self.get_current_metrics()
 
     def get_current_snapshot(self) -> Dict[str, Any]:
         """Get current world state snapshot.


### PR DESCRIPTION
### Motivation

- Eliminate the duplicate "two registries" problem by making the backend world factory delegate to the central core world registry (`core.worlds.registry.WorldRegistry`).
- Ensure the backend still returns the existing tank `SnapshotBuilder` so frontend payloads remain backward-compatible.
- Preserve world metadata such as `view_mode="side"` and `display_name="Fish Tank"` for the UI.
- Maintain that no runtime path in the backend directly instantiates `core.tank_world.TankWorld`.

### Description

- Updated `backend/world_registry.py` to call `WorldRegistry.create_world("tank", ...)` instead of constructing `TankWorld` directly and to call `world.reset(seed=...)` on creation.
- Adjusted the tank factory docstring to reflect it now returns a `TankWorldBackendAdapter` and a `TankSnapshotBuilder`.
- Added compatibility shims in `core/worlds/tank/backend.py` to satisfy legacy `WorldRunner` expectations by exposing `frame_count`, `paused` (getter/setter), `entities_list`, `setup`, `update`, and `get_stats` which delegate to the underlying `TankWorld`.
- Kept returning `TankSnapshotBuilder()` from the backend factory so UI snapshot logic is unchanged.

### Testing

- Ran `pytest -q tests/test_world_runner.py tests/test_world_registry.py` which executed the suite covering world runner and registry behavior.
- All tests passed with `31 passed` in the run (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695462aed24883318390dd826dbeb2ce)