### PR TITLE
Fix unsorted imports across project

### DIFF
--- a/core/poker_interaction.py
+++ b/core/poker_interaction.py
@@ -21,21 +21,26 @@ from __future__ import annotations
 
 import random
 
-# Re-export the unified poker classes
-# Also export utility types
-from core.mixed_poker import (
-    MixedPokerInteraction,
-    MixedPokerResult as PokerResult,
-    MultiplayerBettingRound as BettingRound,
-    MultiplayerGameState as GameState,
-    MultiplayerPlayerContext as PlayerContext,
-    Player,
-)
-
 from core.config.fish import (
     POST_POKER_REPRODUCTION_ENERGY_THRESHOLD,
     POST_POKER_REPRODUCTION_LOSER_PROB,
     POST_POKER_REPRODUCTION_WINNER_PROB,
+)
+from core.mixed_poker import (
+    MixedPokerInteraction,
+    Player,
+)
+from core.mixed_poker import (
+    MixedPokerResult as PokerResult,
+)
+from core.mixed_poker import (
+    MultiplayerBettingRound as BettingRound,
+)
+from core.mixed_poker import (
+    MultiplayerGameState as GameState,
+)
+from core.mixed_poker import (
+    MultiplayerPlayerContext as PlayerContext,
 )
 
 # Constants for poker games

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -10,6 +10,8 @@ These tests demonstrate the architectural benefits of protocols over
 isinstance checks on concrete types.
 """
 
+from typing import List
+
 import pytest
 
 from core.protocols import (
@@ -189,7 +191,7 @@ class TestProtocolPolymorphism:
     def test_lifecycle_checking_works_on_any_mortal(self, sample_fish):
         """Systems can check death status on any Mortal entity."""
 
-        def cleanup_dead_entities(entities: list[Mortal]) -> list[Mortal]:
+        def cleanup_dead_entities(entities: List[Mortal]) -> List[Mortal]:
             """Generic function that filters out dead entities.
 
             This works with any entity implementing Mortal,
@@ -297,7 +299,7 @@ class TestProtocolArchitecturalBenefits:
             def __init__(self, drain_rate: float):
                 self.drain_rate = drain_rate
 
-            def update(self, entities: list[EnergyHolder]) -> int:
+            def update(self, entities: List[EnergyHolder]) -> int:
                 """Drain energy from all entities.
 
                 Returns count of entities that survived.


### PR DESCRIPTION
Reorganize imports to follow ruff/isort standards:
- Add blank line between stdlib and local imports
- Split aliased imports from core.mixed_poker into separate statements
- This follows PEP 8 import grouping conventions