### PR TITLE
fix: prevent IP spoofing in rate limiting and enforce WebSocket limiter

### DIFF
--- a/backend/routers/websocket.py
+++ b/backend/routers/websocket.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from backend.security import websocket_limiter
+
 if TYPE_CHECKING:
     from backend.world_broadcast_adapter import WorldBroadcastAdapter
     from backend.world_manager import WorldManager
@@ -17,11 +19,9 @@ logger = logging.getLogger(__name__)
 
 
 def _get_client_ip(websocket: WebSocket) -> str:
-    """Extract client IP from WebSocket connection."""
+    """Extract client IP from WebSocket connection (host only, no port)."""
     client = websocket.client
-    if client:
-        return f"{client.host}:{client.port}"
-    return "unknown"
+    return client.host if client else "unknown"
 
 
 async def _handle_websocket_for_adapter(
@@ -157,6 +157,17 @@ async def _handle_websocket_for_world(
         await websocket.close(code=4004)
         return
 
+    # Enforce per-IP WebSocket connection limit before accepting.
+    client_ip = _get_client_ip(websocket)
+    if not websocket_limiter.connect(client_ip):
+        logger.warning(
+            "World %s: WebSocket connection limit reached for %s, rejecting",
+            world_id[:8],
+            client_ip,
+        )
+        await websocket.close(code=4029)  # 4029 = Too Many Connections (app-defined)
+        return
+
     # Register client with world manager for tracking
     world_manager.add_client(world_id, websocket)
 
@@ -164,6 +175,7 @@ async def _handle_websocket_for_world(
         await _handle_websocket_for_adapter(websocket, adapter, world_id)
     finally:
         world_manager.remove_client(world_id, websocket)
+        websocket_limiter.disconnect(client_ip)
 
 
 def setup_router(

--- a/backend/security.py
+++ b/backend/security.py
@@ -25,6 +25,13 @@ RATE_LIMIT_WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))  # window in secon
 # Whitelist for internal/development IPs
 IP_WHITELIST = set(filter(None, os.getenv("IP_WHITELIST", "127.0.0.1,::1").split(",")))
 
+# IPs of trusted reverse proxies (e.g. nginx, load balancer).
+# Only connections arriving from one of these IPs may influence the resolved
+# client address via X-Forwarded-For / X-Real-IP.  Leave empty (the default)
+# when not running behind a proxy — doing so prevents clients from spoofing
+# their identity and bypassing per-IP rate limits.
+TRUSTED_PROXIES = set(filter(None, os.getenv("TRUSTED_PROXIES", "").split(",")))
+
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
     """Simple in-memory rate limiting middleware.
@@ -39,19 +46,23 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self.request_counts: dict[str, list] = defaultdict(list)
 
     def _get_client_ip(self, request: Request) -> str:
-        """Extract client IP, considering proxy headers."""
-        # Check for proxy headers (when behind nginx/load balancer)
-        forwarded_for = request.headers.get("X-Forwarded-For")
-        if forwarded_for:
-            # Get the first IP in the chain (original client)
-            return forwarded_for.split(",")[0].strip()
+        """Extract client IP.
 
-        real_ip = request.headers.get("X-Real-IP")
-        if real_ip:
-            return real_ip
+        Proxy headers (X-Forwarded-For, X-Real-IP) are only trusted when the
+        direct connection arrives from a TRUSTED_PROXIES address, preventing
+        clients from spoofing their IP to bypass rate limiting.
+        """
+        direct_ip = request.client.host if request.client else None
 
-        # Fall back to direct connection IP
-        return request.client.host if request.client else "unknown"
+        if direct_ip in TRUSTED_PROXIES:
+            forwarded_for = request.headers.get("X-Forwarded-For")
+            if forwarded_for:
+                return forwarded_for.split(",")[0].strip()
+            real_ip = request.headers.get("X-Real-IP")
+            if real_ip:
+                return real_ip
+
+        return direct_ip or "unknown"
 
     def _is_rate_limited(self, client_ip: str) -> bool:
         """Check if client has exceeded rate limit."""
@@ -174,12 +185,16 @@ def rate_limit(max_requests: int = 10, window_seconds: int = 60):
             if not RATE_LIMIT_ENABLED:
                 return await func(request, *args, **kwargs)
 
-            # Get client IP
-            client_ip = request.headers.get("X-Forwarded-For", "").split(",")[0].strip()
-            if not client_ip:
-                client_ip = request.headers.get("X-Real-IP", "")
-            if not client_ip and request.client:
-                client_ip = request.client.host
+            # Get client IP — only honour proxy headers from trusted proxies.
+            direct_ip = request.client.host if request.client else "unknown"
+            if direct_ip in TRUSTED_PROXIES:
+                client_ip = request.headers.get("X-Forwarded-For", "").split(",")[0].strip()
+                if not client_ip:
+                    client_ip = request.headers.get("X-Real-IP", "")
+                if not client_ip:
+                    client_ip = direct_ip
+            else:
+                client_ip = direct_ip
 
             # Whitelist check
             if client_ip in IP_WHITELIST:


### PR DESCRIPTION
- Trust X-Forwarded-For/X-Real-IP only when the direct TCP connection arrives from a TRUSTED_PROXIES address (new env var, default empty). Previously any caller could set these headers to claim a different IP and bypass per-IP throttling in both RateLimitMiddleware and the @rate_limit decorator.
- Wire websocket_limiter into _handle_websocket_for_world: connections are now checked and registered before accept(), rejected with close code 4029 when the per-IP limit is hit, and unregistered in finally. Previously WebSocketLimiter was declared but never called.
- Fix _get_client_ip in websocket.py to return host only (not host:port) so the limiter's per-IP tracking is consistent.