### PR TITLE
Make soccer training benchmarks side-invariant

### DIFF
--- a/benchmarks/soccer/training_3k.py
+++ b/benchmarks/soccer/training_3k.py
@@ -1,14 +1,15 @@
 """Soccer Training Benchmark (3k frames).
 
 Measures team performance and coordination in soccer using RCSS-Lite engine.
-Score is based on goal differential, possession time, and stamina efficiency.
+Score is side-invariant and aggregated across multiple seeds with team swapping
+to reduce left/right assignment noise.
 
 Reduced from 5k to 3k frames for faster evolution iteration.
 """
 
 import sys
 import time
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from core.code_pool import create_default_genome_code_pool
 from core.genetics import Genome
@@ -16,39 +17,101 @@ from core.minigames.soccer import SoccerMatchRunner
 
 BENCHMARK_ID = "soccer/training_3k"
 FRAMES = 3000
+DEFAULT_N_SEEDS = 5
 
 
-def run(seed: int) -> Dict[str, Any]:
+def _create_default_population(
+    seed: int,
+    population_size: int,
+    genome_code_pool: Any,
+) -> List[Genome]:
+    import random
+
+    rng = random.Random(seed)
+
+    population: List[Genome] = []
+    default_id = genome_code_pool.get_default("soccer_policy")
+    if default_id:
+        from core.genetics.trait import GeneticTrait
+
+    for _ in range(population_size):
+        genome = Genome.random(use_algorithm=False, rng=rng)
+        if default_id:
+            genome.behavioral.soccer_policy_id = GeneticTrait(default_id)
+        population.append(genome)
+
+    return population
+
+
+def _run_episode(
+    runner: SoccerMatchRunner,
+    population: List[Genome],
+    seed: int,
+    frames: int,
+) -> Dict[str, Any]:
+    episode_result, agent_results = runner.run_episode(
+        genomes=population,
+        seed=seed,
+        frames=frames,
+        goal_weight=100.0,
+    )
+
+    score_left = episode_result.score_left
+    score_right = episode_result.score_right
+    total_goals = score_left + score_right
+
+    possession_left = 0
+    possession_right = 0
+    for _pid, stats in episode_result.player_stats.items():
+        if stats.team == "left":
+            possession_left += stats.possessions
+        else:
+            possession_right += stats.possessions
+
+    team_fitness_left = sum(r.fitness for r in agent_results if r.team == "left")
+    team_fitness_right = sum(r.fitness for r in agent_results if r.team == "right")
+    team_fitness = team_fitness_left + team_fitness_right
+    avg_fitness = team_fitness / max(len(population), 1)
+
+    # Side-invariant score (left/right labels do not matter).
+    score = avg_fitness
+
+    return {
+        "score": score,
+        "avg_fitness": avg_fitness,
+        "team_fitness_left": team_fitness_left,
+        "team_fitness_right": team_fitness_right,
+        "score_left": score_left,
+        "score_right": score_right,
+        "total_goals": total_goals,
+        "possession_left": possession_left,
+        "possession_right": possession_right,
+        "total_possession": possession_left + possession_right,
+    }
+
+
+def run(
+    seed: int,
+    *,
+    n_seeds: int = DEFAULT_N_SEEDS,
+    frames: int = FRAMES,
+    team_size: int = 3,
+) -> Dict[str, Any]:
     """Run the benchmark deterministically.
 
     Args:
         seed: Random seed for the simulation
+        n_seeds: Number of seeds to aggregate over (default: training benchmark setting)
+        frames: Frames per episode (default: training benchmark setting)
+        team_size: Players per team (default: 3)
 
     Returns:
         Result dictionary with score, metrics, and metadata
     """
-    import random
-
     start_time = time.time()
 
     # Create genome code pool for autopolicy
     genome_code_pool = create_default_genome_code_pool()
-
-    # Create population with default policies
-    rng = random.Random(seed)
-    team_size = 3  # 3v3 for faster training
-    population_size = team_size * 2
-
-    population = []
-    for _ in range(population_size):
-        genome = Genome.random(use_algorithm=False, rng=rng)
-        # Assign default soccer policy
-        default_id = genome_code_pool.get_default("soccer_policy")
-        if default_id:
-            from core.genetics.trait import GeneticTrait
-
-            genome.behavioral.soccer_policy_id = GeneticTrait(default_id)
-        population.append(genome)
 
     # Create match runner
     runner = SoccerMatchRunner(
@@ -56,47 +119,42 @@ def run(seed: int) -> Dict[str, Any]:
         genome_code_pool=genome_code_pool,
     )
 
-    # Run episode
-    print(f"  Running {FRAMES} frames...", file=sys.stderr)
-    episode_result, agent_results = runner.run_episode(
-        genomes=population,
-        seed=seed,
-        frames=FRAMES,
-        goal_weight=100.0,
-    )
+    population_size = team_size * 2
+    seeds = [seed + i for i in range(n_seeds)]
+
+    per_seed_results: List[Dict[str, Any]] = []
+    per_seed_scores: List[float] = []
+
+    for eval_seed in seeds:
+        population = _create_default_population(
+            seed=eval_seed,
+            population_size=population_size,
+            genome_code_pool=genome_code_pool,
+        )
+        swapped_population = population[team_size:] + population[:team_size]
+
+        print(
+            f"  Seed {eval_seed}: {frames} frames x2 (normal + swapped)...",
+            file=sys.stderr,
+        )
+
+        normal = _run_episode(runner, population, seed=eval_seed, frames=frames)
+        swapped = _run_episode(runner, swapped_population, seed=eval_seed, frames=frames)
+
+        per_seed_score = (normal["score"] + swapped["score"]) / 2.0
+        per_seed_scores.append(per_seed_score)
+        per_seed_results.append(
+            {
+                "seed": eval_seed,
+                "per_seed_score": per_seed_score,
+                "normal": normal,
+                "swapped": swapped,
+            }
+        )
+
+    score = sum(per_seed_scores) / max(len(per_seed_scores), 1)
 
     runtime = time.time() - start_time
-
-    # Calculate metrics from episode result
-    score_left = episode_result.score_left
-    score_right = episode_result.score_right
-    goal_diff = score_left - score_right
-    total_goals = score_left + score_right
-
-    # Possession from player stats
-    possession_left = 0
-    possession_right = 0
-    for pid, stats in episode_result.player_stats.items():
-        if stats.team == "left":
-            possession_left += stats.possessions
-        else:
-            possession_right += stats.possessions
-
-    total_possession = possession_left + possession_right
-    # Convert frames to approximate seconds
-    possession_diff = (possession_left - possession_right) / 60.0
-
-    # Team fitness from agent results
-    team_fitness_left = sum(r.fitness for r in agent_results if r.team == "left")
-    team_fitness_right = sum(r.fitness for r in agent_results if r.team == "right")
-    team_fitness = team_fitness_left + team_fitness_right
-    avg_fitness = team_fitness / max(population_size, 1)
-
-    # Score formula:
-    # - Goal differential: 100 points per goal
-    # - Possession diff: 1.0 point per second of advantage
-    # - Average fitness: 0.1 points per fitness unit
-    score = (goal_diff * 100.0) + (possession_diff * 1.0) + (avg_fitness * 0.1)
 
     return {
         "benchmark_id": BENCHMARK_ID,
@@ -104,18 +162,13 @@ def run(seed: int) -> Dict[str, Any]:
         "score": score,
         "runtime_seconds": runtime,
         "metadata": {
-            "frames": FRAMES,
-            "score_left": score_left,
-            "score_right": score_right,
-            "total_goals": total_goals,
-            "goal_diff": goal_diff,
-            "possession_left": possession_left,
-            "possession_right": possession_right,
-            "total_possession": total_possession,
-            "possession_diff": possession_diff,
-            "avg_fitness": avg_fitness,
-            "team_fitness_left": team_fitness_left,
-            "team_fitness_right": team_fitness_right,
+            "frames": frames,
+            "team_size": team_size,
+            "population_size": population_size,
+            "n_seeds": n_seeds,
+            "seeds": seeds,
+            "score_mode": "avg_fitness (side-invariant)",
+            "per_seed_results": per_seed_results,
         },
     }
 
@@ -132,7 +185,8 @@ if __name__ == "__main__":
     if args.verify_determinism:
         res1 = run(args.seed)
         res2 = run(args.seed)
-        if res1["score"] != res2["score"]:
+        score_diff = abs(res1["score"] - res2["score"])
+        if score_diff > 1e-9:
             print(f"DETERMINISM FAILED: {res1['score']} != {res2['score']}", file=sys.stderr)
             sys.exit(1)
         print(f"DETERMINISM PASSED: {res1['score']}")

--- a/benchmarks/soccer/training_5k.py
+++ b/benchmarks/soccer/training_5k.py
@@ -1,14 +1,15 @@
 """Soccer Training Benchmark (5k frames).
 
 Measures team performance and coordination in soccer using RCSS-Lite engine.
-Score is based on goal differential, possession time, and stamina efficiency.
+Score is side-invariant and aggregated across multiple seeds with team swapping
+to reduce left/right assignment noise.
 
-Restored for historical compatibility with training_5k.json champion.
+Maintains the 5k-frame horizon for historical continuity.
 """
 
 import sys
 import time
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from core.code_pool import create_default_genome_code_pool
 from core.genetics import Genome
@@ -16,39 +17,101 @@ from core.minigames.soccer import SoccerMatchRunner
 
 BENCHMARK_ID = "soccer/training_5k"
 FRAMES = 5000
+DEFAULT_N_SEEDS = 3
 
 
-def run(seed: int) -> Dict[str, Any]:
+def _create_default_population(
+    seed: int,
+    population_size: int,
+    genome_code_pool: Any,
+) -> List[Genome]:
+    import random
+
+    rng = random.Random(seed)
+
+    population: List[Genome] = []
+    default_id = genome_code_pool.get_default("soccer_policy")
+    if default_id:
+        from core.genetics.trait import GeneticTrait
+
+    for _ in range(population_size):
+        genome = Genome.random(use_algorithm=False, rng=rng)
+        if default_id:
+            genome.behavioral.soccer_policy_id = GeneticTrait(default_id)
+        population.append(genome)
+
+    return population
+
+
+def _run_episode(
+    runner: SoccerMatchRunner,
+    population: List[Genome],
+    seed: int,
+    frames: int,
+) -> Dict[str, Any]:
+    episode_result, agent_results = runner.run_episode(
+        genomes=population,
+        seed=seed,
+        frames=frames,
+        goal_weight=100.0,
+    )
+
+    score_left = episode_result.score_left
+    score_right = episode_result.score_right
+    total_goals = score_left + score_right
+
+    possession_left = 0
+    possession_right = 0
+    for _pid, stats in episode_result.player_stats.items():
+        if stats.team == "left":
+            possession_left += stats.possessions
+        else:
+            possession_right += stats.possessions
+
+    team_fitness_left = sum(r.fitness for r in agent_results if r.team == "left")
+    team_fitness_right = sum(r.fitness for r in agent_results if r.team == "right")
+    team_fitness = team_fitness_left + team_fitness_right
+    avg_fitness = team_fitness / max(len(population), 1)
+
+    # Side-invariant score (left/right labels do not matter).
+    score = avg_fitness
+
+    return {
+        "score": score,
+        "avg_fitness": avg_fitness,
+        "team_fitness_left": team_fitness_left,
+        "team_fitness_right": team_fitness_right,
+        "score_left": score_left,
+        "score_right": score_right,
+        "total_goals": total_goals,
+        "possession_left": possession_left,
+        "possession_right": possession_right,
+        "total_possession": possession_left + possession_right,
+    }
+
+
+def run(
+    seed: int,
+    *,
+    n_seeds: int = DEFAULT_N_SEEDS,
+    frames: int = FRAMES,
+    team_size: int = 3,
+) -> Dict[str, Any]:
     """Run the benchmark deterministically.
 
     Args:
         seed: Random seed for the simulation
+        n_seeds: Number of seeds to aggregate over (default: training benchmark setting)
+        frames: Frames per episode (default: training benchmark setting)
+        team_size: Players per team (default: 3)
 
     Returns:
         Result dictionary with score, metrics, and metadata
     """
-    import random
-
     start_time = time.time()
 
     # Create genome code pool for autopolicy
     genome_code_pool = create_default_genome_code_pool()
-
-    # Create population with default policies
-    rng = random.Random(seed)
-    team_size = 3  # 3v3 for faster training
-    population_size = team_size * 2
-
-    population = []
-    for _ in range(population_size):
-        genome = Genome.random(use_algorithm=False, rng=rng)
-        # Assign default soccer policy
-        default_id = genome_code_pool.get_default("soccer_policy")
-        if default_id:
-            from core.genetics.trait import GeneticTrait
-
-            genome.behavioral.soccer_policy_id = GeneticTrait(default_id)
-        population.append(genome)
 
     # Create match runner
     runner = SoccerMatchRunner(
@@ -56,47 +119,42 @@ def run(seed: int) -> Dict[str, Any]:
         genome_code_pool=genome_code_pool,
     )
 
-    # Run episode
-    print(f"  Running {FRAMES} frames...", file=sys.stderr)
-    episode_result, agent_results = runner.run_episode(
-        genomes=population,
-        seed=seed,
-        frames=FRAMES,
-        goal_weight=100.0,
-    )
+    population_size = team_size * 2
+    seeds = [seed + i for i in range(n_seeds)]
+
+    per_seed_results: List[Dict[str, Any]] = []
+    per_seed_scores: List[float] = []
+
+    for eval_seed in seeds:
+        population = _create_default_population(
+            seed=eval_seed,
+            population_size=population_size,
+            genome_code_pool=genome_code_pool,
+        )
+        swapped_population = population[team_size:] + population[:team_size]
+
+        print(
+            f"  Seed {eval_seed}: {frames} frames x2 (normal + swapped)...",
+            file=sys.stderr,
+        )
+
+        normal = _run_episode(runner, population, seed=eval_seed, frames=frames)
+        swapped = _run_episode(runner, swapped_population, seed=eval_seed, frames=frames)
+
+        per_seed_score = (normal["score"] + swapped["score"]) / 2.0
+        per_seed_scores.append(per_seed_score)
+        per_seed_results.append(
+            {
+                "seed": eval_seed,
+                "per_seed_score": per_seed_score,
+                "normal": normal,
+                "swapped": swapped,
+            }
+        )
+
+    score = sum(per_seed_scores) / max(len(per_seed_scores), 1)
 
     runtime = time.time() - start_time
-
-    # Calculate metrics from episode result
-    score_left = episode_result.score_left
-    score_right = episode_result.score_right
-    goal_diff = score_left - score_right
-    total_goals = score_left + score_right
-
-    # Possession from player stats
-    possession_left = 0
-    possession_right = 0
-    for pid, stats in episode_result.player_stats.items():
-        if stats.team == "left":
-            possession_left += stats.possessions
-        else:
-            possession_right += stats.possessions
-
-    total_possession = possession_left + possession_right
-    # Convert frames to approximate seconds
-    possession_diff = (possession_left - possession_right) / 60.0
-
-    # Team fitness from agent results
-    team_fitness_left = sum(r.fitness for r in agent_results if r.team == "left")
-    team_fitness_right = sum(r.fitness for r in agent_results if r.team == "right")
-    team_fitness = team_fitness_left + team_fitness_right
-    avg_fitness = team_fitness / max(population_size, 1)
-
-    # Score formula:
-    # - Goal differential: 100 points per goal
-    # - Possession diff: 1.0 point per second of advantage
-    # - Average fitness: 0.1 points per fitness unit
-    score = (goal_diff * 100.0) + (possession_diff * 1.0) + (avg_fitness * 0.1)
 
     return {
         "benchmark_id": BENCHMARK_ID,
@@ -104,18 +162,13 @@ def run(seed: int) -> Dict[str, Any]:
         "score": score,
         "runtime_seconds": runtime,
         "metadata": {
-            "frames": FRAMES,
-            "score_left": score_left,
-            "score_right": score_right,
-            "total_goals": total_goals,
-            "goal_diff": goal_diff,
-            "possession_left": possession_left,
-            "possession_right": possession_right,
-            "total_possession": total_possession,
-            "possession_diff": possession_diff,
-            "avg_fitness": avg_fitness,
-            "team_fitness_left": team_fitness_left,
-            "team_fitness_right": team_fitness_right,
+            "frames": frames,
+            "team_size": team_size,
+            "population_size": population_size,
+            "n_seeds": n_seeds,
+            "seeds": seeds,
+            "score_mode": "avg_fitness (side-invariant)",
+            "per_seed_results": per_seed_results,
         },
     }
 
@@ -132,7 +185,8 @@ if __name__ == "__main__":
     if args.verify_determinism:
         res1 = run(args.seed)
         res2 = run(args.seed)
-        if res1["score"] != res2["score"]:
+        score_diff = abs(res1["score"] - res2["score"])
+        if score_diff > 1e-9:
             print(f"DETERMINISM FAILED: {res1['score']} != {res2['score']}", file=sys.stderr)
             sys.exit(1)
         print(f"DETERMINISM PASSED: {res1['score']}")

--- a/tests/test_benchmark_determinism.py
+++ b/tests/test_benchmark_determinism.py
@@ -208,5 +208,25 @@ class TestBenchmarkEvaluation(unittest.TestCase):
             self.assertEqual(res.benchmark_id, pid)
 
 
+class TestSoccerBenchmarkDeterminism(unittest.TestCase):
+    """Smoke tests for soccer benchmark determinism (fast config)."""
+
+    def test_training_3k_is_deterministic_smoke(self):
+        import benchmarks.soccer.training_3k as bench
+
+        res1 = bench.run(42, n_seeds=1, frames=100)
+        res2 = bench.run(42, n_seeds=1, frames=100)
+
+        self.assertAlmostEqual(res1["score"], res2["score"], places=9)
+
+    def test_training_5k_is_deterministic_smoke(self):
+        import benchmarks.soccer.training_5k as bench
+
+        res1 = bench.run(42, n_seeds=1, frames=100)
+        res2 = bench.run(42, n_seeds=1, frames=100)
+
+        self.assertAlmostEqual(res1["score"], res2["score"], places=9)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Average normal+swapped team assignments per seed
- Aggregate across multiple seeds (3k: 5 seeds, 5k: 3 seeds)
- Score uses side-invariant avg_fitness (drops goal_diff/possession_diff)
- Add determinism smoke coverage for soccer benches

Repro:
python tools/run_bench.py benchmarks/soccer/training_3k.py --seed 42 --verify-determinism