### PR TITLE
Make dt and frame explicit parameters in movement policy execution

### DIFF
--- a/core/movement_strategy.py
+++ b/core/movement_strategy.py
@@ -237,6 +237,11 @@ class AlgorithmicMovement(MovementStrategy):
         # Build observation
         observation = build_movement_observation(fish)
 
+        # Extract explicit dt and frame for deterministic execution
+        env_dt = getattr(fish.environment, "dt", 1.0)
+        lifecycle = getattr(fish, "_lifecycle_component", None)
+        fish_frame = getattr(lifecycle, "age", None) if lifecycle is not None else None
+
         # Execute via runner
         # run_movement_policy handles extracting the component_id from the genome
         return run_movement_policy(
@@ -245,6 +250,8 @@ class AlgorithmicMovement(MovementStrategy):
             observation=observation,
             rng=fish.environment.rng,
             fish_id=getattr(fish, "fish_id", None),
+            dt=env_dt,
+            frame=fish_frame,
         )
 
     def _get_ball_pursuit_velocity(self, fish: Fish) -> VelocityComponents | None:

--- a/core/worlds/shared/movement_observations.py
+++ b/core/worlds/shared/movement_observations.py
@@ -142,7 +142,6 @@ def _nearest_vector(
             return {"x": 0.0, "y": 0.0}
 
     if max_distance is not None:
-        int(max_distance) + 1
         if use_resources and hasattr(environment, "nearby_resources"):
             agents = environment.nearby_resources(fish, radius)
         else:

--- a/tests/test_movement_policy_runner.py
+++ b/tests/test_movement_policy_runner.py
@@ -201,3 +201,120 @@ def test_movement_policy_error_logs_not_rate_limited_without_age(
 
     warning_count = sum(1 for r in caplog.records if r.levelname == "WARNING")
     assert warning_count == 2, f"Expected 2 warnings without rate limiting, got {warning_count}"
+
+
+def test_explicit_frame_parameter_used_for_rate_limiting(mock_genome, mock_code_pool, caplog):
+    """Test that explicit frame parameter is used for rate limiting over observation age."""
+    from core.policies.movement_policy_runner import _reset_error_log_state_for_tests
+
+    _reset_error_log_state_for_tests()
+
+    # Setup failing execution result
+    execution_result = MagicMock()
+    execution_result.success = False
+    execution_result.error_message = "Test error"
+    mock_code_pool.execute_policy.return_value = execution_result
+
+    rng = random.Random(42)
+
+    # Observation has age=100 (bucket 1), but explicit frame=0 (bucket 0)
+    # If explicit frame is used, calls within the same bucket should be rate-limited
+    caplog.clear()
+    obs = {"age": 100}  # Would be bucket 1
+    run_movement_policy(
+        mock_genome, mock_code_pool, obs, rng, fish_id=1, frame=0
+    )  # Explicit bucket 0
+    run_movement_policy(
+        mock_genome, mock_code_pool, obs, rng, fish_id=1, frame=30
+    )  # Still bucket 0
+
+    warning_count = sum(1 for r in caplog.records if r.levelname == "WARNING")
+    assert (
+        warning_count == 1
+    ), f"Expected 1 warning (rate limited by explicit frame), got {warning_count}"
+
+    # Call with frame=60 (bucket 1), should trigger new log
+    caplog.clear()
+    run_movement_policy(mock_genome, mock_code_pool, obs, rng, fish_id=1, frame=60)
+    warning_count = sum(1 for r in caplog.records if r.levelname == "WARNING")
+    assert warning_count == 1, f"Expected 1 warning in new bucket, got {warning_count}"
+
+
+def test_explicit_frame_falls_back_to_observation_age(mock_genome, mock_code_pool, caplog):
+    """Test that when frame is None, observation['age'] is used for rate limiting."""
+    from core.policies.movement_policy_runner import _reset_error_log_state_for_tests
+
+    _reset_error_log_state_for_tests()
+
+    # Setup failing execution result
+    execution_result = MagicMock()
+    execution_result.success = False
+    execution_result.error_message = "Test error"
+    mock_code_pool.execute_policy.return_value = execution_result
+
+    rng = random.Random(42)
+
+    # Call without explicit frame - should fall back to observation["age"]
+    caplog.clear()
+    obs = {"age": 10}  # Bucket 0
+    run_movement_policy(mock_genome, mock_code_pool, obs, rng, fish_id=1, frame=None)
+    run_movement_policy(mock_genome, mock_code_pool, obs, rng, fish_id=1)  # frame defaults to None
+
+    warning_count = sum(1 for r in caplog.records if r.levelname == "WARNING")
+    assert warning_count == 1, f"Expected 1 warning (rate limited by obs age), got {warning_count}"
+
+
+def test_explicit_dt_forwarded_to_execute_policy(mock_genome, mock_code_pool):
+    """Test that explicit dt parameter is forwarded to GenomeCodePool.execute_policy."""
+    execution_result = MagicMock()
+    execution_result.success = True
+    execution_result.output = (0.5, 0.5)
+    mock_code_pool.execute_policy.return_value = execution_result
+
+    rng = random.Random(42)
+    obs = {}
+
+    # Call with explicit dt=0.1
+    run_movement_policy(mock_genome, mock_code_pool, obs, rng, dt=0.1)
+
+    # Verify execute_policy was called with dt=0.1
+    mock_code_pool.execute_policy.assert_called_once()
+    call_kwargs = mock_code_pool.execute_policy.call_args.kwargs
+    assert call_kwargs["dt"] == 0.1, f"Expected dt=0.1, got dt={call_kwargs['dt']}"
+
+
+def test_dt_defaults_to_1_when_not_provided(mock_genome, mock_code_pool):
+    """Test that dt defaults to 1.0 when not explicitly provided."""
+    execution_result = MagicMock()
+    execution_result.success = True
+    execution_result.output = (0.5, 0.5)
+    mock_code_pool.execute_policy.return_value = execution_result
+
+    rng = random.Random(42)
+    obs = {}
+
+    # Call without explicit dt
+    run_movement_policy(mock_genome, mock_code_pool, obs, rng)
+
+    # Verify execute_policy was called with dt=1.0
+    mock_code_pool.execute_policy.assert_called_once()
+    call_kwargs = mock_code_pool.execute_policy.call_args.kwargs
+    assert call_kwargs["dt"] == 1.0, f"Expected dt=1.0, got dt={call_kwargs['dt']}"
+
+
+def test_dt_not_read_from_observation(mock_genome, mock_code_pool):
+    """Test that dt is NOT read from observation (uses explicit param only)."""
+    execution_result = MagicMock()
+    execution_result.success = True
+    execution_result.output = (0.5, 0.5)
+    mock_code_pool.execute_policy.return_value = execution_result
+
+    rng = random.Random(42)
+    obs = {"dt": 999.0}  # This should be ignored
+
+    # Call with explicit dt=0.5 while observation has dt=999.0
+    run_movement_policy(mock_genome, mock_code_pool, obs, rng, dt=0.5)
+
+    # Verify execute_policy was called with the explicit dt=0.5, not obs dt=999.0
+    call_kwargs = mock_code_pool.execute_policy.call_args.kwargs
+    assert call_kwargs["dt"] == 0.5, f"Expected explicit dt=0.5, got dt={call_kwargs['dt']}"


### PR DESCRIPTION
## Summary
Refactors the movement policy execution pipeline to pass `dt` (time delta) and `frame` (simulation frame) as explicit parameters rather than extracting them from the observation dictionary. This improves code clarity, enables deterministic execution, and decouples physics calculations from observation data.

## Key Changes

- **Explicit dt parameter**: `run_movement_policy()` now accepts `dt` as a keyword-only parameter (defaults to 1.0) instead of reading it from `observation["dt"]`. This ensures consistent physics calculations regardless of observation contents.

- **Explicit frame parameter**: `run_movement_policy()` now accepts `frame` as a keyword-only parameter for rate-limited logging, with fallback to `observation["age"]` if not provided. This gives callers explicit control over logging behavior.

- **Updated caller**: `_execute_policy_if_present()` in `movement_strategy.py` now extracts `dt` from the environment and `frame` from the fish's lifecycle component, passing them explicitly to `run_movement_policy()`.

- **Comprehensive test coverage**: Added 5 new tests validating:
  - Explicit frame parameter takes precedence over observation age for rate limiting
  - Fallback to observation age when frame is None
  - Explicit dt is forwarded to the code pool executor
  - dt defaults to 1.0 when not provided
  - dt is never read from observation (explicit parameter only)

- **Bug fix**: Removed dead code in `movement_observations.py` that computed `int(max_distance) + 1` without using the result.

## Implementation Details

The changes use keyword-only parameters (`*,` syntax) for `dt` and `frame` in `run_movement_policy()` to prevent accidental positional argument confusion and make the API more explicit. The frame parameter gracefully falls back to extracting from observation if not provided, maintaining backward compatibility while enabling deterministic execution when needed.