### PR TITLE
Harden mypy_gate against mypy installation/runtime failures

### DIFF
--- a/tests/test_mypy_gate.py
+++ b/tests/test_mypy_gate.py
@@ -68,7 +68,8 @@ class TestMypyGateFatalDetection:
     def test_clean_run_passes(self, tmp_path: Path):
         fake = _fake_run(stdout="Success: no issues found in 42 source files\n", returncode=0)
         baseline = tmp_path / "mypy_baseline.txt"
-        with patch("tools.mypy_gate.subprocess.run", fake), \
-             patch("tools.mypy_gate.BASELINE_PATH", baseline):
+        with patch("tools.mypy_gate.subprocess.run", fake), patch(
+            "tools.mypy_gate.BASELINE_PATH", baseline
+        ):
             rc = main(["--write-baseline"])
         assert rc == 0

--- a/tests/test_mypy_gate.py
+++ b/tests/test_mypy_gate.py
@@ -1,0 +1,76 @@
+"""Tests for tools/mypy_gate.py hardening against mypy-not-runnable."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.mypy_gate import main
+
+
+def _fake_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    """Return a factory that yields a fake subprocess.run result."""
+
+    def _run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0] if args else [],
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    return _run
+
+
+class TestMypyGateFatalDetection:
+    """Ensure the gate fails when mypy can't actually run."""
+
+    def test_no_module_named_mypy(self):
+        fake = _fake_run(
+            stderr="/usr/bin/python: No module named mypy\n",
+            returncode=1,
+        )
+        with patch("tools.mypy_gate.subprocess.run", fake):
+            rc = main([])
+        assert rc == 2
+
+    def test_module_not_found_error(self):
+        fake = _fake_run(
+            stderr="ModuleNotFoundError: No module named 'mypy'\n",
+            returncode=1,
+        )
+        with patch("tools.mypy_gate.subprocess.run", fake):
+            rc = main([])
+        assert rc == 2
+
+    def test_traceback_in_output(self):
+        fake = _fake_run(
+            stderr="Traceback (most recent call last):\n  File ...\nImportError: ...\n",
+            returncode=1,
+        )
+        with patch("tools.mypy_gate.subprocess.run", fake):
+            rc = main([])
+        assert rc == 2
+
+    def test_unexpected_returncode(self):
+        fake = _fake_run(stdout="", returncode=2)
+        with patch("tools.mypy_gate.subprocess.run", fake):
+            rc = main([])
+        assert rc == 2
+
+    def test_segfault_returncode(self):
+        fake = _fake_run(stdout="", returncode=-11)
+        with patch("tools.mypy_gate.subprocess.run", fake):
+            rc = main([])
+        assert rc == 2
+
+    def test_clean_run_passes(self, tmp_path: Path):
+        fake = _fake_run(stdout="Success: no issues found in 42 source files\n", returncode=0)
+        baseline = tmp_path / "mypy_baseline.txt"
+        with (
+            patch("tools.mypy_gate.subprocess.run", fake),
+            patch("tools.mypy_gate.BASELINE_PATH", baseline),
+        ):
+            rc = main(["--write-baseline"])
+        assert rc == 0

--- a/tests/test_mypy_gate.py
+++ b/tests/test_mypy_gate.py
@@ -68,9 +68,7 @@ class TestMypyGateFatalDetection:
     def test_clean_run_passes(self, tmp_path: Path):
         fake = _fake_run(stdout="Success: no issues found in 42 source files\n", returncode=0)
         baseline = tmp_path / "mypy_baseline.txt"
-        with (
-            patch("tools.mypy_gate.subprocess.run", fake),
-            patch("tools.mypy_gate.BASELINE_PATH", baseline),
-        ):
+        with patch("tools.mypy_gate.subprocess.run", fake), \
+             patch("tools.mypy_gate.BASELINE_PATH", baseline):
             rc = main(["--write-baseline"])
         assert rc == 0

--- a/tools/mypy_gate.py
+++ b/tools/mypy_gate.py
@@ -173,7 +173,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:  # noqa: UP045
     # Detect fatal failures (mypy not installed, import errors, crashes)
     for pattern in _FATAL_PATTERNS:
         if pattern in output:
-            print(f"mypy gate FAILED: mypy did not run successfully.")
+            print("mypy gate FAILED: mypy did not run successfully.")
             print(f"Detected fatal pattern: {pattern!r}")
             print(f"--- mypy output ---\n{output.strip()}")
             return 2


### PR DESCRIPTION
## Summary
Add detection and handling of fatal mypy failures (missing installation, import errors, crashes) in the mypy gate tool, returning a distinct exit code (2) when mypy cannot run successfully.

## Changes
- **Modified `_run_mypy()`**: Now returns both output and return code as a tuple, allowing callers to detect abnormal exits
- **Added fatal pattern detection**: Checks for common failure indicators:
  - "No module named mypy" (mypy not installed)
  - "ModuleNotFoundError" (import failures)
  - "Traceback" (runtime errors/crashes)
- **Added return code validation**: Detects unexpected return codes (anything other than 0 or 1), including segfaults and other crashes
- **Improved error reporting**: Prints diagnostic messages when fatal failures are detected
- **Added comprehensive test suite**: New `test_mypy_gate.py` with tests covering:
  - Missing mypy module detection
  - ModuleNotFoundError handling
  - Traceback detection
  - Unexpected return codes
  - Segfault detection (-11)
  - Clean run success case

## Implementation Details
The gate now distinguishes between:
- **Exit code 0**: Success (no type errors)
- **Exit code 1**: Type errors found (expected mypy behavior)
- **Exit code 2**: Fatal failure (mypy couldn't run, should be investigated)

This prevents masking of environment/installation issues that would otherwise silently pass the gate.

https://claude.ai/code/session_015vJ33n9wKJvgrLHVsUj6zD