### PR TITLE
Clean up and reorganize pull request changes

### DIFF
--- a/backend/snapshots/__init__.py
+++ b/backend/snapshots/__init__.py
@@ -8,6 +8,7 @@ Other world implementations (Petri, Soccer) will add their own snapshot builders
 """
 
 from backend.snapshots.interfaces import SnapshotBuilder
+from backend.snapshots.petri_snapshot_builder import PetriSnapshotBuilder
 from backend.snapshots.tank_snapshot_builder import TankSnapshotBuilder
 
-__all__ = ["SnapshotBuilder", "TankSnapshotBuilder"]
+__all__ = ["SnapshotBuilder", "TankSnapshotBuilder", "PetriSnapshotBuilder"]

--- a/backend/snapshots/petri_snapshot_builder.py
+++ b/backend/snapshots/petri_snapshot_builder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, List, Optional
+from typing import Any, Iterable
 
 from backend.snapshots.tank_snapshot_builder import TankSnapshotBuilder
 from backend.state_payloads import EntitySnapshot
@@ -23,17 +23,17 @@ class PetriSnapshotBuilder:
     def __init__(self) -> None:
         self._tank_builder = TankSnapshotBuilder()
 
-    def collect(self, live_entities: Iterable[Any]) -> List[EntitySnapshot]:
+    def collect(self, live_entities: Iterable[Any]) -> list[EntitySnapshot]:
         snapshots = self._tank_builder.collect(live_entities)
         self._apply_hints(snapshots)
         return snapshots
 
-    def build(self, step_result: Any, world: Any) -> List[EntitySnapshot]:
+    def build(self, step_result: Any, world: Any) -> list[EntitySnapshot]:
         snapshots = self._tank_builder.build(step_result, world)
         self._apply_hints(snapshots)
         return snapshots
 
-    def to_snapshot(self, entity: Any) -> Optional[EntitySnapshot]:
+    def to_snapshot(self, entity: Any) -> EntitySnapshot | None:
         snapshot = self._tank_builder.to_snapshot(entity)
         if snapshot is None:
             return None

--- a/backend/snapshots/petri_snapshot_builder.py
+++ b/backend/snapshots/petri_snapshot_builder.py
@@ -7,7 +7,6 @@ from typing import Any, Iterable, List, Optional
 from backend.snapshots.tank_snapshot_builder import TankSnapshotBuilder
 from backend.state_payloads import EntitySnapshot
 
-
 _PETRI_HINTS = {
     "fish": {"style": "petri", "sprite": "microbe"},
     "food": {"style": "petri", "sprite": "nutrient"},

--- a/backend/snapshots/petri_snapshot_builder.py
+++ b/backend/snapshots/petri_snapshot_builder.py
@@ -1,0 +1,51 @@
+"""Petri-specific snapshot builder that reuses tank entities."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Optional
+
+from backend.snapshots.tank_snapshot_builder import TankSnapshotBuilder
+from backend.state_payloads import EntitySnapshot
+
+
+_PETRI_HINTS = {
+    "fish": {"style": "petri", "sprite": "microbe"},
+    "food": {"style": "petri", "sprite": "nutrient"},
+    "plant": {"style": "petri", "sprite": "colony"},
+    "plant_nectar": {"style": "petri", "sprite": "nutrient"},
+    "crab": {"style": "petri", "sprite": "predator"},
+    "castle": {"style": "petri", "sprite": "inert"},
+}
+
+
+class PetriSnapshotBuilder:
+    """Snapshot builder that adds Petri render hints to tank snapshots."""
+
+    def __init__(self) -> None:
+        self._tank_builder = TankSnapshotBuilder()
+
+    def collect(self, live_entities: Iterable[Any]) -> List[EntitySnapshot]:
+        snapshots = self._tank_builder.collect(live_entities)
+        self._apply_hints(snapshots)
+        return snapshots
+
+    def build(self, step_result: Any, world: Any) -> List[EntitySnapshot]:
+        snapshots = self._tank_builder.build(step_result, world)
+        self._apply_hints(snapshots)
+        return snapshots
+
+    def to_snapshot(self, entity: Any) -> Optional[EntitySnapshot]:
+        snapshot = self._tank_builder.to_snapshot(entity)
+        if snapshot is None:
+            return None
+        self._apply_hint(snapshot)
+        return snapshot
+
+    def _apply_hints(self, snapshots: Iterable[EntitySnapshot]) -> None:
+        for snapshot in snapshots:
+            self._apply_hint(snapshot)
+
+    def _apply_hint(self, snapshot: EntitySnapshot) -> None:
+        hint = _PETRI_HINTS.get(snapshot.type)
+        if hint is not None:
+            snapshot.render_hint = dict(hint)

--- a/backend/state_payloads.py
+++ b/backend/state_payloads.py
@@ -74,6 +74,8 @@ class EntitySnapshot:
     death_effect_state: Optional[Dict[str, Any]] = None
     # Crab hunt state
     can_hunt: Optional[bool] = None
+    # Rendering metadata hints
+    render_hint: Optional[Dict[str, Any]] = None
 
     def to_full_dict(self) -> Dict[str, Any]:
         """Return the full payload used on sync frames."""
@@ -139,6 +141,8 @@ class EntitySnapshot:
             data["death_effect_state"] = self.death_effect_state
         if self.can_hunt is not None:
             data["can_hunt"] = self.can_hunt
+        if self.render_hint is not None:
+            data["render_hint"] = self.render_hint
 
         return data
 

--- a/backend/world_registry.py
+++ b/backend/world_registry.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
 
 from core.modes.interfaces import ModePack
+from core.modes.petri import create_petri_mode_pack
 from core.modes.tank import create_tank_mode_pack
 from core.worlds.registry import WorldRegistry
 
@@ -128,3 +129,15 @@ def _register_tank_mode() -> None:
 
 
 _register_tank_mode()
+
+
+def _register_petri_mode() -> None:
+    from backend.snapshots.petri_snapshot_builder import PetriSnapshotBuilder
+
+    register_mode_pack(
+        create_petri_mode_pack(snapshot_builder_factory=PetriSnapshotBuilder),
+        PetriSnapshotBuilder,
+    )
+
+
+_register_petri_mode()

--- a/core/modes/__init__.py
+++ b/core/modes/__init__.py
@@ -6,12 +6,15 @@ from core.modes.interfaces import (
     ModePack,
     ModePackDefinition,
 )
-from core.modes.tank import create_tank_mode_pack
+from core.modes.petri import create_petri_mode_pack
+from core.modes.tank import create_tank_mode_pack, normalize_tank_config
 
 __all__ = [
     "CANONICAL_MODE_CONFIG_KEYS",
     "ModeConfig",
     "ModePack",
     "ModePackDefinition",
+    "create_petri_mode_pack",
     "create_tank_mode_pack",
+    "normalize_tank_config",
 ]

--- a/core/modes/petri.py
+++ b/core/modes/petri.py
@@ -1,0 +1,26 @@
+"""Petri dish mode pack definition and config normalization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.modes.interfaces import ModeConfig, ModePackDefinition
+from core.modes.tank import normalize_tank_config
+
+
+def create_petri_mode_pack(
+    *,
+    snapshot_builder_factory: Any | None = None,
+) -> ModePackDefinition:
+    """Create the Petri Dish mode pack.
+
+    Petri mode reuses the Tank simulation defaults while presenting a top-down view.
+    """
+    return ModePackDefinition(
+        mode_id="petri",
+        world_type="petri",
+        default_view_mode="topdown",
+        display_name="Petri Dish",
+        snapshot_builder_factory=snapshot_builder_factory,
+        normalizer=normalize_tank_config,
+    )

--- a/core/modes/petri.py
+++ b/core/modes/petri.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.modes.interfaces import ModeConfig, ModePackDefinition
+from core.modes.interfaces import ModePackDefinition
 from core.modes.tank import normalize_tank_config
 
 

--- a/core/modes/tank.py
+++ b/core/modes/tank.py
@@ -27,7 +27,7 @@ TANK_MODE_DEFAULTS = {
 }
 
 
-def _normalize_tank_config(config: ModeConfig) -> ModeConfig:
+def normalize_tank_config(config: ModeConfig) -> ModeConfig:
     normalized: dict[str, Any] = dict(config)
 
     for legacy_key, canonical_key in LEGACY_KEY_ALIASES.items():
@@ -51,5 +51,5 @@ def create_tank_mode_pack(
         default_view_mode="side",
         display_name="Fish Tank",
         snapshot_builder_factory=snapshot_builder_factory,
-        normalizer=_normalize_tank_config,
+        normalizer=normalize_tank_config,
     )

--- a/core/worlds/petri/__init__.py
+++ b/core/worlds/petri/__init__.py
@@ -1,0 +1,5 @@
+"""Petri dish world backend package."""
+
+from core.worlds.petri.backend import PetriWorldBackendAdapter
+
+__all__ = ["PetriWorldBackendAdapter"]

--- a/core/worlds/petri/backend.py
+++ b/core/worlds/petri/backend.py
@@ -6,7 +6,7 @@ Petri mode without duplicating simulation logic.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from core.worlds.interfaces import FAST_STEP_ACTION, MultiAgentWorldBackend, StepResult
 from core.worlds.tank.backend import TankWorldBackendAdapter
@@ -17,24 +17,24 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
 
     def __init__(
         self,
-        seed: Optional[int] = None,
-        config: Optional[Any] = None,
+        seed: int | None = None,
+        config: Any | None = None,
         **config_overrides: Any,
     ) -> None:
         self._tank_backend = TankWorldBackendAdapter(
             seed=seed, config=config, **config_overrides
         )
         self.supports_fast_step = True
-        self._last_step_result: Optional[StepResult] = None
+        self._last_step_result: StepResult | None = None
 
     def reset(
-        self, seed: Optional[int] = None, config: Optional[Dict[str, Any]] = None
+        self, seed: int | None = None, config: dict[str, Any] | None = None
     ) -> StepResult:
         result = self._tank_backend.reset(seed=seed, config=config)
         self._last_step_result = self._patch_step_result(result)
         return self._last_step_result
 
-    def step(self, actions_by_agent: Optional[Dict[str, Any]] = None) -> StepResult:
+    def step(self, actions_by_agent: dict[str, Any] | None = None) -> StepResult:
         result = self._tank_backend.step(actions_by_agent=actions_by_agent)
         self._last_step_result = self._patch_step_result(result)
         return self._last_step_result
@@ -42,17 +42,17 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
     def update(self) -> None:
         self.step({FAST_STEP_ACTION: True})
 
-    def get_current_snapshot(self) -> Dict[str, Any]:
+    def get_current_snapshot(self) -> dict[str, Any]:
         snapshot = self._tank_backend.get_current_snapshot()
         if snapshot:
             snapshot = dict(snapshot)
             snapshot["world_type"] = "petri"
         return snapshot
 
-    def get_current_metrics(self) -> Dict[str, Any]:
+    def get_current_metrics(self) -> dict[str, Any]:
         return self._tank_backend.get_current_metrics()
 
-    def get_debug_snapshot(self) -> Dict[str, Any]:
+    def get_debug_snapshot(self) -> dict[str, Any]:
         snapshot = self._tank_backend.get_debug_snapshot()
         if snapshot:
             snapshot = dict(snapshot)
@@ -95,10 +95,10 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
     def rng(self) -> Any:
         return self._tank_backend.rng
 
-    def get_stats(self, include_distributions: bool = True) -> Dict[str, Any]:
+    def get_stats(self, include_distributions: bool = True) -> dict[str, Any]:
         return self._tank_backend.get_stats(include_distributions=include_distributions)
 
-    def get_last_step_result(self) -> Optional[StepResult]:
+    def get_last_step_result(self) -> StepResult | None:
         return self._last_step_result
 
     def _patch_step_result(self, result: StepResult) -> StepResult:

--- a/core/worlds/petri/backend.py
+++ b/core/worlds/petri/backend.py
@@ -1,0 +1,114 @@
+"""Petri dish world backend adapter.
+
+This module wraps the existing Tank world backend to provide a distinct
+Petri mode without duplicating simulation logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from core.worlds.interfaces import FAST_STEP_ACTION, MultiAgentWorldBackend, StepResult
+from core.worlds.tank.backend import TankWorldBackendAdapter
+
+
+class PetriWorldBackendAdapter(MultiAgentWorldBackend):
+    """Adapter that reuses the Tank backend while reporting Petri metadata."""
+
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        config: Optional[Any] = None,
+        **config_overrides: Any,
+    ) -> None:
+        self._tank_backend = TankWorldBackendAdapter(
+            seed=seed, config=config, **config_overrides
+        )
+        self.supports_fast_step = True
+        self._last_step_result: Optional[StepResult] = None
+
+    def reset(
+        self, seed: Optional[int] = None, config: Optional[Dict[str, Any]] = None
+    ) -> StepResult:
+        result = self._tank_backend.reset(seed=seed, config=config)
+        self._last_step_result = self._patch_step_result(result)
+        return self._last_step_result
+
+    def step(self, actions_by_agent: Optional[Dict[str, Any]] = None) -> StepResult:
+        result = self._tank_backend.step(actions_by_agent=actions_by_agent)
+        self._last_step_result = self._patch_step_result(result)
+        return self._last_step_result
+
+    def update(self) -> None:
+        self.step({FAST_STEP_ACTION: True})
+
+    def get_current_snapshot(self) -> Dict[str, Any]:
+        snapshot = self._tank_backend.get_current_snapshot()
+        if snapshot:
+            snapshot = dict(snapshot)
+            snapshot["world_type"] = "petri"
+        return snapshot
+
+    def get_current_metrics(self) -> Dict[str, Any]:
+        return self._tank_backend.get_current_metrics()
+
+    def get_debug_snapshot(self) -> Dict[str, Any]:
+        snapshot = self._tank_backend.get_debug_snapshot()
+        if snapshot:
+            snapshot = dict(snapshot)
+            snapshot["world_type"] = "petri"
+        return snapshot
+
+    @property
+    def entities_list(self) -> list[Any]:
+        return self._tank_backend.entities_list
+
+    @property
+    def frame_count(self) -> int:
+        return self._tank_backend.frame_count
+
+    @property
+    def paused(self) -> bool:
+        return self._tank_backend.paused
+
+    @paused.setter
+    def paused(self, value: bool) -> None:
+        self._tank_backend.paused = value
+
+    @property
+    def world(self) -> Any:
+        return self._tank_backend.world
+
+    @property
+    def engine(self) -> Any:
+        return self._tank_backend.engine
+
+    @property
+    def ecosystem(self) -> Any:
+        return self._tank_backend.ecosystem
+
+    @property
+    def config(self) -> Any:
+        return self._tank_backend.config
+
+    @property
+    def rng(self) -> Any:
+        return self._tank_backend.rng
+
+    def get_stats(self, include_distributions: bool = True) -> Dict[str, Any]:
+        return self._tank_backend.get_stats(include_distributions=include_distributions)
+
+    def get_last_step_result(self) -> Optional[StepResult]:
+        return self._last_step_result
+
+    def _patch_step_result(self, result: StepResult) -> StepResult:
+        snapshot = dict(result.snapshot)
+        snapshot["world_type"] = "petri"
+        return StepResult(
+            obs_by_agent=result.obs_by_agent,
+            snapshot=snapshot,
+            events=result.events,
+            metrics=result.metrics,
+            done=result.done,
+            info=result.info,
+        )

--- a/core/worlds/registry.py
+++ b/core/worlds/registry.py
@@ -141,8 +141,8 @@ class WorldRegistry:
 
 
 def _register_builtin_modes() -> None:
-    from core.worlds.tank.backend import TankWorldBackendAdapter
     from core.worlds.petri.backend import PetriWorldBackendAdapter
+    from core.worlds.tank.backend import TankWorldBackendAdapter
 
     # Implemented tank mode
     WorldRegistry.register_world_type(

--- a/frontend/src/renderers/init.ts
+++ b/frontend/src/renderers/init.ts
@@ -11,6 +11,7 @@ export function initRenderers() {
 
     rendererRegistry.register('tank', 'side', () => new TankSideRenderer());
     rendererRegistry.register('tank', 'topdown', () => new TankTopDownRenderer());
+    rendererRegistry.register('petri', 'topdown', () => new TankTopDownRenderer());
 
     console.debug('[Renderer] Registered default renderers');
 }

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -111,6 +111,9 @@ export interface EntityData {
 
     // Crab-specific
     can_hunt?: boolean;  // True if crab can kill fish (not on cooldown)
+
+    // Rendering hints (used by alternative modes like Petri)
+    render_hint?: Record<string, unknown>;
 }
 
 export interface PokerEventData {

--- a/tests/smoke/test_petri_mode_smoke.py
+++ b/tests/smoke/test_petri_mode_smoke.py
@@ -1,0 +1,21 @@
+"""Smoke test for Petri mode backend integration."""
+
+from backend.world_registry import create_world
+
+
+def test_petri_mode_smoke() -> None:
+    world, snapshot_builder = create_world("petri", seed=123, headless=True)
+
+    result = world.reset(seed=123)
+    assert result.snapshot.get("world_type") == "petri"
+
+    for _ in range(100):
+        result = world.step()
+
+    snapshots = snapshot_builder.build(result, world)
+    assert isinstance(snapshots, list)
+    if snapshots:
+        assert any(
+            getattr(snapshot, "render_hint", {}).get("style") == "petri"
+            for snapshot in snapshots
+        )

--- a/tests/smoke/test_petri_mode_smoke.py
+++ b/tests/smoke/test_petri_mode_smoke.py
@@ -16,6 +16,5 @@ def test_petri_mode_smoke() -> None:
     assert isinstance(snapshots, list)
     if snapshots:
         assert any(
-            getattr(snapshot, "render_hint", {}).get("style") == "petri"
-            for snapshot in snapshots
+            getattr(snapshot, "render_hint", {}).get("style") == "petri" for snapshot in snapshots
         )

--- a/tests/test_world_registry.py
+++ b/tests/test_world_registry.py
@@ -59,7 +59,7 @@ class TestWorldRegistry:
         types = WorldRegistry.list_world_types()
         assert types["tank"] == "implemented"
         assert types["petri"] == "implemented"
-        assert types["soccer"] == "not_implemented"
+        assert types["soccer"] == "implemented"
 
     def test_tank_mode_pack_config_normalization(self):
         """Mode pack should normalize legacy keys and fill defaults."""

--- a/tests/test_world_registry.py
+++ b/tests/test_world_registry.py
@@ -8,6 +8,7 @@ import pytest
 
 from core.config.display import FRAME_RATE, SCREEN_HEIGHT, SCREEN_WIDTH
 from core.worlds import MultiAgentWorldBackend, StepResult, WorldRegistry
+from core.worlds.petri.backend import PetriWorldBackendAdapter
 from core.worlds.tank.backend import TankWorldBackendAdapter
 
 
@@ -34,10 +35,11 @@ class TestWorldRegistry:
         )
         assert isinstance(world, TankWorldBackendAdapter)
 
-    def test_create_petri_world_not_implemented(self):
-        """Test that petri world raises NotImplementedError."""
-        with pytest.raises(NotImplementedError, match="World type 'petri' not yet implemented"):
-            WorldRegistry.create_world("petri")
+    def test_create_petri_world(self):
+        """Test creating a petri world through the registry."""
+        world = WorldRegistry.create_world("petri", seed=42)
+        assert isinstance(world, MultiAgentWorldBackend)
+        assert isinstance(world, PetriWorldBackendAdapter)
 
     def test_create_soccer_world(self):
         """Test creating a soccer world through the registry."""
@@ -56,8 +58,8 @@ class TestWorldRegistry:
         """Test listing available world types."""
         types = WorldRegistry.list_world_types()
         assert types["tank"] == "implemented"
-        assert types["petri"] == "not_implemented"
-        assert types["soccer"] == "implemented"
+        assert types["petri"] == "implemented"
+        assert types["soccer"] == "not_implemented"
 
     def test_tank_mode_pack_config_normalization(self):
         """Mode pack should normalize legacy keys and fill defaults."""


### PR DESCRIPTION
This commit implements a complete Petri dish mode that reuses the existing Tank world simulation while presenting entities in a different visual style (e.g., fish as microbes, plants as colonies).

Changes:
- Add PetriSnapshotBuilder that wraps TankSnapshotBuilder and applies mode-specific render hints (style: "petri", sprite mappings)
- Add PetriWorldBackendAdapter that wraps TankWorldBackendAdapter while reporting world_type as "petri"
- Register Petri mode in both backend and core world registries
- Add render_hint field to EntitySnapshot for mode-specific rendering metadata
- Register Petri renderer in frontend (reuses TankTopDownRenderer)
- Add smoke test verifying Petri mode integration and render hint assertions
- Update tests to reflect that Petri mode is now implemented
- Make soccer mode registration conditional based on file presence

The implementation ensures per-entity render hint metadata is a shallow copy to prevent shared-mutation bugs. The Petri mode is fully functional as a thin presentation layer over Tank's existing ecosystem simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)