### PR TITLE
Refine code-driven movement policy setup

### DIFF
--- a/core/environment.py
+++ b/core/environment.py
@@ -7,10 +7,13 @@ for agents in the simulation.
 import math
 import random
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Type
 
 from core.entities import Agent, Food
 from core.interfaces import MigrationHandler
+
+if TYPE_CHECKING:
+    from core.policies.code_pool import CodePool
 
 
 class SpatialGrid:
@@ -508,6 +511,7 @@ class Environment:
         time_system: Optional[Any] = None,
         rng: Optional[random.Random] = None,
         event_bus: Optional[Any] = None,
+        code_pool: Optional["CodePool"] = None,
     ):
         """
         Initialize the environment.
@@ -528,6 +532,12 @@ class Environment:
         from core.util.rng import require_rng_param
 
         self._rng = require_rng_param(rng, "__init__")
+        if code_pool is None:
+            from core.policies.code_pool import CodePool
+
+            self.code_pool = CodePool()
+        else:
+            self.code_pool = code_pool
 
         # Migration support (injected by backend)
         self.connection_manager: Any = None  # Set by backend if migrations enabled

--- a/core/genetics/behavioral.py
+++ b/core/genetics/behavioral.py
@@ -196,6 +196,10 @@ class BehavioralTraits:
     # Mate preferences (dictionary trait; preferred mate trait values + legacy weights)
     mate_preferences: Optional[GeneticTrait[Dict[str, float]]] = None
 
+    # Optional code policy overrides (non-genetic, opt-in)
+    code_policy_kind: Optional[str] = None
+    code_policy_component_id: Optional[str] = None
+
     @classmethod
     def random(
         cls,

--- a/core/genetics/behavioral.py
+++ b/core/genetics/behavioral.py
@@ -196,9 +196,24 @@ class BehavioralTraits:
     # Mate preferences (dictionary trait; preferred mate trait values + legacy weights)
     mate_preferences: Optional[GeneticTrait[Dict[str, float]]] = None
 
-    # Optional code policy overrides (non-genetic, opt-in)
-    code_policy_kind: Optional[str] = None
-    code_policy_component_id: Optional[str] = None
+    # ========================================================================
+    # Code Policy Traits (for linking to CodePool components)
+    # ========================================================================
+    # These traits allow a genome to carry references into the CodePool,
+    # enabling fish to use evolved code policies. This is purely data plumbing;
+    # the actual code execution happens elsewhere.
+
+    # The kind of policy this genome references (e.g. "movement_policy", "foraging_policy")
+    # Must be set if code policy component id is set.
+    code_policy_kind: Optional[GeneticTrait[Optional[str]]] = None
+
+    # The component ID from the CodePool. This references an existing component;
+    # genetics does NOT generate new component IDs (that's CodePool's job).
+    code_policy_component_id: Optional[GeneticTrait[Optional[str]]] = None
+
+    # Optional tuning parameters for the code policy.
+    # Keys are parameter names, values are floats in [-10.0, 10.0] range.
+    code_policy_params: Optional[GeneticTrait[Optional[Dict[str, float]]]] = None
 
     @classmethod
     def random(

--- a/core/movement_strategy.py
+++ b/core/movement_strategy.py
@@ -163,6 +163,10 @@ class AlgorithmicMovement(MovementStrategy):
     def _execute_policy_if_present(self, fish: Fish) -> Optional[VelocityComponents]:
         policy_kind = getattr(fish.genome.behavioral, "code_policy_kind", None)
         component_id = getattr(fish.genome.behavioral, "code_policy_component_id", None)
+        if hasattr(policy_kind, "value"):
+            policy_kind = policy_kind.value
+        if hasattr(component_id, "value"):
+            component_id = component_id.value
         if policy_kind != "movement_policy" or not component_id:
             return None
 

--- a/core/policies/__init__.py
+++ b/core/policies/__init__.py
@@ -1,0 +1,13 @@
+"""Policy interfaces and code pools for runtime behavior overrides."""
+
+from core.policies.code_pool import BUILTIN_SEEK_NEAREST_FOOD_ID, CodePool, seek_nearest_food_policy
+from core.policies.interfaces import MovementAction, Observation, build_movement_observation
+
+__all__ = [
+    "BUILTIN_SEEK_NEAREST_FOOD_ID",
+    "CodePool",
+    "MovementAction",
+    "Observation",
+    "build_movement_observation",
+    "seek_nearest_food_policy",
+]

--- a/core/policies/code_pool.py
+++ b/core/policies/code_pool.py
@@ -1,0 +1,43 @@
+"""Code policy pool for runtime behavior overrides."""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Callable, Dict, Optional
+from core.policies.interfaces import MovementAction, Observation
+
+MovementPolicyCallable = Callable[[Observation, random.Random], object]
+
+BUILTIN_SEEK_NEAREST_FOOD_ID = "builtin_seek_nearest_food"
+
+
+class CodePool:
+    """Stores callable policy components keyed by ID."""
+
+    def __init__(self) -> None:
+        self._components: Dict[str, MovementPolicyCallable] = {}
+
+    def register(self, component_id: str, func: MovementPolicyCallable) -> None:
+        self._components[str(component_id)] = func
+
+    def get_callable(self, component_id: str) -> Optional[MovementPolicyCallable]:
+        return self._components.get(str(component_id))
+
+
+def seek_nearest_food_policy(observation: Observation, rng: random.Random) -> MovementAction:
+    """Simple built-in movement policy that heads toward the nearest food vector."""
+    _ = rng
+    food_vector = observation.get("nearest_food_vector")
+    if isinstance(food_vector, dict):
+        try:
+            dx = float(food_vector.get("x", 0.0))
+            dy = float(food_vector.get("y", 0.0))
+        except (TypeError, ValueError):
+            dx = 0.0
+            dy = 0.0
+        length_sq = dx * dx + dy * dy
+        if length_sq > 0:
+            length = math.sqrt(length_sq)
+            return MovementAction(dx / length, dy / length)
+    return MovementAction(0.0, 0.0)

--- a/core/policies/interfaces.py
+++ b/core/policies/interfaces.py
@@ -1,0 +1,89 @@
+"""Policy interfaces and observation builders for code-driven behavior."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+
+if TYPE_CHECKING:
+    from core.entities import Fish
+
+Observation = Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class MovementAction:
+    """Normalized movement action returned by code policies."""
+
+    vx: float
+    vy: float
+
+
+def build_movement_observation(fish: "Fish") -> Observation:
+    """Build a minimal observation payload for movement policies."""
+    from core.config.food import BASE_FOOD_DETECTION_RANGE
+    from core.entities import Crab, Food
+
+    environment = fish.environment
+    detection_modifier = getattr(environment, "get_detection_modifier", lambda: 1.0)()
+    max_food_distance = BASE_FOOD_DETECTION_RANGE * detection_modifier
+
+    nearest_food_vector = _nearest_vector(
+        fish, Food, max_distance=max_food_distance, use_resources=True
+    )
+    nearest_threat_vector = _nearest_vector(fish, Crab, max_distance=200.0, use_resources=False)
+
+    return {
+        "position": {"x": fish.pos.x, "y": fish.pos.y},
+        "velocity": {"x": fish.vel.x, "y": fish.vel.y},
+        "nearest_food_vector": nearest_food_vector,
+        "nearest_threat_vector": nearest_threat_vector,
+        "energy": fish.energy,
+        "age": getattr(getattr(fish, "_lifecycle_component", None), "age", 0),
+        "can_play_poker": getattr(fish, "can_play_skill_games", False),
+    }
+
+
+def _nearest_vector(
+    fish: "Fish",
+    agent_type: Type,
+    *,
+    max_distance: Optional[float],
+    use_resources: bool,
+) -> Dict[str, float]:
+    environment = fish.environment
+    fish_x = fish.pos.x
+    fish_y = fish.pos.y
+
+    if max_distance is not None:
+        radius = int(max_distance) + 1
+        if use_resources and hasattr(environment, "nearby_resources"):
+            agents = environment.nearby_resources(fish, radius)
+        else:
+            agents = environment.nearby_agents_by_type(fish, radius, agent_type)
+    else:
+        agents = environment.get_agents_of_type(agent_type)
+
+    if not agents:
+        return {"x": 0.0, "y": 0.0}
+
+    max_distance_sq = max_distance * max_distance if max_distance is not None else None
+    nearest_dx = 0.0
+    nearest_dy = 0.0
+    nearest_dist_sq = float("inf")
+
+    for agent in agents:
+        dx = agent.pos.x - fish_x
+        dy = agent.pos.y - fish_y
+        dist_sq = dx * dx + dy * dy
+        if max_distance_sq is not None and dist_sq > max_distance_sq:
+            continue
+        if dist_sq < nearest_dist_sq:
+            nearest_dist_sq = dist_sq
+            nearest_dx = dx
+            nearest_dy = dy
+
+    if nearest_dist_sq == float("inf"):
+        return {"x": 0.0, "y": 0.0}
+
+    return {"x": nearest_dx, "y": nearest_dy}

--- a/core/simulation/engine.py
+++ b/core/simulation/engine.py
@@ -239,8 +239,17 @@ class SimulationEngine:
 
         # Create EventBus for domain event dispatch
         from core.events import EventBus
+        from core.policies.code_pool import (
+            BUILTIN_SEEK_NEAREST_FOOD_ID,
+            CodePool,
+            seek_nearest_food_policy,
+        )
 
         self.event_bus = EventBus()
+
+        # Initialize code pool (per-engine for isolation)
+        self.code_pool = CodePool()
+        self.code_pool.register(BUILTIN_SEEK_NEAREST_FOOD_ID, seek_nearest_food_policy)
 
         # Initialize environment with EventBus for decoupled telemetry
         self.environment = environment.Environment(
@@ -250,6 +259,7 @@ class SimulationEngine:
             self.time_system,
             rng=self.rng,
             event_bus=self.event_bus,
+            code_pool=self.code_pool,
         )
         self.environment.set_spawn_requester(self.request_spawn)
         self.environment.set_remove_requester(self.request_remove)

--- a/tests/test_code_pool_movement_integration.py
+++ b/tests/test_code_pool_movement_integration.py
@@ -1,0 +1,75 @@
+import random
+
+import pytest
+
+from core.environment import Environment
+from core.entities.fish import Fish
+from core.genetics.trait import GeneticTrait
+from core.math_utils import Vector2
+from core.movement_strategy import AlgorithmicMovement
+from core.policies.code_pool import CodePool
+
+
+class StubBehavior:
+    def __init__(self, vx: float, vy: float) -> None:
+        self._vx = vx
+        self._vy = vy
+
+    def execute(self, fish: Fish) -> tuple[float, float]:
+        return self._vx, self._vy
+
+
+def _make_fish(env: Environment, behavior: StubBehavior) -> Fish:
+    movement = AlgorithmicMovement()
+    fish = Fish(
+        environment=env,
+        movement_strategy=movement,
+        species="test_fish",
+        x=100,
+        y=100,
+        speed=2.0,
+    )
+    fish.genome.behavioral.behavior = GeneticTrait(behavior)
+    fish.vel = Vector2(0, 0)
+    return fish
+
+
+def test_code_policy_movement_overrides_composable_behavior():
+    rng = random.Random(42)
+    pool = CodePool()
+    pool.register("fixed_policy", lambda obs, rng: (0.0, 1.0))
+
+    env = Environment(width=800, height=600, rng=rng, code_pool=pool)
+    fish = _make_fish(env, StubBehavior(-1.0, 0.0))
+    fish.genome.behavioral.code_policy_kind = "movement_policy"
+    fish.genome.behavioral.code_policy_component_id = "fixed_policy"
+
+    fish.movement_strategy.move(fish)
+
+    assert fish.vel.y > 0.0
+    assert fish.vel.x == pytest.approx(0.0)
+
+
+def test_code_policy_fallbacks_when_pool_missing():
+    rng = random.Random(7)
+    env = Environment(width=800, height=600, rng=rng)
+    fish = _make_fish(env, StubBehavior(1.0, 0.0))
+    fish.genome.behavioral.code_policy_kind = "movement_policy"
+    fish.genome.behavioral.code_policy_component_id = "missing_policy"
+
+    fish.movement_strategy.move(fish)
+
+    assert fish.vel.x > 0.0
+
+
+def test_code_policy_fallbacks_when_component_missing():
+    rng = random.Random(11)
+    pool = CodePool()
+    env = Environment(width=800, height=600, rng=rng, code_pool=pool)
+    fish = _make_fish(env, StubBehavior(1.0, 0.0))
+    fish.genome.behavioral.code_policy_kind = "movement_policy"
+    fish.genome.behavioral.code_policy_component_id = "missing_policy"
+
+    fish.movement_strategy.move(fish)
+
+    assert fish.vel.x > 0.0

--- a/tests/test_code_pool_movement_integration.py
+++ b/tests/test_code_pool_movement_integration.py
@@ -41,8 +41,8 @@ def test_code_policy_movement_overrides_composable_behavior():
 
     env = Environment(width=800, height=600, rng=rng, code_pool=pool)
     fish = _make_fish(env, StubBehavior(-1.0, 0.0))
-    fish.genome.behavioral.code_policy_kind = "movement_policy"
-    fish.genome.behavioral.code_policy_component_id = "fixed_policy"
+    fish.genome.behavioral.code_policy_kind = GeneticTrait("movement_policy")
+    fish.genome.behavioral.code_policy_component_id = GeneticTrait("fixed_policy")
 
     fish.movement_strategy.move(fish)
 
@@ -54,8 +54,8 @@ def test_code_policy_fallbacks_when_pool_missing():
     rng = random.Random(7)
     env = Environment(width=800, height=600, rng=rng)
     fish = _make_fish(env, StubBehavior(1.0, 0.0))
-    fish.genome.behavioral.code_policy_kind = "movement_policy"
-    fish.genome.behavioral.code_policy_component_id = "missing_policy"
+    fish.genome.behavioral.code_policy_kind = GeneticTrait("movement_policy")
+    fish.genome.behavioral.code_policy_component_id = GeneticTrait("missing_policy")
 
     fish.movement_strategy.move(fish)
 
@@ -67,8 +67,8 @@ def test_code_policy_fallbacks_when_component_missing():
     pool = CodePool()
     env = Environment(width=800, height=600, rng=rng, code_pool=pool)
     fish = _make_fish(env, StubBehavior(1.0, 0.0))
-    fish.genome.behavioral.code_policy_kind = "movement_policy"
-    fish.genome.behavioral.code_policy_component_id = "missing_policy"
+    fish.genome.behavioral.code_policy_kind = GeneticTrait("movement_policy")
+    fish.genome.behavioral.code_policy_component_id = GeneticTrait("missing_policy")
 
     fish.movement_strategy.move(fish)
 


### PR DESCRIPTION
### Motivation

- Ensure the environment always has a `CodePool` instance so code-driven policies can be looked up at runtime without null checks.  
- Standardize movement observations to use plain dict vectors so policies receive a simple, language-agnostic payload.  
- Make the built-in seek-food policy and runtime policy execution robust to varied return shapes and invalid outputs.  

### Description

- Initialize a per-engine `CodePool` and pass it into `Environment` with a fallback creation when `code_pool` is not provided, and register the built-in seek policy in the engine via `BUILTIN_SEEK_NEAREST_FOOD_ID`.  
- Add `core.policies.interfaces` with `MovementAction` and `build_movement_observation` which now emits plain dict vectors like `{"x":..., "y":...}`.  
- Implement `CodePool` and update `seek_nearest_food_policy` to consume dict vectors, and wire optional code policy execution into `AlgorithmicMovement` with output parsing, validation, and rate-limited logging.  
- Add two non-invasive behavioral fields `code_policy_kind` and `code_policy_component_id` and include test coverage in `tests/test_code_pool_movement_integration.py`.  

### Testing

- Ran `python -m pytest tests/test_code_pool_movement_integration.py` which executed 3 tests and all passed.  
- The tests verify that a registered policy (`fixed_policy`) overrides composable behavior and that missing pools or components fall back to normal movement without crashing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69558b880acc833199ded1d447710b47)