### PR TITLE
Verify regression tests passing safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,20 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Check for compiled Python artifacts
+      run: |
+        if find backend/ core/ -name "__pycache__" -type d 2>/dev/null | grep -q .; then
+          echo "ERROR: __pycache__ directories found in backend/ or core/"
+          find backend/ core/ -name "__pycache__" -type d
+          exit 1
+        fi
+        if find backend/ core/ -name "*.pyc" 2>/dev/null | grep -q .; then
+          echo "ERROR: .pyc files found in backend/ or core/"
+          find backend/ core/ -name "*.pyc"
+          exit 1
+        fi
+        echo "No compiled Python artifacts found in backend/ or core/"
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,16 @@
 # Install with: pip install pre-commit && pre-commit install
 
 repos:
+  # Local hook to prevent compiled Python artifacts from being committed
+  - repo: local
+    hooks:
+      - id: no-pycache
+        name: Check for __pycache__ and .pyc files
+        entry: bash -c 'if find backend/ core/ -name "__pycache__" -type d 2>/dev/null | grep -q . || find backend/ core/ -name "*.pyc" 2>/dev/null | grep -q .; then echo "ERROR: Compiled Python artifacts found in backend/ or core/"; exit 1; fi'
+        language: system
+        pass_filenames: false
+        always_run: true
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/tests/test_mixed_poker_with_plants.py
+++ b/tests/test_mixed_poker_with_plants.py
@@ -179,6 +179,7 @@ class TestPlantPokerDetection:
 class TestPlantPokerGames:
     """Tests for actual poker game execution with plants."""
 
+    @pytest.mark.slow
     def test_plants_can_play_poker(self, run_simulation):
         """Verify plants can participate in poker games.
 
@@ -193,6 +194,7 @@ class TestPlantPokerGames:
 
         pytest.fail("At least one plant should have played poker in 5 trials of 1200 frames")
 
+    @pytest.mark.slow
     def test_plant_poker_records_wins_and_losses(self, run_simulation):
         """Verify poker games properly record wins and losses for plants."""
         # Run 5 trials with 1200 frames each for better coverage
@@ -518,6 +520,7 @@ class TestPokerEffectState:
 class TestSimulationIntegration:
     """Integration tests for the full simulation with plants."""
 
+    @pytest.mark.slow
     def test_long_simulation_stability(self, engine):
         """Verify simulation runs stably with plant poker for extended time."""
         # Run for 30 seconds (1800 frames)


### PR DESCRIPTION
- Delete all __pycache__/ and *.pyc artifacts from repo tree
- Add CI check (fast-gate) that fails if compiled artifacts exist in backend/ or core/
- Add pre-commit hook (no-pycache) to prevent committing compiled files
- Mark long multi-trial tests in test_mixed_poker_with_plants.py as @pytest.mark.slow:
  - test_plants_can_play_poker (5 trials × 1200 frames)
  - test_plant_poker_records_wins_and_losses (5 trials × 1200 frames)
  - test_long_simulation_stability (1800 frames)

Fast tests (27) now run in ~8s vs slow tests running 7800+ frames. This enables clean diffs/reviews and fast feedback during refactoring.

🤖 Generated with [Claude Code](https://claude.ai/code)