### PR TITLE
feat(dx): one-command launcher (start.py) + environment health check (diagnose.py)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,21 +128,32 @@ pre-commit install
 
 # Frontend setup
 cd frontend && npm ci && cd ..
+
+# Verify the setup (prints a green/red health checklist)
+python scripts/diagnose.py
 ```
 
 ### Run the Web UI
 
-```bash
-# Terminal 1: Backend
-python main.py
+One command launches the backend (:8000) and frontend (:3000) together, streams
+both logs, opens your browser, and shuts everything down on Ctrl-C:
 
-# Terminal 2: Frontend
-cd frontend && npm run dev
+```bash
+python start.py
+# python start.py --no-browser     # skip opening a browser tab
+# python start.py --backend-only   # backend only (no Node required)
 
 # Open http://localhost:3000
 ```
 
-On Windows PowerShell, you can also use [`start.ps1`](start.ps1) after the environment is set up to launch the backend, frontend, and browser together.
+Prefer two terminals (or need to debug one side in isolation)? Run them separately:
+
+```bash
+python main.py                 # Terminal 1: backend
+cd frontend && npm run dev     # Terminal 2: frontend
+```
+
+On Windows PowerShell, [`start.ps1`](start.ps1) does the same as `start.py`.
 
 ### Run Headless (10-300x Faster)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -120,6 +120,16 @@ Visit http://localhost:3000 in your browser. You should now see the Tank World U
 
 ## Troubleshooting
 
+### First step: run the health check
+
+Before digging into a specific symptom, run the diagnostic — it pinpoints which
+layer is broken (Python deps, core modules, the simulation, or the frontend
+toolchain) and prints a fix hint for each failure:
+
+```bash
+python scripts/diagnose.py
+```
+
 ### Extensive Logs / High CPU on Startup
 - **Cause**: The server is restoring many old simulations found in `data/tanks`. This often happens if test runs created persistent snapshots.
 - **Fix**: Stop the server and delete the `data/tanks` directory to start fresh:

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -150,15 +150,13 @@ never silently leave their design range.
 
 This is where "fun to use" and "excellent example of software design" are won.
 
-### 4.1 One-command startup — `S` · ★★★
-Add `python start.py` (or a `tank` console-script entry point) that launches
-backend + frontend together with sane defaults and a single Ctrl-C shutdown.
-Two-terminal setup is the #1 onboarding friction point.
+### 4.1 One-command startup — ✅ shipped
+`python start.py` launches backend + frontend together with a single Ctrl-C
+shutdown (see Shipped). Remaining nice-to-have: a `tank` console-script entry
+point in `pyproject.toml`.
 
-### 4.2 `scripts/diagnose.py` health check — `S` · ★★★
-One command that verifies the environment and prints a green/red checklist:
-Python deps importable, core modules load, a 100-frame sim initializes, frontend
-deps installed. Turns "it's broken somewhere" into a precise pointer.
+### 4.2 `scripts/diagnose.py` health check — ✅ shipped
+Shipped — see Shipped section below.
 
 ### 4.3 Algorithm catalog doc — `S` · ★★
 Generate `docs/ALGORITHM_CATALOG.md` from the registry: each algorithm's file,
@@ -206,6 +204,14 @@ algorithm-count bug is exactly the failure this prevents.
   `REPLAY.md` / `UI_SPEC.md` entries. (commit `380a6c0`)
 - **Docs: refreshed ROADMAP status** — marked `validate_improvement.py` and
   `bench.yml` as shipped, clarified which tank benchmarks actually exist.
+- **DX: one-command startup (`start.py`)** (proposal 4.1) — cross-platform
+  launcher that runs backend + frontend together, streams prefixed logs, opens
+  the browser, and shuts both down cleanly on Ctrl-C. `--backend-only` skips
+  Node entirely. Verified end-to-end including graceful SIGINT shutdown.
+- **DX: environment health check (`scripts/diagnose.py`)** (proposal 4.2) — a
+  green/red checklist over the Python toolchain, core modules, the algorithm
+  registry, a live short simulation, and the frontend toolchain. Each failure
+  prints an actionable hint. Covered by `tests/smoke/test_diagnose.py`.
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,15 @@ Run any Python script with `PYTHONPATH=.` if you hit import errors:
 PYTHONPATH=. python scripts/<name>.py --help
 ```
 
+## Start here
+
+- `diagnose.py`: **Environment health check.** Prints a green/red checklist over
+  the Python toolchain, core modules, the algorithm registry, a live short
+  simulation, and the frontend toolchain — each failure comes with an actionable
+  hint. Run it first whenever something won't start. Exits non-zero on failure,
+  so it doubles as a CI/setup gate. (To launch the app itself, use `python
+  start.py` from the repo root.)
+
 ## Evolution loop
 
 - `ai_code_evolution_agent.py`: End-to-end AI agent — reads simulation stats,

--- a/scripts/diagnose.py
+++ b/scripts/diagnose.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Tank World environment health check.
+
+Run this when something is broken and you are not sure where. It prints a
+green/red checklist covering the Python toolchain, core modules, the algorithm
+registry, a live (short) simulation, and the frontend toolchain — turning
+"it's broken somewhere" into a precise pointer.
+
+Usage:
+    python scripts/diagnose.py
+    python scripts/diagnose.py --no-color
+
+Exit code is 0 when every required check passes, 1 otherwise. Warnings (for
+optional tooling like Node or pre-commit) never fail the run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import logging
+import os
+import shutil
+import sys
+import time
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXPECTED_ALGORITHM_COUNT = 58
+
+
+# --------------------------------------------------------------------------- #
+# Output helpers
+# --------------------------------------------------------------------------- #
+class Style:
+    """ANSI styling that disables itself when output is not a TTY."""
+
+    def __init__(self, enabled: bool) -> None:
+        self.enabled = enabled
+
+    def _wrap(self, code: str, text: str) -> str:
+        return f"\033[{code}m{text}\033[0m" if self.enabled else text
+
+    def green(self, t: str) -> str:
+        return self._wrap("32", t)
+
+    def red(self, t: str) -> str:
+        return self._wrap("31", t)
+
+    def yellow(self, t: str) -> str:
+        return self._wrap("33", t)
+
+    def bold(self, t: str) -> str:
+        return self._wrap("1", t)
+
+    def dim(self, t: str) -> str:
+        return self._wrap("2", t)
+
+
+# Check outcomes
+OK = "ok"
+WARN = "warn"
+FAIL = "fail"
+
+
+@dataclass
+class Result:
+    status: str
+    title: str
+    detail: str = ""
+    hint: str = ""
+
+
+def _icon(style: Style, status: str) -> str:
+    if status == OK:
+        return style.green("PASS")
+    if status == WARN:
+        return style.yellow("WARN")
+    return style.red("FAIL")
+
+
+# --------------------------------------------------------------------------- #
+# Individual checks
+# --------------------------------------------------------------------------- #
+def check_python_version() -> Result:
+    major, minor = sys.version_info[:2]
+    version = f"{major}.{minor}.{sys.version_info.micro}"
+    if (major, minor) >= (3, 10):
+        return Result(OK, "Python version", f"{version} (>= 3.10)")
+    return Result(
+        FAIL,
+        "Python version",
+        f"{version} is too old",
+        hint="Tank World requires Python 3.10+ (see pyproject.toml).",
+    )
+
+
+def check_dependencies() -> Result:
+    required = ["numpy", "fastapi", "uvicorn", "pydantic", "orjson", "websockets"]
+    missing = []
+    for mod in required:
+        if importlib.util.find_spec(mod) is None:
+            missing.append(mod)
+    if not missing:
+        return Result(OK, "Python dependencies", f"{len(required)} core packages present")
+    return Result(
+        FAIL,
+        "Python dependencies",
+        f"missing: {', '.join(missing)}",
+        hint="Install the project: pip install -e .[dev]",
+    )
+
+
+def check_core_imports() -> Result:
+    modules = [
+        "core.simulation.engine",
+        "core.algorithms.registry",
+        "core.worlds",
+        "backend.main",
+    ]
+    failures = []
+    for mod in modules:
+        try:
+            importlib.import_module(mod)
+        except Exception as exc:
+            failures.append(f"{mod} ({type(exc).__name__}: {exc})")
+    if not failures:
+        return Result(OK, "Core modules", f"{len(modules)} modules import cleanly")
+    return Result(
+        FAIL,
+        "Core modules",
+        "; ".join(failures),
+        hint="A broken import usually means an editable install is stale: pip install -e .",
+    )
+
+
+def check_algorithm_registry() -> Result:
+    try:
+        from core.algorithms.registry import ALL_ALGORITHMS
+    except Exception as exc:
+        return Result(
+            FAIL,
+            "Algorithm registry",
+            f"could not import ALL_ALGORITHMS ({type(exc).__name__}: {exc})",
+            hint="Check core/algorithms/registry.py imports.",
+        )
+
+    count = len(ALL_ALGORITHMS)
+    if count == 0:
+        return Result(FAIL, "Algorithm registry", "registry is empty")
+    if count != EXPECTED_ALGORITHM_COUNT:
+        return Result(
+            WARN,
+            "Algorithm registry",
+            f"{count} algorithms registered (docs reference {EXPECTED_ALGORITHM_COUNT})",
+            hint="If this is intentional, update the count in docs/BEHAVIOR_DEVELOPMENT_GUIDE.md.",
+        )
+    return Result(OK, "Algorithm registry", f"{count} behavior algorithms registered")
+
+
+def check_simulation_smoke(frames: int = 50) -> Result:
+    try:
+        from core.worlds import WorldRegistry
+
+        world = WorldRegistry.create_world("tank", seed=42, headless=True)
+        world.reset(seed=42)
+        advance = getattr(world, "update", None) or world.step
+        start = time.perf_counter()
+        for _ in range(frames):
+            advance()
+        elapsed = time.perf_counter() - start
+        metrics = world.get_current_metrics(include_distributions=False)
+    except Exception as exc:
+        return Result(
+            FAIL,
+            "Simulation smoke test",
+            f"{type(exc).__name__}: {exc}",
+            hint="Run with TANK_LOG_LEVEL=DEBUG for a fuller trace.",
+        )
+
+    fish = metrics.get("fish_count")
+    if not fish:
+        return Result(
+            WARN,
+            "Simulation smoke test",
+            f"ran {frames} frames but fish_count is {fish!r}",
+            hint="Population collapsed immediately — check spawn/energy config.",
+        )
+    rate = frames / elapsed if elapsed else float("inf")
+    return Result(
+        OK,
+        "Simulation smoke test",
+        f"{frames} frames OK, {fish} fish alive ({rate:.0f} fps headless)",
+    )
+
+
+def check_frontend_deps() -> Result:
+    node_modules = REPO_ROOT / "frontend" / "node_modules"
+    if node_modules.is_dir():
+        return Result(OK, "Frontend dependencies", "frontend/node_modules present")
+    return Result(
+        WARN,
+        "Frontend dependencies",
+        "frontend/node_modules missing",
+        hint="The web UI needs them: cd frontend && npm install",
+    )
+
+
+def check_node_toolchain() -> Result:
+    npm = shutil.which("npm")
+    node = shutil.which("node")
+    if npm and node:
+        return Result(OK, "Node toolchain", "node and npm on PATH")
+    missing = [name for name, found in (("node", node), ("npm", npm)) if not found]
+    return Result(
+        WARN,
+        "Node toolchain",
+        f"missing from PATH: {', '.join(missing)}",
+        hint="Node 20+ is needed only for the web UI; headless mode does not require it.",
+    )
+
+
+def check_precommit() -> Result:
+    hook = REPO_ROOT / ".git" / "hooks" / "pre-commit"
+    if hook.exists():
+        return Result(OK, "Pre-commit hook", "installed")
+    return Result(
+        WARN,
+        "Pre-commit hook",
+        "not installed",
+        hint="Enable auto-formatting/linting on commit: pre-commit install",
+    )
+
+
+CHECKS = [
+    check_python_version,
+    check_dependencies,
+    check_core_imports,
+    check_algorithm_registry,
+    check_simulation_smoke,
+    check_frontend_deps,
+    check_node_toolchain,
+    check_precommit,
+]
+
+
+# --------------------------------------------------------------------------- #
+# Runner
+# --------------------------------------------------------------------------- #
+def run_diagnostics(style: Style) -> int:
+    """Run every check, print a checklist, and return a process exit code."""
+    print(style.bold("Tank World — environment diagnostics"))
+    print(style.dim(f"repo: {REPO_ROOT}"))
+    print()
+
+    results: list[Result] = []
+    for check in CHECKS:
+        try:
+            result = check()
+        except Exception as exc:
+            result = Result(
+                FAIL,
+                check.__name__,
+                f"check raised {type(exc).__name__}: {exc}",
+                hint=style.dim(traceback.format_exc(limit=1).strip()),
+            )
+        results.append(result)
+        line = f"  [{_icon(style, result.status)}] {result.title}"
+        if result.detail:
+            line += f"  {style.dim('—')} {result.detail}"
+        print(line)
+        if result.hint and result.status != OK:
+            print(f"           {style.dim('→ ' + result.hint)}")
+
+    failures = sum(1 for r in results if r.status == FAIL)
+    warnings = sum(1 for r in results if r.status == WARN)
+    passes = sum(1 for r in results if r.status == OK)
+
+    print()
+    summary = f"{passes} passed, {warnings} warning(s), {failures} failure(s)"
+    if failures:
+        print(style.red(style.bold("✗ " + summary)))
+        print(style.dim("  Fix the FAIL items above before running the simulation."))
+        return 1
+    if warnings:
+        print(style.yellow(style.bold("✓ " + summary)))
+        print(style.dim("  Core is healthy; warnings are optional tooling."))
+        return 0
+    print(style.green(style.bold("✓ " + summary + " — all good!")))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Tank World environment health check")
+    parser.add_argument("--no-color", action="store_true", help="Disable colored output")
+    args = parser.parse_args()
+
+    # Keep simulation/backend import logging quiet so the checklist stays readable.
+    logging.disable(logging.CRITICAL)
+
+    color = not args.no_color and sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
+    return run_diagnostics(Style(enabled=color))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.py
+++ b/start.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""One-command launcher for Tank World.
+
+Starts the FastAPI backend (:8000) and the Vite React frontend (:3000)
+together, streams their logs with colored prefixes, and shuts both down
+cleanly on Ctrl-C. Cross-platform replacement for juggling two terminals.
+
+Usage:
+    python start.py                 # backend + frontend, opens the browser
+    python start.py --no-browser    # don't open a browser tab
+    python start.py --backend-only  # run only the backend (no Node required)
+
+Run `python scripts/diagnose.py` first if anything fails to start.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+import webbrowser
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+FRONTEND_DIR = REPO_ROOT / "frontend"
+BACKEND_URL = "http://localhost:8000"
+FRONTEND_URL = "http://localhost:3000"
+
+_COLOR = sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
+
+
+def _c(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _COLOR else text
+
+
+def _info(msg: str) -> None:
+    print(_c("36", "[start] ") + msg, flush=True)
+
+
+def _error(msg: str) -> None:
+    print(_c("31", "[start] " + msg), file=sys.stderr, flush=True)
+
+
+def _stream(proc: subprocess.Popen, label: str, color: str) -> None:
+    """Forward a child's combined output to our stdout with a colored prefix."""
+    prefix = _c(color, f"[{label}] ")
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        sys.stdout.write(prefix + line)
+        sys.stdout.flush()
+
+
+def _popen(cmd: list[str], cwd: Path) -> subprocess.Popen:
+    """Start a child process in its own group so we can stop the whole tree."""
+    kwargs: dict = {
+        "cwd": str(cwd),
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
+        "bufsize": 1,
+        "text": True,
+    }
+    if os.name == "posix":
+        kwargs["start_new_session"] = True
+    else:  # Windows: allow sending CTRL_BREAK to the group
+        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+    return subprocess.Popen(cmd, **kwargs)
+
+
+def _terminate(proc: subprocess.Popen, label: str) -> None:
+    if proc.poll() is not None:
+        return
+    _info(f"stopping {label}...")
+    try:
+        if os.name == "posix":
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        else:
+            proc.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
+    except (ProcessLookupError, PermissionError, OSError):
+        proc.terminate()
+    try:
+        proc.wait(timeout=8)
+    except subprocess.TimeoutExpired:
+        _info(f"force-killing {label}")
+        if os.name == "posix":
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except OSError:
+                proc.kill()
+        else:
+            proc.kill()
+
+
+def _preflight(backend_only: bool) -> bool:
+    if backend_only:
+        return True
+    if not (FRONTEND_DIR / "node_modules").is_dir():
+        _error("frontend/node_modules is missing. Install it with:")
+        _error("    cd frontend && npm install")
+        _error("Or run backend only:  python start.py --backend-only")
+        return False
+    if shutil.which("npm") is None:
+        _error("npm is not on PATH. Install Node 20+, or run: python start.py --backend-only")
+        return False
+    return True
+
+
+def _open_browser_later(url: str, delay: float = 3.0) -> None:
+    def _open() -> None:
+        time.sleep(delay)
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+    threading.Thread(target=_open, daemon=True).start()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Launch Tank World (backend + frontend)")
+    parser.add_argument(
+        "--backend-only", action="store_true", help="Run only the backend (no Node required)"
+    )
+    parser.add_argument(
+        "--no-browser", action="store_true", help="Do not open a browser tab on startup"
+    )
+    args = parser.parse_args()
+
+    if not _preflight(args.backend_only):
+        return 1
+
+    processes: list[tuple[subprocess.Popen, str]] = []
+    threads: list[threading.Thread] = []
+
+    _info("starting backend on " + BACKEND_URL)
+    backend = _popen([sys.executable, str(REPO_ROOT / "main.py")], cwd=REPO_ROOT)
+    processes.append((backend, "backend"))
+    t = threading.Thread(target=_stream, args=(backend, "backend", "32"), daemon=True)
+    t.start()
+    threads.append(t)
+
+    if not args.backend_only:
+        _info("starting frontend on " + FRONTEND_URL)
+        npm = shutil.which("npm") or "npm"
+        frontend = _popen([npm, "run", "dev"], cwd=FRONTEND_DIR)
+        processes.append((frontend, "frontend"))
+        t = threading.Thread(target=_stream, args=(frontend, "frontend", "35"), daemon=True)
+        t.start()
+        threads.append(t)
+
+    target_url = BACKEND_URL if args.backend_only else FRONTEND_URL
+    if not args.no_browser:
+        _open_browser_later(target_url)
+
+    _info(f"open {target_url} — press Ctrl+C to stop")
+
+    exit_code = 0
+    try:
+        # Wait until any child exits (which usually signals a crash), or Ctrl-C.
+        while True:
+            for proc, label in processes:
+                code = proc.poll()
+                if code is not None:
+                    _error(f"{label} exited with code {code}; shutting down")
+                    exit_code = code or 1
+                    raise KeyboardInterrupt
+            time.sleep(0.4)
+    except KeyboardInterrupt:
+        print()
+        _info("shutdown requested")
+    finally:
+        for proc, label in reversed(processes):
+            _terminate(proc, label)
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/tests/smoke/test_diagnose.py
+++ b/tests/smoke/test_diagnose.py
@@ -1,0 +1,64 @@
+"""Smoke tests for the environment diagnostic tool (scripts/diagnose.py)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DIAGNOSE_PATH = REPO_ROOT / "scripts" / "diagnose.py"
+
+
+def _load_diagnose():
+    spec = importlib.util.spec_from_file_location("diagnose", DIAGNOSE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so @dataclass can resolve the module by name.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def diagnose():
+    return _load_diagnose()
+
+
+def test_core_checks_pass_in_dev_env(diagnose):
+    """The checks that must hold in any working install should report OK."""
+    required_checks = [
+        diagnose.check_python_version,
+        diagnose.check_dependencies,
+        diagnose.check_core_imports,
+        diagnose.check_algorithm_registry,
+        diagnose.check_simulation_smoke,
+    ]
+    for check in required_checks:
+        result = check()
+        assert result.status in (
+            diagnose.OK,
+            diagnose.WARN,
+        ), f"{check.__name__} unexpectedly failed: {result.detail}"
+        assert result.title
+        assert result.status != diagnose.FAIL
+
+
+def test_simulation_smoke_reports_live_fish(diagnose):
+    result = diagnose.check_simulation_smoke(frames=10)
+    assert result.status == diagnose.OK
+    assert "fish alive" in result.detail
+
+
+def test_runner_returns_zero_when_core_healthy(diagnose):
+    """The full runner should exit 0 (warnings are non-fatal)."""
+    style = diagnose.Style(enabled=False)
+    assert diagnose.run_diagnostics(style) == 0
+
+
+def test_every_check_is_resilient(diagnose):
+    """No check should raise; each must return a Result."""
+    for check in diagnose.CHECKS:
+        result = check()
+        assert isinstance(result, diagnose.Result)
+        assert result.status in (diagnose.OK, diagnose.WARN, diagnose.FAIL)

--- a/tests/smoke/test_start_launcher.py
+++ b/tests/smoke/test_start_launcher.py
@@ -1,0 +1,47 @@
+"""Smoke tests for the one-command launcher (start.py).
+
+These intentionally do NOT spawn the servers — they only exercise the pure
+helper logic so CI stays fast and side-effect free.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+START_PATH = REPO_ROOT / "start.py"
+
+
+def _load_start():
+    spec = importlib.util.spec_from_file_location("start_launcher", START_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def start():
+    return _load_start()
+
+
+def test_urls_and_paths_are_sane(start):
+    assert start.BACKEND_URL.endswith(":8000")
+    assert start.FRONTEND_URL.endswith(":3000")
+    assert start.FRONTEND_DIR.name == "frontend"
+    assert start.REPO_ROOT == REPO_ROOT
+
+
+def test_backend_only_preflight_always_ok(start):
+    """--backend-only must never be blocked by missing Node tooling."""
+    assert start._preflight(backend_only=True) is True
+
+
+def test_color_helper_respects_toggle(start, monkeypatch):
+    # When color is disabled, text passes through unchanged.
+    monkeypatch.setattr(start, "_COLOR", False)
+    assert start._c("32", "hello") == "hello"
+    # When enabled, it wraps in ANSI codes.
+    monkeypatch.setattr(start, "_COLOR", True)
+    assert "\033[32m" in start._c("32", "hello")


### PR DESCRIPTION
## What this is

The "fun to use" follow-up to the docs PR (#586). Implements the two highest-impact developer-experience proposals from `docs/IMPROVEMENT_PROPOSALS.md` — **4.1 one-command startup** and **4.2 environment health check** — both tagged S/★★★. Removes the project's #1 onboarding friction (juggling two terminals) and turns "it's broken somewhere" into a precise pointer.

## `start.py` — cross-platform one-command launcher

```bash
python start.py                 # backend (:8000) + frontend (:3000), opens browser
python start.py --no-browser    # skip the browser tab
python start.py --backend-only  # backend only — no Node required
```

- Streams both children's logs with colored `[backend]` / `[frontend]` prefixes.
- **Clean Ctrl-C shutdown**: children start in their own process group and get SIGTERM (CTRL_BREAK on Windows), escalating to SIGKILL only if they hang. If one child crashes, the other is torn down too.
- Verified end-to-end, including a full graceful backend lifespan shutdown on SIGINT with no orphaned processes.

## `scripts/diagnose.py` — environment health check

```
$ python scripts/diagnose.py
  [PASS] Python version  — 3.11.15 (>= 3.10)
  [PASS] Python dependencies  — 6 core packages present
  [PASS] Core modules  — 4 modules import cleanly
  [PASS] Algorithm registry  — 58 behavior algorithms registered
  [PASS] Simulation smoke test  — 50 frames OK, 13 fish alive (517 fps headless)
  [PASS] Frontend dependencies  — frontend/node_modules present
  [PASS] Node toolchain  — node and npm on PATH
  [PASS] Pre-commit hook  — installed
  ✓ 8 passed, 0 warning(s), 0 failure(s) — all good!
```

- Required checks (Python version, deps, core imports, registry, live sim) fail the run with **exit 1**; optional tooling (Node, pre-commit) only **warns** and keeps exit 0 — so it doubles as a CI/setup gate.
- Every failure prints an actionable `→ hint`. Colors auto-disable when not a TTY or under `NO_COLOR`.

## Tests

- `tests/smoke/test_diagnose.py` — exercises each check and the runner (asserts a healthy dev env passes, the runner exits 0, and no check raises).
- `tests/smoke/test_start_launcher.py` — covers the launcher's pure helpers (URLs, `--backend-only` preflight, color toggle) **without** spawning servers.

All 9 smoke tests pass; `pre-commit` (black + ruff + isort) is clean.

## Docs

- README Quick Start now leads with `python start.py` and a setup-verification `python scripts/diagnose.py`, keeping the two-terminal flow as an alternative.
- SETUP.md troubleshooting points at the health check first.
- `scripts/README.md` gains a "Start here" entry; `IMPROVEMENT_PROPOSALS.md` moves 4.1/4.2 to Shipped.

## Verification

- `python scripts/diagnose.py` → exit 0, all checks pass.
- `python start.py --backend-only --no-browser` → backend boots, SIGINT → full graceful shutdown, no orphans.
- `pytest tests/smoke/` → 9 passed.
- `pre-commit run` → all hooks pass.

https://claude.ai/code/session_01EVh3JZFE3wxHFvXXDYatNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVh3JZFE3wxHFvXXDYatNc)_