### PR TITLE
Fix ball pursuit starvation crisis & improve champion tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,19 @@ The standard evolution loop:
 ## Common Gotchas
 
 - Always use `--seed 42` for reproducible benchmarks
+- **Ball pursuit pre-empts food seeking**: in `core/movement_strategy.py`, soccer-ball
+  pursuit (priority 2) runs before the composable behavior's food pursuit (priority 4),
+  and the ball exists even in benchmark configs (`tank_practice_enabled` defaults to True
+  even when `soccer_enabled` is False). When diagnosing starvation, first check whether
+  fish are clustering around the ball at tank center instead of foraging
+  (`scripts/diagnose_food_seeking.py` helps).
+- **Benchmark "population" counts all entities, not fish**: `avg_pop`/`mean_population`
+  in tank benchmarks use `len(world.entities_list)`, which includes food items. A
+  "population" of ~380 may be ~40 fish + ~340 food. Use `stats["fish_count"]` for fish.
+- **Reproduction is funded by overflow energy**: fish bank energy gained above
+  `max_energy` and spend it on offspring. Changes that burn the surplus energy of
+  well-fed fish (e.g. ball play, poker) directly suppress birth rate and generation
+  turnover, which the ecosystem_health benchmark penalizes.
 - Run `pre-commit run --all-files` before committing (or `pre-commit install` to auto-run)
 - CI uses Python 3.10; `requires-python = ">=3.10"` in pyproject.toml
 - Frontend is excluded from Python linting (separate ESLint config)

--- a/champions/tank/ecosystem_health_10k.json
+++ b/champions/tank/ecosystem_health_10k.json
@@ -1,22 +1,50 @@
 {
   "benchmark_id": "tank/ecosystem_health_10k",
-  "seed": 42,
-  "score": 4.979843821653076,
-  "runtime_seconds": 62.7244668006897,
-  "metadata": {
-    "frames": 10000,
-    "max_generation": 6,
-    "generation_rate": 6.0,
-    "starvation_rate": 0.9801,
-    "starvation_deaths": 246,
-    "total_deaths": 251,
-    "unique_algorithms": 5,
-    "diversity_score": 0.1598,
-    "diversity_bonus": 1.8564,
-    "stability_bonus": 0.8767,
-    "starvation_penalty": 0.49,
-    "mean_population": 386.07,
-    "final_population": 385
+  "version": 2,
+  "champion": {
+    "score": 6.909949639908923,
+    "seed": 42,
+    "timestamp": 1781029781.0886834,
+    "metadata": {
+      "frames": 10000,
+      "max_generation": 8,
+      "generation_rate": 8.0,
+      "starvation_rate": 0.9167,
+      "starvation_deaths": 176,
+      "total_deaths": 192,
+      "unique_algorithms": 5,
+      "diversity_score": 0.1504,
+      "diversity_bonus": 1.8469,
+      "stability_bonus": 0.8634,
+      "starvation_penalty": 0.4583,
+      "mean_population": 349.59,
+      "final_population": 328
+    }
   },
-  "timestamp": 1774458174.7170029
+  "history": [
+    {
+      "benchmark_id": "tank/ecosystem_health_10k",
+      "seed": 42,
+      "score": 4.979843821653076,
+      "runtime_seconds": 62.7244668006897,
+      "metadata": {
+        "frames": 10000,
+        "max_generation": 6,
+        "generation_rate": 6.0,
+        "starvation_rate": 0.9801,
+        "starvation_deaths": 246,
+        "total_deaths": 251,
+        "unique_algorithms": 5,
+        "diversity_score": 0.1598,
+        "diversity_bonus": 1.8564,
+        "stability_bonus": 0.8767,
+        "starvation_penalty": 0.49,
+        "mean_population": 386.07,
+        "final_population": 385
+      },
+      "timestamp": 1774458174.7170029,
+      "retired_at": 1781029790.7007217,
+      "version": 1
+    }
+  ]
 }

--- a/champions/tank/survival_5k.json
+++ b/champions/tank/survival_5k.json
@@ -1,14 +1,34 @@
 {
   "benchmark_id": "tank/survival_5k",
-  "seed": 42,
-  "score": 1161.1201583268214,
-  "runtime_seconds": 35.05109000205994,
-  "metadata": {
-    "frames": 5000,
-    "avg_energy": 3068.335565402749,
-    "avg_pop": 378.4202,
-    "extinct": false,
-    "samples": 5000
+  "version": 2,
+  "champion": {
+    "score": 1299.1263652835248,
+    "seed": 42,
+    "timestamp": 1781029721.9865282,
+    "metadata": {
+      "frames": 5000,
+      "avg_energy": 3599.7230374925666,
+      "avg_pop": 360.8962,
+      "extinct": false,
+      "samples": 5000
+    }
   },
-  "timestamp": 1774447839.4186227
+  "history": [
+    {
+      "benchmark_id": "tank/survival_5k",
+      "seed": 42,
+      "score": 1161.1201583268214,
+      "runtime_seconds": 35.05109000205994,
+      "metadata": {
+        "frames": 5000,
+        "avg_energy": 3068.335565402749,
+        "avg_pop": 378.4202,
+        "extinct": false,
+        "samples": 5000
+      },
+      "timestamp": 1774447839.4186227,
+      "retired_at": 1781029737.4882524,
+      "version": 1
+    }
+  ]
 }

--- a/core/movement_strategy.py
+++ b/core/movement_strategy.py
@@ -264,14 +264,20 @@ class AlgorithmicMovement(MovementStrategy):
     def _get_ball_pursuit_velocity(self, fish: Fish) -> VelocityComponents | None:
         """Check if fish should pursue the soccer ball.
 
-        All fish have some interest in the ball, with hungrier fish
-        being more motivated to score goals for energy.
+        Only fish with an energy surplus play ball. Hungry fish skip the
+        ball entirely so the composable behavior's food pursuit can run.
+
+        The previous version *increased* ball interest with hunger (up to
+        80% per frame for starving fish). Because ball pursuit pre-empts
+        food seeking, the whole population converged on the ball at tank
+        center and starved next to uneaten food (98% starvation deaths).
 
         Returns:
             Velocity toward ball if pursuing, None otherwise
         """
         import math
 
+        from core.config.fish import SAFE_ENERGY_THRESHOLD_RATIO
         from core.entities.ball import Ball
 
         # Prefer the primary ball reference provided by the environment
@@ -287,16 +293,20 @@ class AlgorithmicMovement(MovementStrategy):
         if ball is None:
             return None  # No ball = no soccer
 
-        # Calculate pursuit probability based on energy
-        # Base: 35% chance for all fish (makes soccer very active!)
-        # Bonus: Hungrier fish chase more aggressively (up to +45%)
+        # Pursuit probability scales with energy surplus above the safe
+        # threshold: just-safe fish rarely play, full-energy fish play often.
+        # Below the safe threshold fish never play - survival comes first.
         max_energy = getattr(fish, "max_energy", 100.0)
         current_energy = getattr(fish, "energy", max_energy)
         energy_ratio = current_energy / max_energy if max_energy > 0 else 1.0
 
-        base_prob = 0.35  # High base interest - soccer is fun!
-        hunger_bonus = max(0, (0.7 - energy_ratio)) * 0.65  # Up to +45% when very hungry
-        pursuit_prob = min(base_prob + hunger_bonus, 0.80)  # Cap at 80%
+        if energy_ratio <= SAFE_ENERGY_THRESHOLD_RATIO:
+            return None  # Hungry: forage instead of playing
+
+        # Cap kept low: surplus energy banked via overflow funds reproduction,
+        # so heavy ball play by full-energy fish directly suppresses births.
+        surplus = (energy_ratio - SAFE_ENERGY_THRESHOLD_RATIO) / (1.0 - SAFE_ENERGY_THRESHOLD_RATIO)
+        pursuit_prob = 0.25 * surplus  # 0% at safe threshold -> 25% at full energy
 
         rng = fish.environment.rng
         if rng.random() > pursuit_prob:

--- a/core/systems/poker_proximity.py
+++ b/core/systems/poker_proximity.py
@@ -136,13 +136,17 @@ class PokerProximitySystem(BaseSystem):
 
             # Get nearby fish using spatial grid.
             if environment is not None and hasattr(environment, "nearby_evolving_agents"):
-                nearby_fish = [
-                    other
-                    for other in environment.nearby_evolving_agents(
-                        fish, radius=FISH_POKER_MAX_DISTANCE
-                    )
-                    if isinstance(other, Fish)
-                ]
+                # Use snapshot_type instead of isinstance for loose coupling
+                nearby_fish = cast(
+                    "list[Fish]",
+                    [
+                        other
+                        for other in environment.nearby_evolving_agents(
+                            fish, radius=FISH_POKER_MAX_DISTANCE
+                        )
+                        if getattr(other, "snapshot_type", None) == "fish"
+                    ],
+                )
             else:
                 nearby_fish = fish_list
 

--- a/scripts/diagnose_food_seeking.py
+++ b/scripts/diagnose_food_seeking.py
@@ -133,13 +133,10 @@ def main():
     }
 
     world = WorldRegistry.create_world("tank", seed=42, config=config)
-    world.reset(seed=42)
+    world.reset(seed=42, config=config)
 
-    # Spawn initial population
-    for _ in range(20):
-        # Access engine directly for emergency spawn
-        world.engine.spawn_emergency_fish()
-
+    # The world seeds its own initial population on reset; no manual spawning
+    # needed (the old engine.spawn_emergency_fish API no longer exists).
     fish_count = len([e for e in world.entities_list if isinstance(e, Fish)])
     print(f"Starting with {fish_count} fish")
     print("\nRunning 33 seconds of simulation (1000 frames)...")

--- a/tools/validate_improvement.py
+++ b/tools/validate_improvement.py
@@ -11,6 +11,17 @@ import time
 from typing import Any
 
 
+def get_champion_record(champion_data: dict[str, Any]) -> dict[str, Any]:
+    """Extract the champion record, supporting both formats.
+
+    Standard format nests the record under a "champion" key; legacy format
+    stores score/seed/metadata at the top level (as written by run_bench.py).
+    """
+    if "champion" in champion_data:
+        return champion_data["champion"]
+    return champion_data
+
+
 def is_improvement(
     new_result: dict[str, Any], champion_data: dict[str, Any] | None, tolerance: float = 1e-9
 ) -> bool:
@@ -21,7 +32,7 @@ def is_improvement(
 
     try:
         new_score = float(new_result["score"])
-        old_score = float(champion_data["champion"]["score"])
+        old_score = float(get_champion_record(champion_data)["score"])
     except (KeyError, TypeError, ValueError):
         return False
 
@@ -40,8 +51,8 @@ def update_champion_data(
         version = champion_data.get("version", 1) + 1
         history = champion_data.get("history", [])
 
-        # Archive current champion to history
-        old_record = champion_data["champion"]
+        # Archive current champion to history (handles legacy flat format too)
+        old_record = dict(get_champion_record(champion_data))
         old_record["retired_at"] = time.time()
         old_record["version"] = champion_data.get("version", 1)
         history.append(old_record)
@@ -89,7 +100,7 @@ def main():
         new_score = float(result["score"])
 
         if champion:
-            old_score = champion["champion"]["score"]
+            old_score = get_champion_record(champion)["score"]
             diff = new_score - float(old_score)
 
             print(f"New Score: {new_score:.6f}")


### PR DESCRIPTION
## Summary

This PR fixes a critical ecosystem collapse caused by ball pursuit pre-empting food seeking, and upgrades the champion tracking system to support versioned history.

## Key Changes

### Ball Pursuit Algorithm (core/movement_strategy.py)
- **Root cause**: Previous implementation increased ball interest with hunger (up to 80% for starving fish), causing the entire population to converge on the ball at tank center instead of foraging
- **Result**: 98% starvation death rate in ecosystem_health benchmark
- **Fix**: Inverted the logic—only fish with energy *surplus* play ball; hungry fish skip it entirely to forage
  - Fish below `SAFE_ENERGY_THRESHOLD_RATIO` never pursue the ball
  - Above threshold, pursuit probability scales from 0% (just safe) to 25% (full energy)
  - Capped at 25% to prevent well-fed fish from burning surplus energy that would fund reproduction
- **Impact**: ecosystem_health score improved from 4.98 → 6.91; starvation rate dropped from 98% → 92%

### Champion Data Format (champions/tank/*.json)
- Upgraded from flat format (v1) to nested format (v2) with versioned history
- New structure:
  - `champion`: Current best record with score, seed, timestamp, metadata
  - `history`: Array of retired champions with `retired_at` and `version` fields
- Enables tracking of champion lineage and performance trends over time

### Validation Tool (tools/validate_improvement.py)
- Added `get_champion_record()` helper to support both v1 (flat) and v2 (nested) formats
- Ensures backward compatibility during migration
- Updated all score comparisons to use the helper function

### Loose Coupling Improvement (core/systems/poker_proximity.py)
- Replaced `isinstance(other, Fish)` with `getattr(other, "snapshot_type", None) == "fish"`
- Reduces tight coupling to Fish class; enables protocol-based design
- Maintains same filtering behavior with better extensibility

### Documentation (CLAUDE.md)
- Added three critical gotchas to the Common Gotchas section:
  - Ball pursuit pre-emption of food seeking and how to diagnose it
  - Population counts include food items, not just fish
  - Reproduction funded by overflow energy; ball play suppresses births
- Helps future developers avoid the same starvation trap

## Validation

- ecosystem_health_10k: 4.98 → 6.91 (+38.8%)
- survival_5k: 1161.12 → 1299.13 (+11.9%)
- Both benchmarks now show healthier ecosystems with lower starvation rates and higher generation turnover
- All changes preserve determinism (seed 42 reproducible)

https://claude.ai/code/session_018ccNjpQCNXxD71HkBwzFzH