### PR TITLE
Fix failing pytest tests in test suite

### DIFF
--- a/core/mixed_poker/interaction.py
+++ b/core/mixed_poker/interaction.py
@@ -166,7 +166,7 @@ class MixedPokerInteraction:
 
     def _modify_player_energy(self, player: Player, amount: float) -> None:
         """Modify the energy of a player.
-        
+
         Uses the unified EnergyHolder.modify_energy() protocol.
         """
         player.modify_energy(amount, source="poker")

--- a/core/poker_participant_manager.py
+++ b/core/poker_participant_manager.py
@@ -16,7 +16,6 @@ The preferred approach is now:
 - Plant.can_play_poker(): method that checks energy + cooldown + alive
 """
 
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 

--- a/tests/test_delta_identity_is_stable.py
+++ b/tests/test_delta_identity_is_stable.py
@@ -4,7 +4,6 @@ This test ensures that the EntityIdentityProvider produces stable IDs
 for entities like Food and PlantNectar that don't have intrinsic IDs.
 """
 
-
 from core.config.entities import FISH_ID_OFFSET, FOOD_ID_OFFSET
 from core.entities import Fish, Food
 from core.movement_strategy import AlgorithmicMovement

--- a/tests/test_energy_holder_protocol.py
+++ b/tests/test_energy_holder_protocol.py
@@ -89,9 +89,9 @@ class TestFishModifyEnergy:
             speed=5,
         )
         fish._energy_component.energy = 50.0
-        
+
         delta = fish.modify_energy(20.0, source="test")
-        
+
         assert delta == 20.0
         assert fish.energy == 70.0
 
@@ -107,10 +107,10 @@ class TestFishModifyEnergy:
         )
         fish._energy_component.energy = 90.0
         max_e = fish.max_energy
-        
+
         # Try to add more than fits
         delta = fish.modify_energy(50.0, source="test")
-        
+
         # Should only gain up to max
         assert fish.energy == max_e
         # Delta should reflect actual internal change (not overflow)
@@ -127,9 +127,9 @@ class TestFishModifyEnergy:
             speed=5,
         )
         fish._energy_component.energy = 20.0
-        
+
         delta = fish.modify_energy(-50.0, source="test")
-        
+
         assert fish.energy == 0.0
         assert delta == -20.0  # Only lost 20, not 50
 
@@ -147,9 +147,9 @@ class TestPlantModifyEnergy:
             plant_id=1,
         )
         plant.energy = 50.0
-        
+
         delta = plant.modify_energy(20.0, source="test")
-        
+
         assert delta == 20.0
         assert plant.energy == 70.0
 
@@ -164,15 +164,15 @@ class TestPlantModifyEnergy:
         )
         plant.energy = plant.max_energy - 10.0
         before = plant.energy
-        
-        with patch.object(plant, '_route_overflow_energy') as mock_route:
+
+        with patch.object(plant, "_route_overflow_energy") as mock_route:
             delta = plant.modify_energy(50.0, source="test")
-            
+
             # Overflow should be routed
             mock_route.assert_called_once()
             overflow_amount = mock_route.call_args[0][0]
             assert overflow_amount == pytest.approx(40.0, abs=0.1)
-        
+
         # Energy should be at max
         assert plant.energy == plant.max_energy
         # Delta reflects internal change only
@@ -188,9 +188,9 @@ class TestPlantModifyEnergy:
             plant_id=1,
         )
         plant.energy = 20.0
-        
+
         delta = plant.modify_energy(-50.0, source="test")
-        
+
         assert plant.energy == 0.0
         assert delta == -20.0  # Only lost 20, not 50
 
@@ -204,8 +204,8 @@ class TestPlantModifyEnergy:
             plant_id=1,
         )
         initial = plant.energy
-        
+
         delta = plant.modify_energy(0.0, source="test")
-        
+
         assert delta == 0.0
         assert plant.energy == initial

--- a/tests/test_engine_pipeline.py
+++ b/tests/test_engine_pipeline.py
@@ -7,7 +7,6 @@ These tests verify that:
 """
 
 
-
 def test_default_pipeline_step_names() -> None:
     """Assert that tank's pipeline step names match the canonical list."""
     from core.simulation.pipeline import default_pipeline

--- a/tests/test_pack_architecture.py
+++ b/tests/test_pack_architecture.py
@@ -6,7 +6,6 @@ added without tangled import chains.
 """
 
 
-
 def test_petri_pack_is_not_a_tankpack_subclass():
     """PetriPack must not inherit TankPack.
 

--- a/tests/test_world_type_first_class.py
+++ b/tests/test_world_type_first_class.py
@@ -47,18 +47,16 @@ class TestWorldTypeFirstClass:
                 name="Petri Step Test",
                 world_type="petri",
             )
-            # Start paused to prevent background thread from running
-            manager.start(start_paused=True)
+            # Don't start the background thread - we're manually stepping the world
+            # to verify frame counting. Starting a background thread would create
+            # a race condition that could cause extra frames to be counted.
 
             # Get initial frame before stepping
             initial_frame = manager.world.frame_count
 
-            # Step 10 times with pause/unpause on each iteration to prevent
-            # background thread from interfering with frame counting
+            # Step 10 times
             for _ in range(10):
-                manager.world.paused = False
                 manager.world.step()
-                manager.world.paused = True
 
             assert manager.world.frame_count == initial_frame + 10
         finally:


### PR DESCRIPTION
The test was experiencing a race condition where the background thread's step() calls could interleave with the test's manual step() calls, causing frame_count to increment by an extra frame.

The test explicitly needs to manually control frame counting, so the background thread should not be running. Removed the start_paused=True call and simplified the loop since we're not contending with the background thread anymore.

This fixes the assertion that was expecting frame_count to increment by exactly 10 after 10 step() calls, but was getting 11 due to the background thread running once during the test.