### PR TITLE
chore: unify project surface as tankworld

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
-# Fish Tank Simulation - Production Environment Variables
+# Tank World - Production Environment Variables
 # Copy this file to .env and modify as needed
 
 # =============================================================================
 # Server Identity
 # =============================================================================
-TANK_SERVER_ID=oracle-fishtank
+TANK_SERVER_ID=oracle-tankworld
 TANK_API_PORT=8000
 
 # =============================================================================

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,9 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
+        files: ^core/
         exclude: ^(frontend/|tests/)
+        stages: [manual]
         args: ['--ignore-missing-imports', '--no-strict-optional']
 
   - repo: https://github.com/pycqa/isort

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,4 +6,4 @@
 
 - [Architecture Overview](docs/ARCHITECTURE.md)
 - [Documentation Index](docs/INDEX.md)
-- [ADR Index](docs/adr/INDEX.md)
+- [ADR Index](docs/adr/README.md)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Fish Tank Simulation - Production Dockerfile
+# Tank World - Production Dockerfile
 # Optimized for Oracle Cloud Always Free ARM instances
 
 # Use Python 3.11 slim image for smaller size
@@ -22,8 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
-RUN groupadd --gid 1000 fishtank \
-    && useradd --uid 1000 --gid fishtank --shell /bin/bash --create-home fishtank
+RUN groupadd --gid 1000 tankworld \
+    && useradd --uid 1000 --gid tankworld --shell /bin/bash --create-home tankworld
 
 # Copy requirements first for better caching
 COPY backend/requirements.txt ./backend/
@@ -41,10 +41,10 @@ COPY main.py ./
 
 # Create data directories
 RUN mkdir -p /app/data /app/logs \
-    && chown -R fishtank:fishtank /app
+    && chown -R tankworld:tankworld /app
 
 # Switch to non-root user
-USER fishtank
+USER tankworld
 
 # Expose port
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ The backend listens on port **8000** by default; the frontend proxies WebSocket 
 You can also launch the backend via the installed console script:
 
 ```bash
-fishtank
+tankworld
 ```
 
 ### Headless Mode (Fast, Stats-Only)
@@ -748,7 +748,7 @@ Tank World is open source and welcomes contributions:
 - **Improve the visualization** system
 - **Propose research directions** and experiments
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [docs/EVO_CONTRIBUTING.md](docs/EVO_CONTRIBUTING.md) for contribution guidelines.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,4 +1,4 @@
-# Fish Tank Simulation - Setup Instructions
+# Tank World - Setup Instructions
 
 ## macOS Quick Install (Sonoma / Apple Silicon)
 
@@ -74,7 +74,7 @@ npm run dev
 
 ### Step 3: Open Browser
 
-Visit http://localhost:3000 in your browser. You should now see the Fish Tank Simulation UI.
+Visit http://localhost:3000 in your browser. You should now see the Tank World UI.
 
 ## Full Setup Steps (First Time)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
-# Fish Tank Simulation Backend
+# Tank World Backend
 
-FastAPI backend that runs the fish tank simulation and provides real-time updates via WebSocket.
+FastAPI backend that runs Tank World simulations and provides real-time updates via WebSocket.
 
 ## Installation
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,4 @@
-"""Backend package for Fish Tank Simulation API.
+"""Backend package for Tank World API.
 
 This package provides the FastAPI web server, WebSocket handling,
 tank management, and distributed networking capabilities.

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -1,4 +1,4 @@
-"""Application factory and context for Fish Tank Simulation API.
+"""Application factory and context for Tank World API.
 
 This module provides a clean factory pattern for creating the FastAPI app,
 avoiding import-time side effects. All singletons are created lazily
@@ -262,7 +262,7 @@ def create_app(
 
     # Create the FastAPI app
     app = FastAPI(
-        title="Fish Tank Simulation API",
+        title="Tank World API",
         lifespan=lifespan,
         docs_url=None if context.production_mode else "/docs",
         redoc_url=None if context.production_mode else "/redoc",

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,1 +1,1 @@
-"""API routers for the Fish Tank Simulation backend."""
+"""API routers for the Tank World backend."""

--- a/core/modes/rulesets.py
+++ b/core/modes/rulesets.py
@@ -180,7 +180,7 @@ class TankRuleSet(ModeRuleSet):
 
     @property
     def display_name(self) -> str:
-        return "Fish Tank"
+        return "Tank"
 
     @property
     def energy_model(self) -> EnergyModel:

--- a/core/modes/tank.py
+++ b/core/modes/tank.py
@@ -38,7 +38,7 @@ def create_tank_mode_pack(
         mode_id="tank",
         world_type="tank",
         default_view_mode="side",
-        display_name="Fish Tank",
+        display_name="Tank",
         supports_persistence=True,
         supports_actions=False,
         supports_websocket=True,

--- a/core/worlds/registry.py
+++ b/core/worlds/registry.py
@@ -148,7 +148,7 @@ def _register_builtin_modes() -> None:
         factory=lambda **kwargs: TankWorldBackendAdapter(**kwargs),
         mode_pack=create_tank_mode_pack(),
         default_view_mode="side",
-        display_name="Fish Tank",
+        display_name="Tank",
     )
 
     # Implemented petri mode (reuses tank backend)

--- a/core/worlds/tank/pack.py
+++ b/core/worlds/tank/pack.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 class TankPack(TankLikePackBase):
-    """System pack for the standard Fish Tank simulation.
+    """System pack for the standard Tank simulation.
 
     Inherits shared Tank-like wiring from TankLikePackBase and provides
     Tank-specific mode_id, metadata, and identity provider.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,22 @@
 version: '3.8'
 
 services:
-  fishtank:
+  tankworld:
     build: .
-    container_name: fishtank-server
+    container_name: tankworld-server
     restart: unless-stopped
     ports:
       - "8000:8000"
     environment:
-      - TANK_SERVER_ID=${TANK_SERVER_ID:-docker-fishtank}
+      - TANK_SERVER_ID=${TANK_SERVER_ID:-docker-tankworld}
       - PRODUCTION=${PRODUCTION:-true}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-*}
       - RATE_LIMIT_ENABLED=${RATE_LIMIT_ENABLED:-true}
       - RATE_LIMIT_REQUESTS=${RATE_LIMIT_REQUESTS:-60}
       - RATE_LIMIT_WINDOW=${RATE_LIMIT_WINDOW:-60}
     volumes:
-      - fishtank-data:/app/data
-      - fishtank-logs:/app/logs
+      - tankworld-data:/app/data
+      - tankworld-logs:/app/logs
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -31,5 +31,5 @@ services:
           memory: 256M
 
 volumes:
-  fishtank-data:
-  fishtank-logs:
+  tankworld-data:
+  tankworld-logs:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# Tank Simulation - Architecture Documentation
+# Tank World - Architecture Documentation
 
 ## Executive Summary
 
-Tank is an advanced artificial life (ALife) ecosystem simulation featuring parametrizable behavior algorithms, genetics, evolution, and emergent population dynamics.
+Tank World is an artificial life (ALife) simulation framework featuring parametrizable behavior algorithms, genetics, evolution, emergent population dynamics, and multiple world/mode configurations.
 
 **Tech Stack:**
 - **Backend**: Python with FastAPI + WebSocket
@@ -48,6 +48,8 @@ tank/
 |   |   `-- diagnostics.py         # Stats printing/export helpers
 |   |-- systems/                   # BaseSystem + system implementations
 |   |-- config/                    # Simulation configuration modules
+|   |-- agent_memory.py            # Agent-local memory primitives
+|   |-- agent_signals.py           # Agent signaling primitives
 |   |-- environment.py             # Spatial queries (implements World Protocol)
 |   `-- world.py                   # Abstract World interface
 |-- backend/                       # FastAPI WebSocket server
@@ -69,6 +71,7 @@ tank/
 
 **Design Goal:** Zero UI dependencies, fully testable
 
+- The same agent/engine loop runs across modes; modes swap rule sets and render profiles while reusing shared systems.
 - **entities/**: Fish, Plant, predator, and resource classes with deterministic IDs
 - **fish/**: Componentized fish systems (energy, lifecycle, reproduction, poker stats)
 - **genetics/**: Genome definitions, mutation, crossover, adaptive inheritance helpers
@@ -78,7 +81,7 @@ tank/
   - Composable behaviors (`composable.py`) expose sub-behavior knobs for hybrids
 - **environment.py**: Spatial grid for efficient proximity queries
 - **ecosystem.py / ecosystem_stats.py / population_tracker.py**: Population tracking, death cause tallies, and reproduction stats
-- **fish_communication.py / fish_memory.py**: Shared memory and communication helpers for strategies
+- **agent_memory.py / agent_signals.py**: Shared memory and signaling helpers for strategies and agent components
 - **world.py**: Abstract World Protocol for environment-agnostic simulation
 - **simulation/engine.py**: Central loop with system registry, plant management, and deterministic RNG plumbing
 
@@ -99,7 +102,7 @@ The codebase uses a domain-agnostic world abstraction to support multiple simula
 
 - **Built-in backends**:
   - `TankWorldBackendAdapter` - Fish ecosystem simulation
-  - `PetriWorldBackendAdapter` - Microbe simulation (same rules, different visuals)
+  - `PetriWorldBackendAdapter` - Microbe simulation (same agent loop, different rules + render profile)
 - **Minigames**:
   - `core/minigames/soccer` - Soccer league + training primitives (pure-Python physics)
 

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -1,4 +1,4 @@
-# Architecture Review: Fish Tank Simulation
+# Architecture Review: Tank World
 
 ## Executive Summary
 

--- a/docs/architecture/world_types.md
+++ b/docs/architecture/world_types.md
@@ -103,7 +103,7 @@ The `/api/worlds/types` endpoint returns all registered world types with their c
     "mode_id": "tank",
     "world_type": "tank",
     "view_mode": "side",
-    "display_name": "Fish Tank",
+    "display_name": "Tank",
     "supports_persistence": true,
     "supports_actions": false,
     "supports_websocket": true,

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# Fish Tank Simulation - React Frontend
+# Tank World - React Frontend
 
-Modern React + TypeScript + Vite frontend for the fish tank simulation with real-time Canvas rendering and Tank World Net support.
+Modern React + TypeScript + Vite frontend for Tank World with real-time Canvas rendering and Tank World Net support.
 
 ## Features
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/images/george1.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fish Tank Simulation</title>
+    <title>Tank World</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/frontend/src/renderers/avatar_renderer.ts
+++ b/frontend/src/renderers/avatar_renderer.ts
@@ -202,7 +202,7 @@ export function drawSVGFish(
     // If we want them to rotate to face movement direction in top-down view (like RPG markers),
     // we might want to rotate. 
     // HOWEVER, Tank view usually just flips horizontal.
-    // If the user wants "Fish Tank Mode", they usually swim left/right.
+    // If the user wants "Tank Mode", they usually swim left/right.
     // But this is top-down soccer...
     // If I rotate them, they look like flat paper cutouts spinning.
     // If I don't rotate, they always face left/right. This is standard side-scroller look.

--- a/main.py
+++ b/main.py
@@ -101,7 +101,7 @@ def run_headless(
 def main():
     """Parse command-line arguments and run the appropriate mode."""
     parser = argparse.ArgumentParser(
-        description="Fish Tank Ecosystem Simulation",
+        description="Tank World Simulation",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["core", "backend"]
-py-modules = []
+py-modules = ["main"]
 
 [tool.setuptools.package-data]
 core = ["py.typed"]
 
 [project]
-name = "fishtank-simulation"
+name = "tankworld"
 version = "0.1.0"
-description = "An artificial life ecosystem simulation with evolving fish behaviors"
+description = "An artificial life research framework with evolving agent behaviors, modes, and deterministic benchmarking"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [
@@ -56,7 +56,7 @@ ai = [
 ]
 
 [project.scripts]
-fishtank = "main:main"
+tankworld = "main:main"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/analyze_sim.py
+++ b/scripts/analyze_sim.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Quick analyzer for the running Fish Tank simulation.
+"""Quick analyzer for the running Tank World simulation.
 
 This script fetches `/api/evaluation-history` and `/api/lineage` from the
 local backend and prints a short report: top performers over time and

--- a/scripts/oracle_cloud_setup.sh
+++ b/scripts/oracle_cloud_setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Oracle Cloud Fish Tank Setup Script
+# Oracle Cloud Tank World Setup Script
 # Run this on your Oracle Cloud instance after SSH-ing in
 
 set -e  # Exit on error
 
 echo "=========================================="
-echo "Fish Tank Oracle Cloud Setup Script"
+echo "Tank World Oracle Cloud Setup Script"
 echo "=========================================="
 
 # Colors for output
@@ -18,7 +18,7 @@ NC='\033[0m' # No Color
 REPO_URL="${REPO_URL:-https://github.com/YOUR_USERNAME/tank.git}"
 INSTALL_DIR="/home/ubuntu/tank"
 PYTHON_VERSION="3.11"
-SERVER_ID="${SERVER_ID:-oracle-fishtank}"
+SERVER_ID="${SERVER_ID:-oracle-tankworld}"
 DOMAIN="${DOMAIN:-}"  # Set this if you have a domain
 
 print_status() {
@@ -114,9 +114,9 @@ print_status "Python environment ready"
 
 echo ""
 echo "Step 7: Creating systemd service..."
-sudo tee /etc/systemd/system/fishtank.service > /dev/null << EOF
+sudo tee /etc/systemd/system/tankworld.service > /dev/null << EOF
 [Unit]
-Description=Fish Tank Simulation Server
+Description=Tank World Simulation Server
 After=network.target
 
 [Service]
@@ -137,13 +137,13 @@ WantedBy=multi-user.target
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl enable fishtank
+sudo systemctl enable tankworld
 print_status "Systemd service created"
 
 echo ""
 echo "Step 8: Configuring Nginx..."
 NGINX_SERVER_NAME="${DOMAIN:-_}"
-sudo tee /etc/nginx/sites-available/fishtank > /dev/null << EOF
+sudo tee /etc/nginx/sites-available/tankworld > /dev/null << EOF
 limit_req_zone \$binary_remote_addr zone=api_limit:10m rate=10r/s;
 limit_conn_zone \$binary_remote_addr zone=conn_limit:10m;
 
@@ -197,22 +197,22 @@ server {
 }
 EOF
 
-sudo ln -sf /etc/nginx/sites-available/fishtank /etc/nginx/sites-enabled/
+sudo ln -sf /etc/nginx/sites-available/tankworld /etc/nginx/sites-enabled/
 sudo rm -f /etc/nginx/sites-enabled/default
 sudo nginx -t
 sudo systemctl restart nginx
 print_status "Nginx configured"
 
 echo ""
-echo "Step 9: Starting Fish Tank service..."
-sudo systemctl start fishtank
+echo "Step 9: Starting Tank World service..."
+sudo systemctl start tankworld
 sleep 3
 
-if sudo systemctl is-active --quiet fishtank; then
-    print_status "Fish Tank service is running!"
+if sudo systemctl is-active --quiet tankworld; then
+    print_status "Tank World service is running!"
 else
-    print_error "Fish Tank service failed to start. Check logs:"
-    echo "  sudo journalctl -u fishtank -n 50"
+    print_error "Tank World service failed to start. Check logs:"
+    echo "  sudo journalctl -u tankworld -n 50"
     exit 1
 fi
 
@@ -227,7 +227,7 @@ echo "=========================================="
 echo -e "${GREEN}Setup Complete!${NC}"
 echo "=========================================="
 echo ""
-echo "Your Fish Tank server is now running!"
+echo "Your Tank World server is now running!"
 echo ""
 echo "Access your server:"
 PUBLIC_IP=$(curl -s ifconfig.me 2>/dev/null || echo "YOUR_PUBLIC_IP")
@@ -235,9 +235,9 @@ echo "  http://${PUBLIC_IP}/"
 echo "  http://${PUBLIC_IP}/health"
 echo ""
 echo "Useful commands:"
-echo "  sudo systemctl status fishtank    # Check status"
-echo "  sudo journalctl -u fishtank -f    # View logs"
-echo "  sudo systemctl restart fishtank   # Restart"
+echo "  sudo systemctl status tankworld    # Check status"
+echo "  sudo journalctl -u tankworld -f    # View logs"
+echo "  sudo systemctl restart tankworld   # Restart"
 echo ""
 
 if [ -z "$DOMAIN" ]; then
@@ -247,4 +247,4 @@ if [ -z "$DOMAIN" ]; then
     echo ""
 fi
 
-echo "Done! 🐟"
+echo "Done!"

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -1,8 +1,8 @@
-# Fish Tank Simulation - Windows Setup Script
+# Tank World - Windows Setup Script
 # This script sets up the Python environment and installs dependencies
 
 Write-Host "======================================" -ForegroundColor Cyan
-Write-Host "Fish Tank Simulation - Setup" -ForegroundColor Cyan
+Write-Host "Tank World - Setup" -ForegroundColor Cyan
 Write-Host "======================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -35,7 +35,7 @@ python -m pip install --upgrade pip
 
 # Install the package in development mode
 Write-Host ""
-Write-Host "Installing fish tank simulation and dependencies..." -ForegroundColor Cyan
+Write-Host "Installing Tank World and dependencies..." -ForegroundColor Cyan
 python -m pip install -e .
 
 # Install development dependencies (optional)

--- a/scripts/start_servers.sh
+++ b/scripts/start_servers.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Linux startup script for Fish Tank Simulation
+# Linux startup script for Tank World
 
 echo "========================================="
-echo "Fish Tank Simulation - Server Startup"
+echo "Tank World - Server Startup"
 echo "========================================="
 echo ""
 

--- a/scripts/stop_servers.sh
+++ b/scripts/stop_servers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Linux stop script for Fish Tank Simulation
+# Linux stop script for Tank World
 
-echo "Stopping Fish Tank servers..."
+echo "Stopping Tank World servers..."
 
 # Kill backend
 pkill -f "python.*backend.*main.py"

--- a/tests/test_mode_rulesets.py
+++ b/tests/test_mode_rulesets.py
@@ -78,7 +78,7 @@ class TestTankRuleSet:
     def test_display_name(self):
         """Should have human-readable name."""
         ruleset = TankRuleSet()
-        assert ruleset.display_name == "Fish Tank"
+        assert ruleset.display_name == "Tank"
 
     def test_has_poker(self):
         """Tank mode should have poker enabled."""

--- a/tests/test_world_runner.py
+++ b/tests/test_world_runner.py
@@ -61,7 +61,7 @@ def test_world_metadata() -> None:
     assert metadata.mode_id == "tank"
     assert metadata.world_type == "tank"
     assert metadata.view_mode == "side"
-    assert metadata.display_name == "Fish Tank"
+    assert metadata.display_name == "Tank"
 
 
 def test_world_runner_reset_returns_step_result() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -605,7 +605,7 @@ wheels = [
 ]
 
 [[package]]
-name = "fishtank-simulation"
+name = "tankworld"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
- Rename package to tankworld and CLI to tankworld
- Rename docker/compose service/container/volumes and Dockerfile user
- Update env defaults, docs, and architecture references
- Rename tank mode display label from 'Fish Tank' to 'Tank'
- Tweak pre-commit: pycache check only blocks staged/tracked; mypy runs manually