### PR TITLE
Replace tabs with always-visible canvas + panel grid

### DIFF
--- a/frontend/src/components/TankView.module.css
+++ b/frontend/src/components/TankView.module.css
@@ -285,3 +285,96 @@
     color: var(--color-text-secondary);
     margin-bottom: 8px;
 }
+
+/* Panel Toggle Bar */
+.panelToggleBar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 20px auto;
+    padding: 8px 12px;
+    max-width: 1140px;
+    width: 100%;
+    background: rgba(15, 23, 42, 0.6);
+    border-radius: 12px;
+    border: 1px solid rgba(51, 65, 85, 0.4);
+    flex-wrap: wrap;
+}
+
+.panelToggleLabel {
+    color: #94a3b8;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    margin-right: 8px;
+}
+
+.panelToggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border: 1px solid rgba(71, 85, 105, 0.5);
+    border-radius: 8px;
+    background: rgba(30, 41, 59, 0.5);
+    color: #94a3b8;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.panelToggle:hover {
+    background: rgba(51, 65, 85, 0.6);
+    border-color: rgba(100, 116, 139, 0.6);
+    color: #e2e8f0;
+}
+
+.panelToggle.active {
+    background: rgba(59, 130, 246, 0.15);
+    border-color: rgba(59, 130, 246, 0.4);
+    color: #60a5fa;
+}
+
+.panelToggle.active:hover {
+    background: rgba(59, 130, 246, 0.25);
+    border-color: rgba(59, 130, 246, 0.5);
+}
+
+.panelToggleIcon {
+    font-size: 14px;
+    line-height: 1;
+}
+
+/* Panel Grid */
+.panelGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(520px, 1fr));
+    gap: 20px;
+    max-width: 1140px;
+    width: 100%;
+    margin: 0 auto 40px auto;
+}
+
+.panel {
+    min-width: 0; /* Prevent overflow */
+}
+
+/* Responsive adjustments */
+@media (max-width: 1100px) {
+    .panelGrid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 600px) {
+    .panelToggleBar {
+        justify-content: center;
+    }
+
+    .panelToggleLabel {
+        width: 100%;
+        text-align: center;
+        margin-bottom: 4px;
+    }
+}

--- a/frontend/src/components/tank_tabs/index.ts
+++ b/frontend/src/components/tank_tabs/index.ts
@@ -1,6 +1,4 @@
-export { TankTabs, useActiveTab } from './TankTabs';
-export type { TabId } from './TankTabs';
-export { TankPlayTab } from './TankPlayTab';
+// Panel components (used in grid layout)
 export { TankSoccerTab } from './TankSoccerTab';
 export { TankPokerTab } from './TankPokerTab';
 export { TankEcosystemTab } from './TankEcosystemTab';

--- a/frontend/src/hooks/useVisiblePanels.ts
+++ b/frontend/src/hooks/useVisiblePanels.ts
@@ -1,0 +1,74 @@
+import { useCallback, useMemo, useState } from 'react';
+
+export type PanelId = 'soccer' | 'poker' | 'ecosystem' | 'genetics';
+
+const STORAGE_KEY = 'tankview.visiblePanels.v1';
+const ALL_PANELS: PanelId[] = ['soccer', 'poker', 'ecosystem', 'genetics'];
+
+function sanitizePanels(value: unknown, fallback: PanelId[]): PanelId[] {
+    if (!Array.isArray(value)) return fallback;
+    const filtered = value.filter((v): v is PanelId => ALL_PANELS.includes(v as PanelId));
+    return filtered.length ? Array.from(new Set(filtered)) : fallback;
+}
+
+export function useVisiblePanels(defaultPanels: PanelId[] = ['soccer', 'poker']): {
+    visible: PanelId[];
+    isVisible: (id: PanelId) => boolean;
+    toggle: (id: PanelId) => void;
+    setVisible: (ids: PanelId[]) => void;
+    showOnly: (id: PanelId) => void;
+    showAll: () => void;
+    hideAll: () => void;
+} {
+    const [visible, setVisibleState] = useState<PanelId[]>(() => {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (!raw) return defaultPanels;
+            return sanitizePanels(JSON.parse(raw), defaultPanels);
+        } catch {
+            return defaultPanels;
+        }
+    });
+
+    const persist = useCallback((next: PanelId[]) => {
+        setVisibleState(next);
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch {
+            // ignore storage failures (private mode, quota, etc.)
+        }
+    }, []);
+
+    const isVisible = useCallback((id: PanelId) => visible.includes(id), [visible]);
+
+    const toggle = useCallback(
+        (id: PanelId) => {
+            persist(visible.includes(id) ? visible.filter((p) => p !== id) : [...visible, id]);
+        },
+        [persist, visible]
+    );
+
+    const setVisible = useCallback(
+        (ids: PanelId[]) => {
+            persist(sanitizePanels(ids, defaultPanels));
+        },
+        [persist, defaultPanels]
+    );
+
+    const showOnly = useCallback((id: PanelId) => persist([id]), [persist]);
+    const showAll = useCallback(() => persist([...ALL_PANELS]), [persist]);
+    const hideAll = useCallback(() => persist([]), [persist]);
+
+    return useMemo(
+        () => ({
+            visible,
+            isVisible,
+            toggle,
+            setVisible,
+            showOnly,
+            showAll,
+            hideAll,
+        }),
+        [visible, isVisible, toggle, setVisible, showOnly, showAll, hideAll]
+    );
+}


### PR DESCRIPTION
The previous tab-based UI was a mistake - it hid the simulation canvas when viewing analytics tabs, making the core product invisible.

Key changes:

1. Canvas is now always visible (never hidden by tab switching)
2. Replace mutually-exclusive tabs with multi-select panel toggles
3. Add useVisiblePanels hook for localStorage-persisted panel selection
4. Add connectedWorldId to useWebSocket for immediate worldId access
5. Panels render in a responsive 2-column grid below the canvas
6. Default panels: Soccer + Ecosystem (user can toggle others)

The simulation view is the product - everything else is now an optional inspector that can be shown alongside it.