### PR TITLE
Fix remaining CI failures in benchmark tests

### DIFF
--- a/tests/test_code_pool_movement_integration.py
+++ b/tests/test_code_pool_movement_integration.py
@@ -3,7 +3,6 @@ from typing import Tuple
 
 import pytest
 
-from core.code_pool import CodePool
 from core.entities.fish import Fish
 from core.environment import Environment
 from core.genetics.trait import GeneticTrait

--- a/tests/test_soccer_training_world.py
+++ b/tests/test_soccer_training_world.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 
-from core.code_pool import CodePool, GenomeCodePool
+from core.code_pool import GenomeCodePool
 from core.worlds.soccer_training.world import SoccerTrainingWorldBackendAdapter
 
 

--- a/tests/test_world_registry.py
+++ b/tests/test_world_registry.py
@@ -6,7 +6,7 @@ including the WorldRegistry and TankWorldBackendAdapter.
 
 import pytest
 
-from core.config.display import FRAME_RATE, SCREEN_HEIGHT, SCREEN_WIDTH
+from core.config.display import FRAME_RATE, SCREEN_WIDTH
 from core.worlds import MultiAgentWorldBackend, StepResult, WorldRegistry
 from core.worlds.petri.backend import PetriWorldBackendAdapter
 from core.worlds.tank.backend import TankWorldBackendAdapter


### PR DESCRIPTION
Remove unused imports that were flagged by ruff:
- CodePool from test_code_pool_movement_integration.py
- CodePool from test_soccer_training_world.py
- SCREEN_HEIGHT from test_world_registry.py

These imports were part of the legacy CodePool removal and are no longer needed.