### PR TITLE
Wire Code Pool into Genetics System

### DIFF
--- a/docs/architecture/genome_code_policy.md
+++ b/docs/architecture/genome_code_policy.md
@@ -1,0 +1,142 @@
+# Genome Code Policy
+
+This document describes the code policy trait system, which allows fish genomes to carry references to the CodePool.
+
+## Overview
+
+The code policy trait block enables a genome to reference executable code components stored in the CodePool. This is a **data plumbing** layer only - the genetics system does not generate or execute code, it only manages references to code that exists elsewhere.
+
+## Fields
+
+The following fields are added to `BehavioralTraits`:
+
+### `code_policy_kind`
+- **Type**: `GeneticTrait[Optional[str]]`
+- **Default**: `None`
+- **Description**: The kind/category of policy this genome references (e.g., `"movement_policy"`, `"foraging_policy"`)
+- **Validation**: Must be set if `code_policy_component_id` is set
+
+### `code_policy_component_id`
+- **Type**: `GeneticTrait[Optional[str]]`
+- **Default**: `None`
+- **Description**: The component ID from the CodePool that this genome references
+- **Validation**: Must be a valid string if set
+
+### `code_policy_params`
+- **Type**: `GeneticTrait[Optional[Dict[str, float]]]`
+- **Default**: `None`
+- **Description**: Optional tuning parameters for the code policy
+- **Validation**:
+  - All values must be finite numbers (no NaN or Infinity)
+  - All values must be in the range `[-10.0, 10.0]`
+
+## Why Genetics Shouldn't Generate New Code
+
+The genetics system is designed to **select from existing code**, not to generate new code. This separation exists for several reasons:
+
+1. **Separation of Concerns**: Code generation is a complex task that belongs in the CodePool/training environment, not in the genetics layer.
+
+2. **Safety**: Allowing genetics to generate arbitrary code would create security and stability risks.
+
+3. **Evolvability**: By keeping genetics focused on selection and parameter tuning, we maintain a clean interface between evolution (which selects) and training (which creates).
+
+4. **Debuggability**: When code references are explicit IDs, it's easier to trace which code a fish is using.
+
+## Inheritance Rules
+
+When two parents reproduce, the offspring's code policy is determined as follows:
+
+1. **Both parents have code policies**: The child inherits one of them based on weighted probability (favoring the "winner" parent in winner-biased inheritance).
+
+2. **Only one parent has a code policy**: The child may inherit it with probability proportional to that parent's weight, plus a small "gene flow" chance (30%) even if the other parent would normally dominate.
+
+3. **Neither parent has a code policy**: The child has no code policy.
+
+### Mutation
+
+- **Drop probability**: 2% chance (scaled by mutation rate) to drop the code policy entirely, setting all fields to `None`.
+- **Parameter mutation**: Each parameter in `code_policy_params` has a 15% chance (scaled by mutation rate) to be mutated with Gaussian noise.
+
+### Constants
+
+```python
+CODE_POLICY_DROP_PROBABILITY = 0.02      # 2% base drop rate
+CODE_POLICY_PARAM_MUTATION_RATE = 0.15   # 15% per-param mutation rate
+CODE_POLICY_PARAM_MUTATION_STRENGTH = 0.1  # Gaussian sigma
+CODE_POLICY_PARAM_MIN = -10.0            # Minimum param value
+CODE_POLICY_PARAM_MAX = 10.0             # Maximum param value
+```
+
+## Serialization
+
+Code policy fields are serialized in the genome's JSON representation:
+
+```json
+{
+  "schema_version": 2,
+  "code_policy_kind": "movement_policy",
+  "code_policy_component_id": "comp_abc123",
+  "code_policy_params": {
+    "speed_mult": 1.5,
+    "turn_rate": 0.8
+  }
+}
+```
+
+Old genomes (schema version 1) without these fields will load correctly, with code policy defaulting to `None`.
+
+## Forward Path: Training Environment Integration
+
+The planned integration with the training environment works as follows:
+
+1. **CodePool creates components**: The training environment generates new code components and registers them in the CodePool with unique IDs.
+
+2. **Genomes reference components**: When a fish is born or "upgraded" by the training system, its genome can be given a reference to a CodePool component.
+
+3. **Evolution selects**: Over generations, natural selection will favor fish with beneficial code policies. The genetics system propagates and mutates these references without understanding what they do.
+
+4. **Pool pruning**: Components that are never referenced by surviving fish can be garbage collected from the CodePool.
+
+This creates a two-layer evolution system:
+- **Layer 1 (Population)**: Genomes evolve, selecting from available code components
+- **Layer 2 (Algorithm)**: The training environment creates new code components based on performance data
+
+## Usage Example
+
+```python
+from core.genetics import Genome
+from core.genetics.trait import GeneticTrait
+
+# Create a genome
+genome = Genome.random(use_algorithm=True, rng=rng)
+
+# Assign a code policy
+genome.behavioral.code_policy_kind = GeneticTrait("movement_policy")
+genome.behavioral.code_policy_component_id = GeneticTrait("fast_swimmer_v1")
+genome.behavioral.code_policy_params = GeneticTrait({
+    "speed_multiplier": 1.5,
+    "energy_cost": 0.8
+})
+
+# Validate
+result = genome.validate()
+assert result["ok"]
+
+# Serialize
+data = genome.to_dict()
+
+# Deserialize
+genome2 = Genome.from_dict(data, rng=rng)
+assert genome2.behavioral.code_policy_component_id.value == "fast_swimmer_v1"
+```
+
+## Testing
+
+The test suite (`tests/test_genome_compatibility.py`) verifies:
+
+- New genomes default to no code policy
+- Old genomes (schema v1) load correctly without code policy
+- Code policy round-trips through serialization
+- Validation catches invalid configurations
+- Inheritance is deterministic under fixed RNG
+- Parameter mutation occurs as expected

--- a/tests/test_genome_compatibility.py
+++ b/tests/test_genome_compatibility.py
@@ -1,6 +1,7 @@
 import random
 
 from core.genetics import Genome
+from core.genetics.trait import GeneticTrait
 
 
 def test_trait_containers():
@@ -33,3 +34,205 @@ def test_cache_invalidation_on_trait_change():
     new_speed = g.speed_modifier
 
     assert new_speed != base_speed
+
+
+# =============================================================================
+# Code Policy Tests
+# =============================================================================
+
+
+def test_code_policy_defaults_to_none():
+    """New genomes should have no code policy by default."""
+    rng = random.Random(42)
+    g = Genome.random(use_algorithm=False, rng=rng)
+
+    # Code policy traits exist but have None values
+    assert g.behavioral.code_policy_kind is not None
+    assert g.behavioral.code_policy_kind.value is None
+
+    assert g.behavioral.code_policy_component_id is not None
+    assert g.behavioral.code_policy_component_id.value is None
+
+    assert g.behavioral.code_policy_params is not None
+    assert g.behavioral.code_policy_params.value is None
+
+
+def test_old_genome_loads_without_code_policy():
+    """Old genomes (schema v1) without code policy should load correctly."""
+    rng = random.Random(123)
+
+    # Simulate an old genome without code policy fields
+    old_genome_data = {
+        "schema_version": 1,
+        "size_modifier": 1.0,
+        "color_hue": 0.5,
+        "color_saturation": 0.5,
+        "color_brightness": 0.5,
+        "fin_size": 0.5,
+        "tail_size": 0.5,
+        "pattern_type": 0,
+        "pattern_intensity": 0.5,
+        "body_aspect": 0.5,
+        "eye_size": 0.5,
+        "template_id": 0,
+        "aggression": 0.5,
+        "social_tendency": 0.5,
+        "pursuit_aggression": 0.5,
+        "prediction_skill": 0.5,
+        "hunting_stamina": 0.5,
+        "asexual_reproduction_chance": 0.1,
+        # No code_policy_* fields
+    }
+
+    # Should load without crashing
+    g = Genome.from_dict(old_genome_data, rng=rng, use_algorithm=False)
+
+    # Code policy should be None
+    assert g.behavioral.code_policy_kind.value is None
+    assert g.behavioral.code_policy_component_id.value is None
+    assert g.behavioral.code_policy_params.value is None
+
+    # Other traits should be loaded
+    assert abs(g.physical.size_modifier.value - 1.0) < 1e-6
+    assert abs(g.behavioral.aggression.value - 0.5) < 1e-6
+
+
+def test_genome_with_code_policy_round_trip():
+    """Genome with code policy should serialize and deserialize correctly."""
+    rng = random.Random(456)
+    g = Genome.random(use_algorithm=False, rng=rng)
+
+    # Set code policy fields
+    g.behavioral.code_policy_kind = GeneticTrait("movement_policy")
+    g.behavioral.code_policy_component_id = GeneticTrait("comp_abc123")
+    g.behavioral.code_policy_params = GeneticTrait({"speed_mult": 1.5, "turn_rate": 0.8})
+
+    # Serialize and deserialize
+    data = g.to_dict()
+    rng2 = random.Random(456)
+    g2 = Genome.from_dict(data, rng=rng2, use_algorithm=False)
+
+    # Verify round-trip
+    assert g2.behavioral.code_policy_kind.value == "movement_policy"
+    assert g2.behavioral.code_policy_component_id.value == "comp_abc123"
+    assert g2.behavioral.code_policy_params.value == {"speed_mult": 1.5, "turn_rate": 0.8}
+
+
+def test_code_policy_validation():
+    """Code policy validation should catch invalid configurations."""
+    rng = random.Random(789)
+    g = Genome.random(use_algorithm=False, rng=rng)
+
+    # Valid: all None
+    result = g.validate()
+    assert result["ok"], f"Unexpected issues: {result['issues']}"
+
+    # Invalid: component_id set but kind is None
+    g.behavioral.code_policy_component_id = GeneticTrait("comp_xyz")
+    g.behavioral.code_policy_kind = GeneticTrait(None)
+    result = g.validate()
+    assert not result["ok"]
+    assert any("code_policy_component_id is set but code_policy_kind is not" in i for i in result["issues"])
+
+    # Valid: both set
+    g.behavioral.code_policy_kind = GeneticTrait("foraging_policy")
+    result = g.validate()
+    assert result["ok"], f"Unexpected issues: {result['issues']}"
+
+    # Invalid: param out of range
+    g.behavioral.code_policy_params = GeneticTrait({"bad_param": 999.0})
+    result = g.validate()
+    assert not result["ok"]
+    assert any("out of range" in i for i in result["issues"])
+
+    # Invalid: param is NaN
+    import math
+    g.behavioral.code_policy_params = GeneticTrait({"nan_param": math.nan})
+    result = g.validate()
+    assert not result["ok"]
+    assert any("must be finite" in i for i in result["issues"])
+
+
+def test_code_policy_inheritance_deterministic():
+    """Code policy inheritance should be deterministic under fixed RNG."""
+    rng1 = random.Random(111)
+    rng2 = random.Random(111)
+
+    # Create parents with code policies
+    parent1 = Genome.random(use_algorithm=False, rng=random.Random(1))
+    parent1.behavioral.code_policy_kind = GeneticTrait("movement_policy")
+    parent1.behavioral.code_policy_component_id = GeneticTrait("parent1_comp")
+    parent1.behavioral.code_policy_params = GeneticTrait({"x": 1.0})
+
+    parent2 = Genome.random(use_algorithm=False, rng=random.Random(2))
+    parent2.behavioral.code_policy_kind = GeneticTrait("foraging_policy")
+    parent2.behavioral.code_policy_component_id = GeneticTrait("parent2_comp")
+    parent2.behavioral.code_policy_params = GeneticTrait({"y": 2.0})
+
+    # Create offspring twice with same RNG seed
+    child1 = Genome.from_parents_weighted(parent1, parent2, rng=rng1)
+    child2 = Genome.from_parents_weighted(parent1, parent2, rng=rng2)
+
+    # Should be identical
+    assert child1.behavioral.code_policy_kind.value == child2.behavioral.code_policy_kind.value
+    assert (
+        child1.behavioral.code_policy_component_id.value
+        == child2.behavioral.code_policy_component_id.value
+    )
+    # Params may have been mutated, but deterministically
+    assert child1.behavioral.code_policy_params.value == child2.behavioral.code_policy_params.value
+
+
+def test_code_policy_inheritance_from_single_parent():
+    """Code policy inheritance when only one parent has it."""
+    # Parent with code policy
+    parent1 = Genome.random(use_algorithm=False, rng=random.Random(10))
+    parent1.behavioral.code_policy_kind = GeneticTrait("movement_policy")
+    parent1.behavioral.code_policy_component_id = GeneticTrait("only_parent_comp")
+    parent1.behavioral.code_policy_params = GeneticTrait({"z": 3.0})
+
+    # Parent without code policy
+    parent2 = Genome.random(use_algorithm=False, rng=random.Random(20))
+    # code_policy fields are already None by default
+
+    # Create multiple offspring to check probability
+    inherited_count = 0
+    total = 100
+    for i in range(total):
+        rng = random.Random(1000 + i)
+        child = Genome.from_parents_weighted(parent1, parent2, parent1_weight=0.5, rng=rng)
+        if child.behavioral.code_policy_component_id.value is not None:
+            inherited_count += 1
+            # If inherited, should be from parent1
+            assert child.behavioral.code_policy_kind.value == "movement_policy"
+            assert child.behavioral.code_policy_component_id.value == "only_parent_comp"
+
+    # Should inherit sometimes but not always (probabilistic)
+    assert 10 < inherited_count < 90, f"Inheritance rate {inherited_count}% seems extreme"
+
+
+def test_code_policy_params_mutation():
+    """Code policy params should mutate slightly during inheritance."""
+    parent1 = Genome.random(use_algorithm=False, rng=random.Random(30))
+    parent1.behavioral.code_policy_kind = GeneticTrait("test_policy")
+    parent1.behavioral.code_policy_component_id = GeneticTrait("test_comp")
+    parent1.behavioral.code_policy_params = GeneticTrait({"a": 5.0, "b": -2.0})
+
+    parent2 = Genome.random(use_algorithm=False, rng=random.Random(40))
+    parent2.behavioral.code_policy_kind = GeneticTrait("test_policy")
+    parent2.behavioral.code_policy_component_id = GeneticTrait("test_comp")
+    parent2.behavioral.code_policy_params = GeneticTrait({"a": 5.0, "b": -2.0})
+
+    # Check if any mutations occur over many offspring
+    mutated = False
+    for i in range(100):
+        rng = random.Random(2000 + i)
+        child = Genome.from_parents_weighted(parent1, parent2, rng=rng)
+        if child.behavioral.code_policy_params.value is not None:
+            params = child.behavioral.code_policy_params.value
+            if params.get("a") != 5.0 or params.get("b") != -2.0:
+                mutated = True
+                break
+
+    # At least some mutations should occur
+    assert mutated, "No param mutations detected over 100 offspring"


### PR DESCRIPTION
Extend genomes so fish can carry references to code components in the CodePool. This is data plumbing + evolution operators only - no behavior changes yet.

Changes:
- Add code_policy_kind, code_policy_component_id, code_policy_params to BehavioralTraits (all optional, defaulting to None)
- Bump GENOME_SCHEMA_VERSION to 2 for backward compatibility
- Update genome_codec to serialize/deserialize new fields
- Implement inheritance logic: weighted selection from parents with mutation (can drop policy or mutate params)
- Add validation: component_id requires kind, params must be finite and bounded in [-10, 10]
- Extend test_genome_compatibility.py with comprehensive tests for:
  - Default values (None)
  - Old genome loading (schema v1 without code policy)
  - Round-trip serialization
  - Validation edge cases
  - Deterministic inheritance under fixed RNG
  - Single-parent inheritance probability
  - Parameter mutation
- Add docs/architecture/genome_code_policy.md explaining the design

Key design decisions:
- Genetics does NOT generate new component IDs (that's CodePool's job)
- Only inherits/swaps among existing references from parents
- 2% base drop probability, 15% param mutation rate
- Params bounded to [-10, 10] with Gaussian mutation