### PR TITLE
Fix world deletion cleanup for autosave and broadcast tasks

### DIFF
--- a/backend/auto_save_service.py
+++ b/backend/auto_save_service.py
@@ -7,6 +7,7 @@ server restarts.
 
 import asyncio
 import logging
+from collections.abc import Coroutine
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -34,6 +35,34 @@ class AutoSaveService:
         self._world_manager = world_manager
         self._tasks: dict[str, asyncio.Task] = {}
         self._running = False
+
+    def register_world(self, instance: "WorldInstance") -> None:
+        """Enroll a newly created persistent world in auto-save.
+
+        Args:
+            instance: The created world instance
+        """
+        if not self._running or not instance.persistent:
+            return
+
+        self._schedule_task(
+            self._start_world_autosave(instance),
+            name=f"autosave_start_{instance.world_id[:8]}",
+        )
+
+    def unregister_world(self, world_id: str) -> None:
+        """Remove a deleted world from auto-save tracking.
+
+        Args:
+            world_id: The deleted world ID
+        """
+        if not self._running:
+            return
+
+        self._schedule_task(
+            self.stop_world_autosave(world_id),
+            name=f"autosave_stop_{world_id[:8]}",
+        )
 
     async def start(self) -> None:
         """Start the auto-save service."""
@@ -87,6 +116,32 @@ class AutoSaveService:
             f"Started auto-save for world {world_id[:8]} "
             f"(interval: {DEFAULT_AUTO_SAVE_INTERVAL}s)"
         )
+
+    def _schedule_task(self, coro: Coroutine[object, object, object], *, name: str) -> None:
+        """Schedule a background auto-save operation on the active loop."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug("No running event loop available for task %s", name)
+            return
+
+        task = loop.create_task(coro, name=name)
+        task.add_done_callback(self._handle_background_task)
+
+    @staticmethod
+    def _handle_background_task(task: asyncio.Task) -> None:
+        """Log unhandled exceptions from background enrollment tasks."""
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            logger.debug("Background auto-save task %s was cancelled", task.get_name())
+        except Exception as exc:
+            logger.error(
+                "Unhandled exception in auto-save task %s: %s",
+                task.get_name(),
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     async def stop_world_autosave(self, world_id: str) -> None:
         """Stop auto-save task for a specific world.

--- a/backend/routers/worlds.py
+++ b/backend/routers/worlds.py
@@ -225,7 +225,7 @@ def setup_worlds_router(world_manager: WorldManager) -> APIRouter:
         Returns:
             Success message or 404 if not found
         """
-        if world_manager.delete_world(world_id):
+        if await world_manager.delete_world_async(world_id):
             return JSONResponse({"message": f"World {world_id} deleted"})
         else:
             raise HTTPException(status_code=404, detail=f"World not found: {world_id}")

--- a/backend/startup_manager.py
+++ b/backend/startup_manager.py
@@ -398,6 +398,10 @@ class StartupManager:
         logger.info("Starting auto-save service...")
         try:
             self.auto_save_service = AutoSaveService(self.world_manager)
+            self.world_manager.set_world_lifecycle_callbacks(
+                created_callback=self.auto_save_service.register_world,
+                deleted_callback=self.auto_save_service.unregister_world,
+            )
             await self.auto_save_service.start()
             logger.info("Auto-save service started")
         except Exception as e:

--- a/backend/startup_manager.py
+++ b/backend/startup_manager.py
@@ -400,7 +400,7 @@ class StartupManager:
             self.auto_save_service = AutoSaveService(self.world_manager)
             self.world_manager.set_world_lifecycle_callbacks(
                 created_callback=self.auto_save_service.register_world,
-                deleted_callback=self.auto_save_service.unregister_world,
+                deleted_callback=self.auto_save_service.stop_world_autosave,
             )
             await self.auto_save_service.start()
             logger.info("Auto-save service started")

--- a/backend/world_manager.py
+++ b/backend/world_manager.py
@@ -10,9 +10,10 @@ WorldManager → WorldInstance → SimulationRunner → Broadcast
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import uuid
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -31,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 # Type alias for broadcast callbacks
 BroadcastCallback = Callable[..., Coroutine[Any, Any, Any]]
+LifecycleWorldCreatedCallback = Callable[["WorldInstance"], object]
+LifecycleWorldDeletedCallback = Callable[[str], object]
 
 
 @dataclass
@@ -115,8 +118,8 @@ class WorldManager:
         self._default_world_id: str | None = None
         self._start_broadcast_callback: BroadcastCallback | None = None
         self._stop_broadcast_callback: BroadcastCallback | None = None
-        self._world_created_callback: Callable[[WorldInstance], None] | None = None
-        self._world_deleted_callback: Callable[[str], None] | None = None
+        self._world_created_callback: LifecycleWorldCreatedCallback | None = None
+        self._world_deleted_callback: LifecycleWorldDeletedCallback | None = None
         self.connection_manager: Any = None
 
     def set_connection_manager(self, connection_manager: Any) -> None:
@@ -140,12 +143,76 @@ class WorldManager:
     def set_world_lifecycle_callbacks(
         self,
         *,
-        created_callback: Callable[[WorldInstance], None] | None = None,
-        deleted_callback: Callable[[str], None] | None = None,
+        created_callback: LifecycleWorldCreatedCallback | None = None,
+        deleted_callback: LifecycleWorldDeletedCallback | None = None,
     ) -> None:
         """Set callbacks for world creation and deletion events."""
         self._world_created_callback = created_callback
         self._world_deleted_callback = deleted_callback
+
+    @staticmethod
+    def _handle_background_task(task: asyncio.Task[Any]) -> None:
+        """Log unhandled exceptions from scheduled lifecycle tasks."""
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            logger.debug("Background world lifecycle task %s was cancelled", task.get_name())
+        except Exception as exc:
+            logger.error(
+                "Unhandled exception in world lifecycle task %s: %s",
+                task.get_name(),
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+
+    def _schedule_awaitable(self, result: object, *, task_name: str) -> None:
+        """Schedule an awaitable lifecycle result on the current event loop."""
+        if not inspect.isawaitable(result):
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug("No running event loop available for task %s", task_name)
+            close = getattr(result, "close", None)
+            if callable(close):
+                close()
+            return
+
+        task = loop.create_task(result, name=task_name)
+        task.add_done_callback(self._handle_background_task)
+
+    def _collect_world_cleanup(
+        self,
+        instance: WorldInstance,
+    ) -> list[Awaitable[object]]:
+        """Stop the runner and collect any async cleanup operations for a world."""
+        cleanup_tasks: list[Awaitable[object]] = []
+
+        if hasattr(instance.runner, "stop"):
+            instance.runner.stop()
+
+        if self._stop_broadcast_callback:
+            cleanup_tasks.append(self._stop_broadcast_callback(instance.world_id))
+
+        if self._world_deleted_callback:
+            callback_result = self._world_deleted_callback(instance.world_id)
+            if inspect.isawaitable(callback_result):
+                cleanup_tasks.append(callback_result)
+
+        return cleanup_tasks
+
+    def _finalize_world_deletion(self, instance: WorldInstance) -> None:
+        """Apply in-memory cleanup after a world has been removed."""
+        world_id = instance.world_id
+
+        if self._default_world_id == world_id:
+            self._default_world_id = next(iter(self._worlds), None)
+
+        if self.connection_manager:
+            self.connection_manager.validate_connections(list(self._worlds.keys()))
+
+        logger.info("Deleted world: %s (%s)", world_id[:8], instance.world_type)
 
     def create_world(
         self,
@@ -355,7 +422,11 @@ class WorldManager:
                     )
 
         if self._world_created_callback:
-            self._world_created_callback(instance)
+            callback_result = self._world_created_callback(instance)
+            self._schedule_awaitable(
+                callback_result,
+                task_name=f"world_created_{world_id[:8]}",
+            )
 
     def get_world(self, world_id: str) -> WorldInstance | None:
         """Get a world instance by ID.
@@ -440,8 +511,8 @@ class WorldManager:
 
         return statuses
 
-    def delete_world(self, world_id: str) -> bool:
-        """Delete a world instance.
+    async def delete_world_async(self, world_id: str) -> bool:
+        """Delete a world instance and await per-world background cleanup.
 
         Args:
             world_id: The world ID to delete
@@ -450,41 +521,43 @@ class WorldManager:
             True if deleted, False if not found
         """
         instance = self._worlds.pop(world_id, None)
+        if instance is None:
+            return False
 
-        if instance is not None:
-            # Stop the runner if it's a SimulationRunner
-            if hasattr(instance.runner, "stop"):
-                instance.runner.stop()
+        cleanup_tasks = self._collect_world_cleanup(instance)
+        self._finalize_world_deletion(instance)
 
-            # Stop the broadcast task for this world
-            if self._stop_broadcast_callback:
-                try:
-                    loop = asyncio.get_running_loop()
-                    loop.create_task(
-                        self._stop_broadcast_callback(world_id),
-                        name=f"broadcast_stop_{world_id[:8]}",
-                    )
-                except RuntimeError:
-                    logger.debug(
-                        "No event loop available, broadcast task for %s may not be stopped",
-                        world_id[:8],
-                    )
+        for cleanup_task in cleanup_tasks:
+            await cleanup_task
 
-            # Update default world if needed
-            if self._default_world_id == world_id:
-                self._default_world_id = next(iter(self._worlds), None)
+        return True
 
-            # Cleanup connections
-            if self.connection_manager:
-                self.connection_manager.validate_connections(list(self._worlds.keys()))
+    def delete_world(self, world_id: str) -> bool:
+        """Delete a world instance.
 
-            if self._world_deleted_callback:
-                self._world_deleted_callback(world_id)
+        This synchronous compatibility wrapper performs immediate in-memory
+        deletion and schedules any async cleanup on the active event loop.
 
-            logger.info("Deleted world: %s (%s)", world_id[:8], instance.world_type)
-            return True
+        Args:
+            world_id: The world ID to delete
 
-        return False
+        Returns:
+            True if deleted, False if not found
+        """
+        instance = self._worlds.pop(world_id, None)
+        if instance is None:
+            return False
+
+        cleanup_tasks = self._collect_world_cleanup(instance)
+        self._finalize_world_deletion(instance)
+
+        for index, cleanup_task in enumerate(cleanup_tasks):
+            self._schedule_awaitable(
+                cleanup_task,
+                task_name=f"world_delete_{world_id[:8]}_{index}",
+            )
+
+        return True
 
     def step_world(self, world_id: str, actions: dict[str, Any] | None = None) -> bool:
         """Step a world by one frame.

--- a/backend/world_manager.py
+++ b/backend/world_manager.py
@@ -115,6 +115,8 @@ class WorldManager:
         self._default_world_id: str | None = None
         self._start_broadcast_callback: BroadcastCallback | None = None
         self._stop_broadcast_callback: BroadcastCallback | None = None
+        self._world_created_callback: Callable[[WorldInstance], None] | None = None
+        self._world_deleted_callback: Callable[[str], None] | None = None
         self.connection_manager: Any = None
 
     def set_connection_manager(self, connection_manager: Any) -> None:
@@ -134,6 +136,16 @@ class WorldManager:
         """Set callbacks for starting/stopping broadcasts."""
         self._start_broadcast_callback = start_callback
         self._stop_broadcast_callback = stop_callback
+
+    def set_world_lifecycle_callbacks(
+        self,
+        *,
+        created_callback: Callable[[WorldInstance], None] | None = None,
+        deleted_callback: Callable[[str], None] | None = None,
+    ) -> None:
+        """Set callbacks for world creation and deletion events."""
+        self._world_created_callback = created_callback
+        self._world_deleted_callback = deleted_callback
 
     def create_world(
         self,
@@ -256,38 +268,7 @@ class WorldManager:
             description=description,
         )
 
-        # Store in unified worlds dict
-        self._worlds[world_id] = instance
-
-        # Set as default if first world
-        if self._default_world_id is None:
-            self._default_world_id = world_id
-
-        logger.info(
-            "Created %s world: %s (%s)",
-            world_type,
-            world_id[:8],
-            name,
-        )
-
-        # Start broadcast task for newly created tank worlds
-        if self._start_broadcast_callback:
-            adapter = self.get_broadcast_adapter(world_id)
-            if adapter:
-                try:
-                    loop = asyncio.get_running_loop()
-                    loop.create_task(
-                        self._start_broadcast_callback(adapter, world_id),
-                        name=f"broadcast_start_{world_id[:8]}",
-                    )
-                    logger.info("Scheduled broadcast task for world %s", world_id[:8])
-                except RuntimeError:
-                    # No running event loop - broadcast will be started when first client connects
-                    logger.debug(
-                        "No event loop available, broadcast task for %s will start on connection",
-                        world_id[:8],
-                    )
-
+        self._finalize_world_creation(instance)
         return instance
 
     def _create_generic_world(
@@ -334,6 +315,13 @@ class WorldManager:
             description=description,
         )
 
+        self._finalize_world_creation(instance)
+        return instance
+
+    def _finalize_world_creation(self, instance: WorldInstance) -> None:
+        """Store a new world instance and trigger lifecycle callbacks."""
+        world_id = instance.world_id
+
         # Store in unified worlds dict
         self._worlds[world_id] = instance
 
@@ -343,12 +331,12 @@ class WorldManager:
 
         logger.info(
             "Created %s world: %s (%s)",
-            world_type,
+            instance.world_type,
             world_id[:8],
-            name,
+            instance.name,
         )
 
-        # Start broadcast task for newly created generic worlds
+        # Start broadcast task for newly created worlds
         if self._start_broadcast_callback:
             adapter = self.get_broadcast_adapter(world_id)
             if adapter:
@@ -358,7 +346,7 @@ class WorldManager:
                         self._start_broadcast_callback(adapter, world_id),
                         name=f"broadcast_start_{world_id[:8]}",
                     )
-                    logger.info("Scheduled broadcast task for generic world %s", world_id[:8])
+                    logger.info("Scheduled broadcast task for world %s", world_id[:8])
                 except RuntimeError:
                     # No running event loop - broadcast will be started when first client connects
                     logger.debug(
@@ -366,7 +354,8 @@ class WorldManager:
                         world_id[:8],
                     )
 
-        return instance
+        if self._world_created_callback:
+            self._world_created_callback(instance)
 
     def get_world(self, world_id: str) -> WorldInstance | None:
         """Get a world instance by ID.
@@ -474,6 +463,9 @@ class WorldManager:
             # Cleanup connections
             if self.connection_manager:
                 self.connection_manager.validate_connections(list(self._worlds.keys()))
+
+            if self._world_deleted_callback:
+                self._world_deleted_callback(world_id)
 
             logger.info("Deleted world: %s (%s)", world_id[:8], instance.world_type)
             return True

--- a/backend/world_manager.py
+++ b/backend/world_manager.py
@@ -213,6 +213,7 @@ class WorldManager:
             self.connection_manager.validate_connections(list(self._worlds.keys()))
 
         logger.info("Deleted world: %s (%s)", world_id[:8], instance.world_type)
+
     def create_world(
         self,
         world_type: str,

--- a/backend/world_manager.py
+++ b/backend/world_manager.py
@@ -456,6 +456,20 @@ class WorldManager:
             if hasattr(instance.runner, "stop"):
                 instance.runner.stop()
 
+            # Stop the broadcast task for this world
+            if self._stop_broadcast_callback:
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(
+                        self._stop_broadcast_callback(world_id),
+                        name=f"broadcast_stop_{world_id[:8]}",
+                    )
+                except RuntimeError:
+                    logger.debug(
+                        "No event loop available, broadcast task for %s may not be stopped",
+                        world_id[:8],
+                    )
+
             # Update default world if needed
             if self._default_world_id == world_id:
                 self._default_world_id = next(iter(self._worlds), None)

--- a/tests/test_auto_save_service.py
+++ b/tests/test_auto_save_service.py
@@ -90,8 +90,7 @@ async def test_deleted_world_is_removed_from_autosave(startup_manager: StartupMa
         await asyncio.sleep(0.05)
         assert instance.world_id in startup_manager.auto_save_service._tasks
 
-        assert startup_manager.world_manager.delete_world(instance.world_id) is True
-        await asyncio.sleep(0.05)
+        assert await startup_manager.world_manager.delete_world_async(instance.world_id) is True
 
         assert instance.world_id not in startup_manager.auto_save_service._tasks
     finally:
@@ -119,8 +118,7 @@ async def test_deleted_world_broadcast_task_is_stopped() -> None:
             "broadcast task should exist after world creation"
         )
 
-        assert sm.world_manager.delete_world(world_id) is True
-        await asyncio.sleep(0.05)
+        assert await sm.world_manager.delete_world_async(world_id) is True
 
         assert not any(k[0] == world_id for k in _broadcast_tasks), (
             "broadcast task should be gone after world deletion"

--- a/tests/test_auto_save_service.py
+++ b/tests/test_auto_save_service.py
@@ -45,6 +45,8 @@ def _make_startup_manager(*, with_broadcast: bool = False) -> StartupManager:
 def startup_manager() -> StartupManager:
     """Create a startup manager with mocked external services."""
     return _make_startup_manager()
+
+
 @pytest.mark.asyncio
 async def test_new_persistent_world_is_enrolled_in_autosave(
     startup_manager: StartupManager,
@@ -112,14 +114,14 @@ async def test_deleted_world_broadcast_task_is_stopped() -> None:
         world_id = instance.world_id
 
         await asyncio.sleep(0.05)
-        assert any(k[0] == world_id for k in _broadcast_tasks), (
-            "broadcast task should exist after world creation"
-        )
+        assert any(
+            k[0] == world_id for k in _broadcast_tasks
+        ), "broadcast task should exist after world creation"
 
         assert await sm.world_manager.delete_world_async(world_id) is True
 
-        assert not any(k[0] == world_id for k in _broadcast_tasks), (
-            "broadcast task should be gone after world deletion"
-        )
+        assert not any(
+            k[0] == world_id for k in _broadcast_tasks
+        ), "broadcast task should be gone after world deletion"
     finally:
         await sm.shutdown()

--- a/tests/test_auto_save_service.py
+++ b/tests/test_auto_save_service.py
@@ -7,6 +7,11 @@ import pytest
 
 pytest.importorskip("pytest_asyncio")
 
+from backend.broadcast import (
+    _broadcast_tasks,
+    start_broadcast_for_world,
+    stop_broadcast_for_world,
+)
 from backend.connection_manager import ConnectionManager
 from backend.discovery_service import DiscoveryService
 from backend.server_client import ServerClient
@@ -14,9 +19,7 @@ from backend.startup_manager import StartupManager
 from backend.world_manager import WorldManager
 
 
-@pytest.fixture
-def startup_manager() -> StartupManager:
-    """Create a startup manager with mocked external services."""
+def _make_startup_manager(*, with_broadcast: bool = False) -> StartupManager:
     connection_manager = MagicMock(spec=ConnectionManager)
 
     discovery_service = MagicMock(spec=DiscoveryService)
@@ -33,7 +36,15 @@ def startup_manager() -> StartupManager:
         discovery_service=discovery_service,
         server_client=server_client,
         server_id="test-server",
+        start_broadcast_callback=start_broadcast_for_world if with_broadcast else None,
+        stop_broadcast_callback=stop_broadcast_for_world if with_broadcast else None,
     )
+
+
+@pytest.fixture
+def startup_manager() -> StartupManager:
+    """Create a startup manager with mocked external services."""
+    return _make_startup_manager()
 
 
 @pytest.mark.asyncio
@@ -85,3 +96,34 @@ async def test_deleted_world_is_removed_from_autosave(startup_manager: StartupMa
         assert instance.world_id not in startup_manager.auto_save_service._tasks
     finally:
         await startup_manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_deleted_world_broadcast_task_is_stopped() -> None:
+    """Deleting a world should cancel its broadcast task."""
+    sm = _make_startup_manager(with_broadcast=True)
+    await sm.initialize(MagicMock(return_value={}))
+
+    try:
+        instance = sm.world_manager.create_world(
+            world_type="petri",
+            name="Broadcast Test World",
+            persistent=False,
+            seed=42,
+            start_paused=True,
+        )
+        world_id = instance.world_id
+
+        await asyncio.sleep(0.05)
+        assert any(k[0] == world_id for k in _broadcast_tasks), (
+            "broadcast task should exist after world creation"
+        )
+
+        assert sm.world_manager.delete_world(world_id) is True
+        await asyncio.sleep(0.05)
+
+        assert not any(k[0] == world_id for k in _broadcast_tasks), (
+            "broadcast task should be gone after world deletion"
+        )
+    finally:
+        await sm.shutdown()

--- a/tests/test_auto_save_service.py
+++ b/tests/test_auto_save_service.py
@@ -1,0 +1,87 @@
+"""Tests for runtime auto-save enrollment of persistent worlds."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("pytest_asyncio")
+
+from backend.connection_manager import ConnectionManager
+from backend.discovery_service import DiscoveryService
+from backend.server_client import ServerClient
+from backend.startup_manager import StartupManager
+from backend.world_manager import WorldManager
+
+
+@pytest.fixture
+def startup_manager() -> StartupManager:
+    """Create a startup manager with mocked external services."""
+    connection_manager = MagicMock(spec=ConnectionManager)
+
+    discovery_service = MagicMock(spec=DiscoveryService)
+    discovery_service.start = AsyncMock()
+    discovery_service.stop = AsyncMock()
+
+    server_client = MagicMock(spec=ServerClient)
+    server_client.start = AsyncMock()
+    server_client.close = AsyncMock()
+
+    return StartupManager(
+        world_manager=WorldManager(),
+        connection_manager=connection_manager,
+        discovery_service=discovery_service,
+        server_client=server_client,
+        server_id="test-server",
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_persistent_world_is_enrolled_in_autosave(
+    startup_manager: StartupManager,
+) -> None:
+    """Persistent worlds created after startup should get their own auto-save loop."""
+    await startup_manager.initialize(MagicMock(return_value={}))
+
+    try:
+        assert startup_manager.auto_save_service is not None
+
+        instance = startup_manager.world_manager.create_world(
+            world_type="petri",
+            name="Late Persistent World",
+            persistent=True,
+            seed=42,
+            start_paused=True,
+        )
+
+        await asyncio.sleep(0.05)
+
+        assert instance.world_id in startup_manager.auto_save_service._tasks
+    finally:
+        await startup_manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_deleted_world_is_removed_from_autosave(startup_manager: StartupManager) -> None:
+    """Deleting a world should cancel its dedicated auto-save task."""
+    await startup_manager.initialize(MagicMock(return_value={}))
+
+    try:
+        assert startup_manager.auto_save_service is not None
+
+        instance = startup_manager.world_manager.create_world(
+            world_type="petri",
+            name="Temporary Persistent World",
+            persistent=True,
+            seed=42,
+            start_paused=True,
+        )
+        await asyncio.sleep(0.05)
+        assert instance.world_id in startup_manager.auto_save_service._tasks
+
+        assert startup_manager.world_manager.delete_world(instance.world_id) is True
+        await asyncio.sleep(0.05)
+
+        assert instance.world_id not in startup_manager.auto_save_service._tasks
+    finally:
+        await startup_manager.shutdown()

--- a/tests/test_world_manager_broadcast.py
+++ b/tests/test_world_manager_broadcast.py
@@ -1,6 +1,9 @@
 """Tests for WorldManager broadcast scheduling."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 class TestWorldManagerBroadcastScheduling:
@@ -77,3 +80,32 @@ class TestWorldManagerBroadcastScheduling:
 
         assert instance is not None
         assert instance.world_type == "petri"
+
+    @pytest.mark.asyncio
+    async def test_delete_world_async_waits_for_broadcast_shutdown(self) -> None:
+        """Async deletion should not return until broadcast shutdown finishes."""
+        from backend.world_manager import WorldManager
+
+        manager = WorldManager()
+        mock_start = AsyncMock()
+        stop_started = asyncio.Event()
+        allow_stop = asyncio.Event()
+
+        async def mock_stop(_world_id: str) -> None:
+            stop_started.set()
+            await allow_stop.wait()
+
+        manager.set_broadcast_callbacks(mock_start, mock_stop)
+        instance = manager.create_world(
+            world_type="petri",
+            name="Delete Test Petri",
+            seed=42,
+        )
+
+        delete_task = asyncio.create_task(manager.delete_world_async(instance.world_id))
+        await stop_started.wait()
+
+        assert not delete_task.done()
+
+        allow_stop.set()
+        assert await delete_task is True

--- a/tests/test_worlds_api.py
+++ b/tests/test_worlds_api.py
@@ -4,10 +4,14 @@ This module tests the /api/worlds and /api/world_types endpoints
 for creating and managing worlds of different types.
 """
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from backend.app_factory import AppContext, create_app
+from backend.routers.worlds import setup_worlds_router
 from backend.world_manager import WorldManager
 
 
@@ -174,6 +178,21 @@ class TestWorldOperations:
         # Verify it's gone
         get_response = test_client.get(f"/api/worlds/{world_id}")
         assert get_response.status_code == 404
+
+    def test_delete_world_endpoint_awaits_async_cleanup(self):
+        """The delete endpoint should await world cleanup before returning."""
+        world_manager = MagicMock(spec=WorldManager)
+        world_manager.delete_world_async = AsyncMock(return_value=True)
+
+        app = FastAPI()
+        app.include_router(setup_worlds_router(world_manager))
+
+        with TestClient(app) as client:
+            response = client.delete("/api/worlds/test-world")
+
+        assert response.status_code == 200
+        world_manager.delete_world_async.assert_awaited_once_with("test-world")
+        world_manager.delete_world.assert_not_called()
 
     def test_get_nonexistent_world_returns_404(self, test_client):
         """Test that getting a nonexistent world returns 404."""


### PR DESCRIPTION
## Summary
- stop per-world autosave and broadcast work as part of world deletion
- add an awaited delete_world_async() path and have the worlds API use it before returning
- add coverage for autosave removal, broadcast shutdown, and the delete endpoint contract

## Validation
- python -m pytest tests/test_auto_save_service.py tests/test_world_manager_broadcast.py tests/test_worlds_api.py -q
- python -m ruff check backend/world_manager.py backend/startup_manager.py backend/routers/worlds.py tests/test_auto_save_service.py tests/test_world_manager_broadcast.py tests/test_worlds_api.py