### PR TITLE
Fix malformed Content-Length handling in request validation

### DIFF
--- a/backend/security.py
+++ b/backend/security.py
@@ -139,11 +139,26 @@ class RequestValidationMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         # Check content length
         content_length = request.headers.get("content-length")
-        if content_length and int(content_length) > self.MAX_CONTENT_LENGTH:
-            return JSONResponse(
-                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                content={"error": "Request too large", "max_size": self.MAX_CONTENT_LENGTH},
-            )
+        if content_length:
+            try:
+                parsed_content_length = int(content_length)
+            except ValueError:
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content={"error": "Invalid Content-Length header"},
+                )
+
+            if parsed_content_length < 0:
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content={"error": "Invalid Content-Length header"},
+                )
+
+            if parsed_content_length > self.MAX_CONTENT_LENGTH:
+                return JSONResponse(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    content={"error": "Request too large", "max_size": self.MAX_CONTENT_LENGTH},
+                )
 
         return await call_next(request)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,62 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import status
+from fastapi.responses import JSONResponse
+from starlette.requests import Request
+
+from backend.security import RequestValidationMiddleware
+
+
+def _make_request(*, content_length: str | None = None) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if content_length is not None:
+        headers.append((b"content-length", content_length.encode("ascii")))
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/test",
+        "raw_path": b"/api/test",
+        "query_string": b"",
+        "headers": headers,
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+@pytest.mark.asyncio
+async def test_request_validation_rejects_malformed_content_length() -> None:
+    middleware = RequestValidationMiddleware(app=AsyncMock())
+    request = _make_request(content_length="not-a-number")
+    call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+    response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert json.loads(response.body) == {"error": "Invalid Content-Length header"}
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_request_validation_rejects_oversized_content_length() -> None:
+    middleware = RequestValidationMiddleware(app=AsyncMock())
+    request = _make_request(content_length=str(RequestValidationMiddleware.MAX_CONTENT_LENGTH + 1))
+    call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+    response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == status.HTTP_413_CONTENT_TOO_LARGE
+    assert json.loads(response.body) == {
+        "error": "Request too large",
+        "max_size": RequestValidationMiddleware.MAX_CONTENT_LENGTH,
+    }
+    call_next.assert_not_called()


### PR DESCRIPTION
## Summary
- reject malformed or negative Content-Length headers with a 400 response instead of letting request validation raise a 500
- keep oversized request handling as a 413 using the current FastAPI status constant
- add focused middleware tests for malformed and oversized Content-Length values

## Validation
- python -m pytest tests/test_security.py -q
- python -m ruff check backend/security.py tests/test_security.py
- python -m black --config pyproject.toml --check backend/security.py tests/test_security.py