### PR TITLE
Soccer: share default formation helper

### DIFF
--- a/core/minigames/soccer/formation.py
+++ b/core/minigames/soccer/formation.py
@@ -1,0 +1,62 @@
+"""Shared soccer player formation helpers.
+
+The interactive match (`SoccerMatch`) and the training runner (`SoccerMatchRunner`)
+must agree on initial spawn positions/angles for determinism and fairness.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from core.minigames.soccer.params import RCSSParams
+
+
+@dataclass(frozen=True)
+class SpawnSpec:
+    player_id: str
+    team: Literal["left", "right"]
+    x: float
+    y: float
+    body_angle: float
+
+
+def build_default_formation(team_size: int, params: RCSSParams) -> list[SpawnSpec]:
+    """Build the default symmetric formation for both teams.
+
+    Returns a deterministic list ordered as: left_1, right_1, left_2, right_2, ...
+    """
+    half_length = params.field_length / 2
+
+    spawns: list[SpawnSpec] = []
+    for i in range(team_size):
+        y = (i // 4 - team_size // 8) * 12
+
+        # Left team - face right (0 radians)
+        left_id = f"left_{i + 1}"
+        left_x = -half_length / 2 + (i % 4) * 8 - 10
+        spawns.append(
+            SpawnSpec(
+                player_id=left_id,
+                team="left",
+                x=left_x,
+                y=y,
+                body_angle=0.0,
+            )
+        )
+
+        # Right team - face left (pi radians)
+        right_id = f"right_{i + 1}"
+        right_x = half_length / 2 - (i % 4) * 8 + 10
+        spawns.append(
+            SpawnSpec(
+                player_id=right_id,
+                team="right",
+                x=right_x,
+                y=y,
+                body_angle=math.pi,
+            )
+        )
+
+    return spawns

--- a/core/minigames/soccer/match.py
+++ b/core/minigames/soccer/match.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from core.code_pool.safety import fork_rng
 from core.minigames.soccer.engine import RCSSLiteEngine, RCSSVector
+from core.minigames.soccer.formation import build_default_formation
 from core.minigames.soccer.params import SOCCER_CANONICAL_PARAMS
 from core.minigames.soccer.participant import create_participants
 from core.minigames.soccer.telemetry_collector import SoccerTelemetryCollector
@@ -146,22 +147,14 @@ class SoccerMatch:
 
     def _setup_formations(self, team_size: int) -> None:
         """Set up initial player formations."""
-        half_length = self._params.field_length / 2
-
-        for i in range(team_size):
-            # Left team - face right (0 radians)
-            left_id = f"left_{i + 1}"
-            x = -half_length / 2 + (i % 4) * 8 - 10
-            y = (i // 4 - team_size // 8) * 12
-            self._initial_positions[left_id] = (x, y, 0.0)
-            self._engine.add_player(left_id, "left", RCSSVector(x, y), body_angle=0.0)
-
-            # Right team - face left (pi radians)
-            right_id = f"right_{i + 1}"
-            x = half_length / 2 - (i % 4) * 8 + 10
-            y = (i // 4 - team_size // 8) * 12
-            self._initial_positions[right_id] = (x, y, math.pi)
-            self._engine.add_player(right_id, "right", RCSSVector(x, y), body_angle=math.pi)
+        for spec in build_default_formation(team_size=team_size, params=self._params):
+            self._initial_positions[spec.player_id] = (spec.x, spec.y, spec.body_angle)
+            self._engine.add_player(
+                spec.player_id,
+                spec.team,
+                RCSSVector(spec.x, spec.y),
+                body_angle=spec.body_angle,
+            )
 
     def step(self, num_steps: int = 1) -> dict[str, Any]:
         """Advance the match by one or more cycles.

--- a/tests/test_soccer_formation.py
+++ b/tests/test_soccer_formation.py
@@ -1,0 +1,82 @@
+import math
+
+
+def _expected_spawn_specs(team_size: int, *, field_length: float):
+    from core.minigames.soccer.formation import SpawnSpec
+
+    half_length = field_length / 2
+
+    specs = []
+    for i in range(team_size):
+        y = (i // 4 - team_size // 8) * 12
+
+        left_id = f"left_{i + 1}"
+        left_x = -half_length / 2 + (i % 4) * 8 - 10
+        specs.append(SpawnSpec(player_id=left_id, team="left", x=left_x, y=y, body_angle=0.0))
+
+        right_id = f"right_{i + 1}"
+        right_x = half_length / 2 - (i % 4) * 8 + 10
+        specs.append(
+            SpawnSpec(player_id=right_id, team="right", x=right_x, y=y, body_angle=math.pi)
+        )
+
+    return specs
+
+
+def test_build_default_formation_team_size_3_matches_previous_formula():
+    from core.minigames.soccer.formation import build_default_formation
+    from core.minigames.soccer.params import SOCCER_CANONICAL_PARAMS
+
+    spawns = build_default_formation(team_size=3, params=SOCCER_CANONICAL_PARAMS)
+    expected = _expected_spawn_specs(team_size=3, field_length=SOCCER_CANONICAL_PARAMS.field_length)
+
+    assert spawns == expected
+    assert {s.player_id for s in spawns} == {
+        "left_1",
+        "left_2",
+        "left_3",
+        "right_1",
+        "right_2",
+        "right_3",
+    }
+    assert {s.body_angle for s in spawns if s.team == "left"} == {0.0}
+    assert {s.body_angle for s in spawns if s.team == "right"} == {math.pi}
+
+
+def test_build_default_formation_team_size_8_matches_previous_formula():
+    from core.minigames.soccer.formation import build_default_formation
+    from core.minigames.soccer.params import SOCCER_CANONICAL_PARAMS
+
+    spawns = build_default_formation(team_size=8, params=SOCCER_CANONICAL_PARAMS)
+    expected = _expected_spawn_specs(team_size=8, field_length=SOCCER_CANONICAL_PARAMS.field_length)
+
+    assert spawns == expected
+    assert {s.player_id for s in spawns} == {
+        "left_1",
+        "left_2",
+        "left_3",
+        "left_4",
+        "left_5",
+        "left_6",
+        "left_7",
+        "left_8",
+        "right_1",
+        "right_2",
+        "right_3",
+        "right_4",
+        "right_5",
+        "right_6",
+        "right_7",
+        "right_8",
+    }
+    assert {s.body_angle for s in spawns if s.team == "left"} == {0.0}
+    assert {s.body_angle for s in spawns if s.team == "right"} == {math.pi}
+
+
+def test_build_default_formation_is_deterministic():
+    from core.minigames.soccer.formation import build_default_formation
+    from core.minigames.soccer.params import SOCCER_CANONICAL_PARAMS
+
+    assert build_default_formation(
+        team_size=8, params=SOCCER_CANONICAL_PARAMS
+    ) == build_default_formation(team_size=8, params=SOCCER_CANONICAL_PARAMS)


### PR DESCRIPTION
Extract duplicated formation spawn math into core/minigames/soccer/formation.py and use it from SoccerMatch and SoccerMatchRunner.

Adds regression tests for team_size=3 and team_size=8 to prevent drift.

Tests: python -m pytest -q tests/test_soccer_formation.py tests/test_soccer_system.py tests/test_soccer_eval.py tests/test_soccer_participant_adapter.py tests/test_soccer_shaped_rewards.py tests/test_determinism.py tests/test_soccer_match_runner_determinism.py