### PR TITLE
Purge deprecated engine entity list APIs

### DIFF
--- a/core/minigames/soccer/league/provider.py
+++ b/core/minigames/soccer/league/provider.py
@@ -84,8 +84,6 @@ class LeagueTeamProvider:
             entity_manager = getattr(world_state, "entity_manager", None)
             if entity_manager is not None and hasattr(entity_manager, "get_fish"):
                 entities = list(entity_manager.get_fish())
-            elif hasattr(world_state, "get_fish_list"):
-                entities = list(world_state.get_fish_list())
 
             # Try to get world_id from state
             source_id = getattr(world_state, "world_id", "Tank")
@@ -144,11 +142,6 @@ class LeagueTeamProvider:
             entity_manager = getattr(world_state, "entity_manager", None)
             if entity_manager is not None and hasattr(entity_manager, "get_fish"):
                 for e in entity_manager.get_fish():
-                    eid = get_entity_id(e)
-                    if eid in entity_ids:
-                        found[eid] = e
-            elif hasattr(world_state, "get_fish_list"):
-                for e in world_state.get_fish_list():
                     eid = get_entity_id(e)
                     if eid in entity_ids:
                         found[eid] = e

--- a/core/minigames/soccer/scheduler.py
+++ b/core/minigames/soccer/scheduler.py
@@ -181,8 +181,6 @@ class SoccerMinigameScheduler:
         entity_manager = getattr(world_state, "entity_manager", None)
         if entity_manager is not None and hasattr(entity_manager, "get_fish"):
             fish_list = list(entity_manager.get_fish())
-        elif hasattr(world_state, "get_fish_list"):
-            fish_list = list(world_state.get_fish_list())
         alive = []
         for fish in fish_list:
             is_dead = getattr(fish, "is_dead", None)

--- a/core/reproduction_service.py
+++ b/core/reproduction_service.py
@@ -50,7 +50,7 @@ class ReproductionService:
 
     def update_frame(self, frame: int) -> ReproductionFrameStats:
         """Run reproduction logic for the current frame."""
-        fish_list = self._get_fish_list()
+        fish_list = self._get_fish_entities()
         self._update_cooldowns(fish_list)
 
         fish_count = len(fish_list)
@@ -191,18 +191,11 @@ class ReproductionService:
             "plant_asexual_reproductions": self._plant_asexual_reproductions,
         }
 
-    def _get_fish_list(self) -> list[Fish]:
+    def _get_fish_entities(self) -> list[Fish]:
         entity_manager = getattr(self._engine, "entity_manager", None)
         get_fish = getattr(entity_manager, "get_fish", None)
         if callable(get_fish):
             return cast("list[Fish]", get_fish())
-
-        get_fish_list = getattr(self._engine, "get_fish_list", None)
-        if callable(get_fish_list):
-            try:
-                return cast("list[Fish]", get_fish_list())
-            except RuntimeError:
-                pass
 
         from core.entities import Fish
 
@@ -341,7 +334,7 @@ class ReproductionService:
             return False
 
         # Try to clone from a surviving fish, using diversity-aware selection
-        fish_list = self._get_fish_list()
+        fish_list = self._get_fish_entities()
         if fish_list:
             parent = self._select_diverse_parent(fish_list)
             # Clone with light mutation to maintain diversity

--- a/core/simulation/engine.py
+++ b/core/simulation/engine.py
@@ -237,26 +237,6 @@ class SimulationEngine:
             return None
         return self.plant_manager.root_spot_manager
 
-    def get_fish_list(self) -> list[entities.Fish]:
-        """Removed helper.
-
-        Use ``engine.entity_manager.get_fish()``.
-        """
-        raise RuntimeError(
-            "SimulationEngine.get_fish_list() was removed; "
-            "use engine.entity_manager.get_fish() instead."
-        )
-
-    def get_food_list(self) -> list[entities.Food]:
-        """Removed helper.
-
-        Use ``engine.entity_manager.get_food()``.
-        """
-        raise RuntimeError(
-            "SimulationEngine.get_food_list() was removed; "
-            "use engine.entity_manager.get_food() instead."
-        )
-
     def cleanup_dying_fish(self) -> None:
         """Remove dying fish.
 

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -114,3 +114,43 @@ def test_no_tank_id_in_world_agnostic_code():
                     print(f"Skipping {file_path}: {e}")
 
     assert not violations, "Found tank_id in world-agnostic code:\n" + "\n".join(violations)
+
+
+def test_no_deprecated_engine_entity_list_apis() -> None:
+    """Ensure removed engine entity-list helper APIs do not reappear."""
+    import os
+
+    root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    search_dirs = ["backend", "core", "frontend/src", "scripts", "tests", "tools"]
+    forbidden_terms = [f"get_{name}_list(" for name in ("fish", "food")]
+
+    violations = []
+
+    for search_dir in search_dirs:
+        abs_search_dir = os.path.join(root_dir, search_dir)
+        if not os.path.exists(abs_search_dir):
+            continue
+
+        for root, dirs, files in os.walk(abs_search_dir):
+            if "__pycache__" in root or "node_modules" in root:
+                continue
+
+            for file in files:
+                if not (file.endswith(".py") or file.endswith(".ts") or file.endswith(".tsx")):
+                    continue
+
+                file_path = os.path.join(root, file)
+                rel_path = os.path.relpath(file_path, root_dir)
+
+                try:
+                    with open(file_path, encoding="utf-8") as f:
+                        content = f.read()
+                except Exception as e:
+                    print(f"Skipping {file_path}: {e}")
+                    continue
+
+                for term in forbidden_terms:
+                    if term in content:
+                        violations.append(f"{rel_path}: Contains removed API '{term}'")
+
+    assert not violations, "Found removed engine entity-list APIs:\n" + "\n".join(violations)

--- a/tests/test_reproduction_credits.py
+++ b/tests/test_reproduction_credits.py
@@ -51,6 +51,7 @@ class _DummyBaby:
 class _DummyEngine:
     def __init__(self, fish_list: list[_DummyFish]) -> None:
         self._fish_list = list(fish_list)
+        self.entity_manager = self
         self.rng = random.Random(1)
         self.config = SimulationConfig.headless_fast()
         self.config.soccer.enabled = True
@@ -60,7 +61,7 @@ class _DummyEngine:
         self.lifecycle_system = None
         self.spawned: list[object] = []
 
-    def get_fish_list(self):
+    def get_fish(self):
         return list(self._fish_list)
 
     def request_spawn(self, entity, **_):

--- a/tests/test_soccer_league_runtime.py
+++ b/tests/test_soccer_league_runtime.py
@@ -32,10 +32,11 @@ class DummyFish:
 class DummyWorld:
     def __init__(self, fish: list[DummyFish]) -> None:
         self._fish = fish
+        self.entity_manager = self
         self.genome_code_pool = None
         self.world_id = "Tank1"
 
-    def get_fish_list(self) -> list[DummyFish]:
+    def get_fish(self) -> list[DummyFish]:
         return list(self._fish)
 
 

--- a/tests/test_soccer_scheduler.py
+++ b/tests/test_soccer_scheduler.py
@@ -41,9 +41,10 @@ class DummyEngine:
 
     def __init__(self, fish: Sequence[DummyFish]) -> None:
         self._fish = list(fish)
+        self.entity_manager = self
         self.genome_code_pool = None
 
-    def get_fish_list(self) -> list[DummyFish]:
+    def get_fish(self) -> list[DummyFish]:
         return list(self._fish)
 
 

--- a/tests/test_soccer_system.py
+++ b/tests/test_soccer_system.py
@@ -85,11 +85,7 @@ class TestSoccerSystemEnergyAccounting:
         fish = MockFish(fish_id=42, x=100, y=100, team="A")
 
         mock_engine.entities_list = [fish]
-
-        def get_fish_list():
-            return [fish]
-
-        mock_engine.get_fish_list = get_fish_list
+        mock_engine.entity_manager.get_fish.return_value = [fish]
 
         system = SoccerSystem(mock_engine)
         system.ball = ball


### PR DESCRIPTION
## Summary
- remove the remaining runtime uses of `get_fish_list()` / `get_food_list()` and switch the affected codepaths to `entity_manager.get_fish()`
- delete the removed `SimulationEngine.get_fish_list()` / `get_food_list()` methods entirely
- add a guardrail test so those removed API names cannot reappear in active code

## Validation
- `rg "get_fish_list\\(|get_food_list\\(" -n backend core frontend/src scripts tests tools`
- `.\.venv\Scripts\python.exe -m pytest tests/test_guardrails.py tests/test_determinism.py tests/test_reproduction_credits.py tests/test_soccer_system.py tests/test_soccer_scheduler.py tests/test_soccer_league_runtime.py -q`
- `.\.venv\Scripts\python.exe -m pytest tests/test_determinism.py -W error::DeprecationWarning -q`
- `.\.venv\Scripts\python.exe -m ruff check core\reproduction_service.py core\minigames\soccer\league\provider.py core\minigames\soccer\scheduler.py core\simulation\engine.py tests\test_reproduction_credits.py tests\test_soccer_system.py tests\test_soccer_scheduler.py tests\test_soccer_league_runtime.py tests\test_guardrails.py`
- `.\.venv\Scripts\python.exe -m black --check core\reproduction_service.py core\minigames\soccer\league\provider.py core\minigames\soccer\scheduler.py core\simulation\engine.py tests\test_reproduction_credits.py tests\test_soccer_system.py tests\test_soccer_scheduler.py tests\test_soccer_league_runtime.py tests\test_guardrails.py`