### PR TITLE
Remove unused import from test file

### DIFF
--- a/tests/test_genome_compatibility.py
+++ b/tests/test_genome_compatibility.py
@@ -67,8 +67,6 @@ def test_old_genome_loads_with_migration():
     When loading a legacy genome that has 'code_policy_kind'='movement_policy',
     it should populate 'movement_policy_id' and 'movement_policy_params'.
     """
-    from core.code_pool import BUILTIN_SEEK_NEAREST_FOOD_ID
-
     rng = random.Random(123)
 
     # Simulate a legacy genome with single-policy fields


### PR DESCRIPTION
Remove unused import of BUILTIN_SEEK_NEAREST_FOOD_ID from test_old_genome_loads_with_migration function. The import was not used in the test and was flagged by ruff (F401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)