### PR TITLE
Soccer: remove match access to engine internals

### DIFF
--- a/core/minigames/soccer/engine.py
+++ b/core/minigames/soccer/engine.py
@@ -255,6 +255,21 @@ class RCSSLiteEngine:
         self._ball.velocity = RCSSVector(0.0, 0.0)
         self._ball.acceleration = RCSSVector(0.0, 0.0)
 
+    @property
+    def play_mode(self) -> str:
+        """Current play mode."""
+        return self._play_mode
+
+    def set_play_mode(self, mode: str) -> None:
+        """Set play mode.
+
+        Only a small set of modes are currently supported.
+        """
+        valid_modes = ("before_kick_off", "kick_off_left", "kick_off_right")
+        if mode not in valid_modes:
+            raise ValueError(f"Invalid play mode: {mode!r}. Expected one of {valid_modes}.")
+        self._play_mode = mode
+
     def set_swapped_sides(self, swapped: bool) -> None:
         """Set whether teams have swapped sides (affects goal attribution)."""
         self._swapped_sides = swapped

--- a/core/minigames/soccer/match.py
+++ b/core/minigames/soccer/match.py
@@ -315,7 +315,7 @@ class SoccerMatch:
         # 2nd half kick-off usually by Right team (if Left started)
         # But if sides swapped, Right Team is on Left Side.
         # kick_off_right means Right Team kicks.
-        self._engine._play_mode = "kick_off_right"
+        self._engine.set_play_mode("kick_off_right")
 
     def _update_telemetry(self) -> None:
         """Update telemetry after each cycle (for shaped rewards)."""


### PR DESCRIPTION
- Add RCSSLiteEngine.play_mode and set_play_mode()

- SoccerMatch uses set_play_mode() instead of _play_mode

- Extend engine API encapsulation tests

Tests: python -m pytest -q tests/test_soccer_system.py tests/test_soccer_eval.py tests/test_soccer_engine_api.py