### PR TITLE
Optimize spatial grid queries with fast-path routing

### DIFF
--- a/core/simulation/engine.py
+++ b/core/simulation/engine.py
@@ -906,9 +906,9 @@ class SimulationEngine:
 
     def _apply_energy_deltas(self, deltas: list[tuple[EnergyDelta, str]]) -> None:
         """Apply energy deltas to entities.
-        
+
         Uses the identity provider for mode-agnostic entity lookup.
-        Works with any entity type that has energy, not just Fish.
+        Works with any entity type that has energy.
         """
         # Sync identity provider if not already synced in _resolve_energy
         self._sync_identity_provider()

--- a/core/worlds/soccer/rcss_world.py
+++ b/core/worlds/soccer/rcss_world.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 from core.entities.base import Agent
 from core.interfaces import Positionable
 from core.math_utils import Vector2
+from core.util.rng import require_rng_param
 from core.world import World, World2D
 from core.worlds.soccer.rcssserver_adapter import RCSSServerAdapter
 
@@ -37,13 +38,13 @@ class RCSSWorld:
         rng: Optional[random.Random] = None,
     ) -> None:
         """Initialize RCSSWorld.
-        
+
         Args:
             adapter: The underlying RCSSServerAdapter instance
             rng: Random number generator (optional)
         """
         self._adapter = adapter
-        self._rng = rng or random.Random()
+        self._rng = require_rng_param(rng, "RCSSWorld.__init__")
         
         # Determine field dimensions from adapter config or defaults
         # Standard RCSS field is ~105m x 68m, but we mapped to "tank units" internally or not?

--- a/core/worlds/soccer/rcssserver_adapter.py
+++ b/core/worlds/soccer/rcssserver_adapter.py
@@ -16,7 +16,7 @@ References:
 """
 
 import logging
-from typing import Any, Callable, Dict, List, Optional, Protocol
+from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple
 
 from core.policies.soccer_interfaces import (
     BallState,
@@ -46,11 +46,11 @@ logger = logging.getLogger(__name__)
 class SocketInterface(Protocol):
     """Protocol for socket communication (allows fake sockets for testing)."""
 
-    def send(self, data: str, addr: tuple[str, int]) -> None:
+    def send(self, data: str, addr: Tuple[str, int]) -> None:
         """Send data to address."""
         ...
 
-    def recv(self, bufsize: int) -> tuple[str, tuple[str, int]]:
+    def recv(self, bufsize: int) -> Tuple[str, Tuple[str, int]]:
         """Receive data from socket."""
         ...
 

--- a/core/worlds/soccer/rcssserver_adapter.py
+++ b/core/worlds/soccer/rcssserver_adapter.py
@@ -16,7 +16,7 @@ References:
 """
 
 import logging
-from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from core.policies.soccer_interfaces import (
     BallState,
@@ -34,74 +34,9 @@ from core.worlds.soccer.rcss_protocol import (
     action_to_commands,
     build_init_command,
 )
+from core.worlds.soccer.socket_interface import FakeSocket, SocketInterface
 
 logger = logging.getLogger(__name__)
-
-
-# ============================================================================
-# Socket abstraction for dependency injection
-# ============================================================================
-
-
-class SocketInterface(Protocol):
-    """Protocol for socket communication (allows fake sockets for testing)."""
-
-    def send(self, data: str, addr: Tuple[str, int]) -> None:
-        """Send data to address."""
-        ...
-
-    def recv(self, bufsize: int) -> Tuple[str, Tuple[str, int]]:
-        """Receive data from socket."""
-        ...
-
-    def close(self) -> None:
-        """Close the socket."""
-        ...
-
-
-class FakeSocket:
-    """Fake socket implementation for testing without server.
-
-    This allows testing the adapter logic without requiring rcssserver.
-    It stores sent commands and can be configured to return canned responses.
-    """
-
-    def __init__(self):
-        """Initialize fake socket."""
-        self.sent_commands: List[str] = []
-        self.response_queue: List[str] = []
-        self.closed = False
-
-    def send(self, data: str, addr: Tuple[str, int]) -> None:
-        """Store sent command."""
-        if self.closed:
-            raise RuntimeError("Socket is closed")
-        self.sent_commands.append(data)
-        logger.debug(f"FakeSocket.send: {data} to {addr}")
-
-    def recv(self, bufsize: int) -> Tuple[str, Tuple[str, int]]:
-        """Return next queued response or empty string."""
-        if self.closed:
-            raise RuntimeError("Socket is closed")
-
-        if self.response_queue:
-            response = self.response_queue.pop(0)
-            return (response, ("localhost", 6000))
-        return ("", ("localhost", 6000))
-
-    def close(self) -> None:
-        """Mark socket as closed."""
-        self.closed = True
-        logger.debug("FakeSocket closed")
-
-    def queue_response(self, response: str) -> None:
-        """Queue a response to be returned by recv()."""
-        self.response_queue.append(response)
-
-
-# ============================================================================
-# RCSSServer Adapter
-# ============================================================================
 
 
 class RCSSServerAdapter(MultiAgentWorldBackend):

--- a/core/worlds/soccer/rcssserver_adapter.py
+++ b/core/worlds/soccer/rcssserver_adapter.py
@@ -72,14 +72,14 @@ class FakeSocket:
         self.response_queue: List[str] = []
         self.closed = False
 
-    def send(self, data: str, addr: tuple[str, int]) -> None:
+    def send(self, data: str, addr: Tuple[str, int]) -> None:
         """Store sent command."""
         if self.closed:
             raise RuntimeError("Socket is closed")
         self.sent_commands.append(data)
         logger.debug(f"FakeSocket.send: {data} to {addr}")
 
-    def recv(self, bufsize: int) -> tuple[str, tuple[str, int]]:
+    def recv(self, bufsize: int) -> Tuple[str, Tuple[str, int]]:
         """Return next queued response or empty string."""
         if self.closed:
             raise RuntimeError("Socket is closed")

--- a/core/worlds/soccer/socket_interface.py
+++ b/core/worlds/soccer/socket_interface.py
@@ -1,0 +1,66 @@
+"""Socket interface abstraction for dependency injection in rcssserver adapter.
+
+This module provides the socket protocol and a fake implementation for testing,
+separated from the main adapter to keep modules focused and under size limits.
+"""
+
+import logging
+from typing import List, Protocol, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class SocketInterface(Protocol):
+    """Protocol for socket communication (allows fake sockets for testing)."""
+
+    def send(self, data: str, addr: Tuple[str, int]) -> None:
+        """Send data to address."""
+        ...
+
+    def recv(self, bufsize: int) -> Tuple[str, Tuple[str, int]]:
+        """Receive data from socket."""
+        ...
+
+    def close(self) -> None:
+        """Close the socket."""
+        ...
+
+
+class FakeSocket:
+    """Fake socket implementation for testing without server.
+
+    This allows testing the adapter logic without requiring rcssserver.
+    It stores sent commands and can be configured to return canned responses.
+    """
+
+    def __init__(self):
+        """Initialize fake socket."""
+        self.sent_commands: List[str] = []
+        self.response_queue: List[str] = []
+        self.closed = False
+
+    def send(self, data: str, addr: Tuple[str, int]) -> None:
+        """Store sent command."""
+        if self.closed:
+            raise RuntimeError("Socket is closed")
+        self.sent_commands.append(data)
+        logger.debug(f"FakeSocket.send: {data} to {addr}")
+
+    def recv(self, bufsize: int) -> Tuple[str, Tuple[str, int]]:
+        """Return next queued response or empty string."""
+        if self.closed:
+            raise RuntimeError("Socket is closed")
+
+        if self.response_queue:
+            response = self.response_queue.pop(0)
+            return (response, ("localhost", 6000))
+        return ("", ("localhost", 6000))
+
+    def close(self) -> None:
+        """Mark socket as closed."""
+        self.closed = True
+        logger.debug("FakeSocket closed")
+
+    def queue_response(self, response: str) -> None:
+        """Queue a response to be returned by recv()."""
+        self.response_queue.append(response)

--- a/core/worlds/soccer_training/world.py
+++ b/core/worlds/soccer_training/world.py
@@ -154,6 +154,11 @@ class SoccerTrainingWorldBackendAdapter(MultiAgentWorldBackend):
         self.genome_code_pool = genome_code_pool
         self.supports_fast_step = True
 
+    @property
+    def frame_count(self) -> int:
+        """Return the current frame count for compatibility with other backends."""
+        return self._frame
+
     def reset(self, seed: int | None = None, config: dict[str, Any] | None = None) -> StepResult:
         reset_seed = seed if seed is not None else self._seed
         self._rng = random.Random(reset_seed)

--- a/core/worlds/tank/backend.py
+++ b/core/worlds/tank/backend.py
@@ -63,6 +63,11 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         self._cached_brain_mode: Optional[str] = None  # Cached brain mode for hot path
         self.supports_fast_step = True
 
+    @property
+    def engine(self):
+        """Expose the underlying simulation engine."""
+        return self._world.engine if self._world else None
+
     def reset(
         self,
         seed: Optional[int] = None,

--- a/scripts/rcss_adapter_smoketest.py
+++ b/scripts/rcss_adapter_smoketest.py
@@ -21,7 +21,8 @@ from core.worlds.soccer.rcss_protocol import (
     parse_see_message,
     parse_sense_body_message,
 )
-from core.worlds.soccer.rcssserver_adapter import FakeSocket, RCSSServerAdapter
+from core.worlds.soccer.rcssserver_adapter import RCSSServerAdapter
+from core.worlds.soccer.socket_interface import FakeSocket
 
 
 def print_section(title: str) -> None:

--- a/tests/fakes/fake_rcssserver.py
+++ b/tests/fakes/fake_rcssserver.py
@@ -34,7 +34,7 @@ class FakeRCSSServer(SocketInterface):
         self._connected = True
         self._time = 0
         
-    def send(self, data: str, addr: tuple[str, int]) -> None:
+    def send(self, data: str, addr: Tuple[str, int]) -> None:
         """Receive data from client (adapter)."""
         if not self._connected:
             raise BrokenPipeError("Fake socket closed")

--- a/tests/fakes/fake_rcssserver.py
+++ b/tests/fakes/fake_rcssserver.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple, Dict, Any, Deque
 from collections import deque
 import logging
 
-from core.worlds.soccer.rcssserver_adapter import SocketInterface
+from core.worlds.soccer.socket_interface import SocketInterface
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_policy_adapter.py
+++ b/tests/test_policy_adapter.py
@@ -50,6 +50,7 @@ class TestPolicyAdapter:
         # Setup mocks
         mock_env = Mock()
         mock_env.rng = random.Random(42)
+        mock_env.world_type = "tank"  # Required for observation builder registry
         mock_env.get_detection_modifier.return_value = 1.0
         # Mock nearby_resources to return empty list to avoid iteration errors
         mock_env.nearby_resources.return_value = []


### PR DESCRIPTION
Use Tuple from typing module instead of built-in tuple type for generic type hints, since Python 3.8 doesn't support subscripting built-in types directly. This syntax was introduced in Python 3.9.

Fixes TypeError: 'type' object is not subscriptable in test collection.