### PR TITLE
Support world-agnostic snapshot collection and isolate poker participants

### DIFF
--- a/core/poker_participant_manager.py
+++ b/core/poker_participant_manager.py
@@ -82,7 +82,17 @@ class PokerParticipantManager:
 
     def __init__(self) -> None:
         """Initialize the participant manager."""
-        self._participants: Dict[int, PokerParticipant] = {}
+        self._participants: Dict[tuple[int | None, int], PokerParticipant] = {}
+
+    @staticmethod
+    def _participant_key(fish: "Fish") -> tuple[int | None, int]:
+        """Build a stable participant key scoped to the fish's environment."""
+        environment = getattr(fish, "environment", None)
+        env_key = id(environment) if environment is not None else None
+        fish_id = getattr(fish, "fish_id", None)
+        if fish_id is None:
+            fish_id = id(fish)
+        return (env_key, int(fish_id))
 
     def get_participant(self, fish: "Fish") -> PokerParticipant:
         """Get or create the poker participant for a fish.
@@ -101,7 +111,7 @@ class PokerParticipantManager:
 
         # Use Python id() as key to ensure uniqueness across engines
         # (fish_id can collide between different simulation engines)
-        fish_key = id(fish)
+        fish_key = self._participant_key(fish)
         participant = self._participants.get(fish_key)
         if participant is None:
             participant = PokerParticipant(
@@ -150,7 +160,7 @@ class PokerParticipantManager:
         Args:
             fish: The fish to clear participant data for
         """
-        self._participants.pop(id(fish), None)
+        self._participants.pop(self._participant_key(fish), None)
 
     def clear_all(self) -> None:
         """Clear all participant data."""

--- a/core/poker_participant_manager.py
+++ b/core/poker_participant_manager.py
@@ -6,7 +6,7 @@ and easier testing.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from core.poker.strategy.base import PokerStrategyEngine
 
@@ -85,7 +85,7 @@ class PokerParticipantManager:
         self._participants: Dict[tuple[int | None, int], PokerParticipant] = {}
 
     @staticmethod
-    def _participant_key(fish: "Fish") -> tuple[Optional[int], int]:
+    def _participant_key(fish: "Fish") -> Tuple[Optional[int], int]:
         """Build a stable participant key scoped to the fish's environment."""
         environment = getattr(fish, "environment", None)
         env_key = id(environment) if environment is not None else None

--- a/core/poker_participant_manager.py
+++ b/core/poker_participant_manager.py
@@ -6,7 +6,7 @@ and easier testing.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from core.poker.strategy.base import PokerStrategyEngine
 
@@ -85,7 +85,7 @@ class PokerParticipantManager:
         self._participants: Dict[tuple[int | None, int], PokerParticipant] = {}
 
     @staticmethod
-    def _participant_key(fish: "Fish") -> tuple[int | None, int]:
+    def _participant_key(fish: "Fish") -> tuple[Optional[int], int]:
         """Build a stable participant key scoped to the fish's environment."""
         environment = getattr(fish, "environment", None)
         env_key = id(environment) if environment is not None else None


### PR DESCRIPTION
### Motivation
- Tests showed non-tank worlds (e.g., soccer_training) crashed during snapshot collection because the backend assumed `world.entities_list` existed.
- Delta/full state handling needed to be robust when the runner is not actively running to avoid stale cached state being reused incorrectly.
- Poker participant tracking used a global id(keyed by `id(fish)`) which could collide across engine instances leading to cross-engine interference.
- Make the snapshot collection and participant tracking world-agnostic and isolated to improve compatibility with multiple world types and multi-engine tests.

### Description
- Updated `backend/simulation_runner.py` to prefer `world.get_last_step_result()` and use `snapshot_builder.build(step_result, world)` when available, and to fall back to `world.get_entities_for_snapshot()` or `world.entities_list` for live-entity collection.
- Forced state rebuilds when the runner is not `running` to ensure fresh full-state payloads are produced for non-background uses.
- Changed `core/poker_participant_manager.py` to key participants by a tuple `(id(environment) | None, fish_id)` with a fallback to `id(fish)` when `fish_id` is missing, preventing collisions between separate engine instances.
- Updated `clear_participant` and internal lookup logic to use the new stable participant key implementation.

### Testing
- No automated tests were run as part of this change.
- The changes are intended to address `AttributeError` from `SoccerTrainingWorldBackendAdapter` missing `entities_list` and to improve multi-engine isolation observed in existing test failures.
- Recommend running the existing test suite (`pytest`) and the world-agnostic simulation tests (`tests/test_simulation_runner_world_agnostic.py` and `tests/test_multi_engine_isolation.py`) after merge to validate fixes.
- Manual smoke validation: instantiate `SimulationRunner` for `soccer_training` and `tank` modes and call `get_state(force_full=True)` to confirm no exceptions and that snapshots are produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695988b8c0148331aebc60108a3b052f)