### PR TITLE
meta: Add benchmark fingerprint instrumentation for determinism bisec…

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -51,7 +51,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: champion-verification-results
-          path: verify_*.json
+          path: |
+            verify_*.json
+            verify_*.jsonl
           if-no-files-found: ignore
 
   benchmark-gate:

--- a/benchmarks/tank/ecosystem_health_10k.py
+++ b/benchmarks/tank/ecosystem_health_10k.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import math
 import sys
 import time
+from collections.abc import Callable
 from typing import Any
 
 from core.worlds import WorldRegistry
@@ -53,7 +54,9 @@ CONFIG: dict[str, Any] = {
 }
 
 
-def run(seed: int) -> dict[str, Any]:
+def run(
+    seed: int, fingerprint_callback: Callable[[Any, int], None] | None = None
+) -> dict[str, Any]:
     """Run the benchmark deterministically.
 
     Args:
@@ -68,6 +71,8 @@ def run(seed: int) -> dict[str, Any]:
 
     world = WorldRegistry.create_world("tank", seed=seed, config=config)
     world.reset(seed=seed, config=config)
+    if fingerprint_callback is not None:
+        fingerprint_callback(world, 0)
 
     # Accumulators
     population_samples = []
@@ -77,6 +82,8 @@ def run(seed: int) -> dict[str, Any]:
 
     for i in range(FRAMES):
         world.step()
+        if fingerprint_callback is not None:
+            fingerprint_callback(world, i + 1)
 
         if (i + 1) % SAMPLE_INTERVAL == 0:
             stats = world.get_stats(include_distributions=False)

--- a/benchmarks/tank/survival_5k.py
+++ b/benchmarks/tank/survival_5k.py
@@ -10,6 +10,7 @@ all entities in the world (which would include food, crabs, balls, etc.).
 
 import sys
 import time
+from collections.abc import Callable
 from typing import Any
 
 from core.worlds import WorldRegistry
@@ -41,7 +42,9 @@ WORLD_CONFIG: dict[str, Any] = {
 CONFIG: dict[str, Any] = {"frames": FRAMES, "world_config": WORLD_CONFIG}
 
 
-def run(seed: int) -> dict[str, Any]:
+def run(
+    seed: int, fingerprint_callback: Callable[[Any, int], None] | None = None
+) -> dict[str, Any]:
     """Run the benchmark deterministically.
 
     Args:
@@ -56,6 +59,8 @@ def run(seed: int) -> dict[str, Any]:
 
     world = WorldRegistry.create_world("tank", seed=seed, config=config)
     world.reset(seed=seed, config=config)
+    if fingerprint_callback is not None:
+        fingerprint_callback(world, 0)
 
     # Metrics accumulators
     total_fish_energy_integral = 0.0
@@ -67,6 +72,8 @@ def run(seed: int) -> dict[str, Any]:
     # Run loop
     for i in range(FRAMES):
         world.step()
+        if fingerprint_callback is not None:
+            fingerprint_callback(world, i + 1)
 
         # Sample metrics every frame for accuracy
         stats = world.get_stats(include_distributions=False)

--- a/core/replay/__init__.py
+++ b/core/replay/__init__.py
@@ -6,12 +6,15 @@ This package provides:
 """
 
 from core.replay.fingerprint import SnapshotFingerprinter, fingerprint_snapshot
+from core.replay.fingerprint_stream import FingerprintStreamRecorder, compare_fingerprint_streams
 from core.replay.jsonl import JsonlReplayReader, JsonlReplayWriter, ReplayFormatError
 
 __all__ = [
+    "FingerprintStreamRecorder",
     "JsonlReplayReader",
     "JsonlReplayWriter",
     "ReplayFormatError",
     "SnapshotFingerprinter",
+    "compare_fingerprint_streams",
     "fingerprint_snapshot",
 ]

--- a/core/replay/fingerprint_stream.py
+++ b/core/replay/fingerprint_stream.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+import sys
+from collections import defaultdict
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, TextIO
+
+from core.replay.fingerprint import SnapshotFingerprinter
+
+FINGERPRINT_STREAM_VERSION = 1
+
+
+def _snapshot_for_fingerprint(world: Any) -> dict[str, Any]:
+    debug_snapshot = getattr(world, "get_debug_snapshot", None)
+    if callable(debug_snapshot):
+        return dict(debug_snapshot())
+    return dict(world.get_current_snapshot())
+
+
+def _environment_manifest() -> dict[str, Any]:
+    environment_keys = (
+        "GLIBC_TUNABLES",
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_RUN_ID",
+        "PYTHONHASHSEED",
+        "RUNNER_ARCH",
+        "RUNNER_NAME",
+        "RUNNER_OS",
+    )
+    return {
+        "python_version": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "python_executable": sys.executable,
+        "platform": platform.platform(),
+        "libc": platform.libc_ver(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "cpu_count": os.cpu_count(),
+        "environment": {key: os.environ[key] for key in environment_keys if key in os.environ},
+    }
+
+
+def _entity_groups(snapshot: Mapping[str, Any]) -> dict[str, list[Any]]:
+    groups: dict[str, list[Any]] = defaultdict(list)
+    entities = snapshot.get("entities", [])
+    if not isinstance(entities, list):
+        return {}
+    for entity in entities:
+        entity_type = "unknown"
+        if isinstance(entity, Mapping):
+            entity_type = str(entity.get("type", "unknown"))
+        groups[entity_type].append(entity)
+    return dict(sorted(groups.items()))
+
+
+class FingerprintStreamRecorder:
+    """Write periodic benchmark snapshot fingerprints for divergence bisection."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        benchmark_id: str,
+        seed: int,
+        interval: int = 100,
+    ) -> None:
+        if interval < 1:
+            raise ValueError("interval must be >= 1")
+
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.interval = interval
+        self._exact = SnapshotFingerprinter(float_precision=None)
+        self._rounded = SnapshotFingerprinter(float_precision=6)
+        self._fh: TextIO = self.path.open("w", encoding="utf-8", newline="\n")
+        self._write(
+            {
+                "type": "header",
+                "version": FINGERPRINT_STREAM_VERSION,
+                "benchmark_id": benchmark_id,
+                "seed": seed,
+                "interval": interval,
+                "environment": _environment_manifest(),
+                "fingerprints": {
+                    "algorithm": self._exact.algorithm,
+                    "digest_size": self._exact.digest_size,
+                    "exact_float_precision": None,
+                    "rounded_float_precision": self._rounded.float_precision,
+                },
+            }
+        )
+
+    def record(self, world: Any, frame: int) -> None:
+        if frame != 0 and frame % self.interval != 0:
+            return
+
+        snapshot = _snapshot_for_fingerprint(world)
+        entity_groups = _entity_groups(snapshot)
+        self._write(
+            {
+                "type": "checkpoint",
+                "frame": frame,
+                "exact": self._fingerprint_parts(snapshot, entity_groups, self._exact),
+                "rounded": self._fingerprint_parts(snapshot, entity_groups, self._rounded),
+                "entity_counts": {name: len(entities) for name, entities in entity_groups.items()},
+            }
+        )
+
+    def finish(self, result: Mapping[str, Any]) -> None:
+        self._write(
+            {
+                "type": "result",
+                "score": result.get("score"),
+                "metadata": result.get("metadata", {}),
+            }
+        )
+        self.close()
+
+    def close(self) -> None:
+        if not self._fh.closed:
+            self._fh.close()
+
+    def _fingerprint_parts(
+        self,
+        snapshot: dict[str, Any],
+        entity_groups: dict[str, list[Any]],
+        fingerprinter: SnapshotFingerprinter,
+    ) -> dict[str, Any]:
+        without_entities = {key: value for key, value in snapshot.items() if key != "entities"}
+        return {
+            "snapshot": fingerprinter.fingerprint(snapshot),
+            "world": fingerprinter.fingerprint(without_entities),
+            "entities": fingerprinter.fingerprint({"entities": snapshot.get("entities", [])}),
+            "entity_types": {
+                name: fingerprinter.fingerprint({"entities": entities})
+                for name, entities in entity_groups.items()
+            },
+        }
+
+    def _write(self, record: dict[str, Any]) -> None:
+        self._fh.write(json.dumps(record, separators=(",", ":"), ensure_ascii=True))
+        self._fh.write("\n")
+        self._fh.flush()
+
+
+def compare_fingerprint_streams(left_path: str | Path, right_path: str | Path) -> dict[str, Any]:
+    """Return the first exact and rounded divergences between two streams."""
+
+    left = _read_checkpoints(left_path)
+    right = _read_checkpoints(right_path)
+    frames = sorted(set(left) | set(right))
+    return {
+        "exact": _first_divergence(left, right, frames, "exact"),
+        "rounded": _first_divergence(left, right, frames, "rounded"),
+    }
+
+
+def _read_checkpoints(path: str | Path) -> dict[int, dict[str, Any]]:
+    checkpoints: dict[int, dict[str, Any]] = {}
+    with Path(path).open(encoding="utf-8") as fh:
+        for line in fh:
+            record = json.loads(line)
+            if record.get("type") == "checkpoint":
+                checkpoints[int(record["frame"])] = record
+    return checkpoints
+
+
+def _first_divergence(
+    left: dict[int, dict[str, Any]],
+    right: dict[int, dict[str, Any]],
+    frames: list[int],
+    precision: str,
+) -> dict[str, Any] | None:
+    if not frames:
+        return {"frame": None, "reason": "no_checkpoints"}
+
+    for frame in frames:
+        left_record = left.get(frame)
+        right_record = right.get(frame)
+        if left_record is None or right_record is None:
+            return {"frame": frame, "reason": "missing_checkpoint"}
+
+        left_parts = left_record[precision]
+        right_parts = right_record[precision]
+        if left_parts["snapshot"] == right_parts["snapshot"]:
+            continue
+
+        differing_entity_types = sorted(
+            name
+            for name in set(left_parts["entity_types"]) | set(right_parts["entity_types"])
+            if left_parts["entity_types"].get(name) != right_parts["entity_types"].get(name)
+        )
+        differing_parts = [
+            name for name in ("world", "entities") if left_parts.get(name) != right_parts.get(name)
+        ]
+        return {
+            "frame": frame,
+            "reason": "fingerprint_mismatch",
+            "differing_parts": differing_parts,
+            "differing_entity_types": differing_entity_types,
+            "left_entity_counts": left_record.get("entity_counts", {}),
+            "right_entity_counts": right_record.get("entity_counts", {}),
+        }
+    return None

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -85,6 +85,13 @@ frame's code path, eliminate the environment input. Then re-land the
 food-targeting improvement (the revert preserved it in git history at
 e1fed26; it beat both tank champions on every local environment).
 
+**Instrumentation status.** Benchmark fingerprint streams now record exact and
+6-decimal-rounded snapshot hashes, entity-type component hashes/counts, and an
+environment manifest every 100 frames. Ecosystem champion verification runs
+twice, compares the streams within CI, and uploads both streams for comparison
+with local runs. Use `tools/compare_fingerprint_streams.py` to report the first
+exact and rounded divergent frames.
+
 
 ### 1.2 Score decomposition in benchmark output — `S` · ★★
 **Problem.** `survival_5k` reports a single opaque scalar

--- a/docs/REPLAY.md
+++ b/docs/REPLAY.md
@@ -47,3 +47,22 @@ The repo includes a small golden replay fixture used as a determinism regression
 If an *intentional* behavior change breaks the golden replay, regenerate the
 fixture with `backend.replay.record_file` (same seed/steps/switch plan) and
 commit it alongside the change, noting why in the commit message.
+
+## Benchmark fingerprint streams
+
+Tank benchmarks can emit periodic diagnostic fingerprints without changing
+their scoring:
+
+```bash
+python tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py \
+  --seed 42 --verify-determinism \
+  --fingerprint-out local.jsonl --fingerprint-every 100
+python tools/compare_fingerprint_streams.py local.jsonl ci.jsonl
+```
+
+Each checkpoint contains exact-float and 6-decimal-rounded snapshot hashes,
+plus hashes and counts grouped by entity type. Exact divergence identifies
+numerical jitter; rounded divergence identifies the first meaningful
+trajectory split. With `--verify-determinism`, the second stream is written
+beside the first as `local.run2.jsonl` and compared automatically. Champion
+verification emits both ecosystem streams as CI artifacts.

--- a/tests/test_fingerprint_stream.py
+++ b/tests/test_fingerprint_stream.py
@@ -1,0 +1,85 @@
+import json
+from pathlib import Path
+
+from core.replay.fingerprint_stream import (
+    FingerprintStreamRecorder,
+    compare_fingerprint_streams,
+)
+from tools.run_bench import second_fingerprint_path
+
+
+class FakeWorld:
+    def __init__(self, snapshot):
+        self.snapshot = snapshot
+
+    def get_debug_snapshot(self):
+        return self.snapshot
+
+
+def _write_stream(path, snapshots):
+    recorder = FingerprintStreamRecorder(path, benchmark_id="test/fake", seed=42, interval=10)
+    world = FakeWorld({})
+    for frame, snapshot in snapshots:
+        world.snapshot = snapshot
+        recorder.record(world, frame)
+    recorder.finish({"score": 1.0, "metadata": {}})
+
+
+def test_fingerprint_stream_records_periodic_component_hashes(tmp_path):
+    path = tmp_path / "nested" / "stream.jsonl"
+    _write_stream(
+        path,
+        [
+            (0, {"frame": 0, "entities": [{"type": "fish", "x": 1.0}]}),
+            (1, {"frame": 1, "entities": [{"type": "fish", "x": 2.0}]}),
+            (10, {"frame": 10, "entities": [{"type": "fish", "x": 3.0}]}),
+        ],
+    )
+
+    records = [json.loads(line) for line in path.read_text().splitlines()]
+    checkpoints = [record for record in records if record["type"] == "checkpoint"]
+
+    assert [record["frame"] for record in checkpoints] == [0, 10]
+    assert checkpoints[0]["entity_counts"] == {"fish": 1}
+    assert "fish" in checkpoints[0]["exact"]["entity_types"]
+
+
+def test_compare_reports_exact_jitter_before_rounded_divergence(tmp_path):
+    left = tmp_path / "left.jsonl"
+    right = tmp_path / "right.jsonl"
+    _write_stream(
+        left,
+        [
+            (0, {"frame": 0, "entities": [{"type": "fish", "x": 1.00000001}]}),
+            (10, {"frame": 10, "entities": [{"type": "fish", "x": 2.0}]}),
+        ],
+    )
+    _write_stream(
+        right,
+        [
+            (0, {"frame": 0, "entities": [{"type": "fish", "x": 1.00000002}]}),
+            (10, {"frame": 10, "entities": [{"type": "fish", "x": 3.0}]}),
+        ],
+    )
+
+    comparison = compare_fingerprint_streams(left, right)
+
+    assert comparison["exact"]["frame"] == 0
+    assert comparison["rounded"]["frame"] == 10
+    assert comparison["rounded"]["differing_entity_types"] == ["fish"]
+
+
+def test_second_fingerprint_path_preserves_jsonl_suffix():
+    assert Path(second_fingerprint_path("results/run.jsonl")) == Path("results/run.run2.jsonl")
+
+
+def test_compare_rejects_streams_without_checkpoints(tmp_path):
+    left = tmp_path / "left.jsonl"
+    right = tmp_path / "right.jsonl"
+    left.write_text('{"type":"header"}\n')
+    right.write_text('{"type":"header"}\n')
+
+    comparison = compare_fingerprint_streams(left, right)
+
+    assert comparison["exact"]["reason"] == "no_checkpoints"
+    assert comparison["rounded"]["reason"] == "no_checkpoints"

--- a/tools/compare_fingerprint_streams.py
+++ b/tools/compare_fingerprint_streams.py
@@ -1,0 +1,27 @@
+"""Compare two benchmark fingerprint JSONL artifacts."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from core.replay.fingerprint_stream import compare_fingerprint_streams
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("left")
+    parser.add_argument("right")
+    args = parser.parse_args()
+
+    comparison = compare_fingerprint_streams(args.left, args.right)
+    print(json.dumps(comparison, indent=2))
+    if comparison["rounded"] is not None:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_bench.py
+++ b/tools/run_bench.py
@@ -6,6 +6,7 @@ Usage:
 
 import argparse
 import importlib.util
+import inspect
 import json
 import os
 import sys
@@ -29,6 +30,35 @@ def load_benchmark_module(path: str):
     return module
 
 
+def run_benchmark(bench_module, seed: int, fingerprint_recorder=None):
+    """Run a benchmark, attaching fingerprint recording when supported."""
+    parameters = inspect.signature(bench_module.run).parameters
+    if fingerprint_recorder is not None and "fingerprint_callback" not in parameters:
+        raise ValueError(
+            f"{bench_module.BENCHMARK_ID} does not support fingerprint artifacts "
+            "(run() needs fingerprint_callback)"
+        )
+    if fingerprint_recorder is None:
+        return bench_module.run(seed)
+    return bench_module.run(seed, fingerprint_callback=fingerprint_recorder.record)
+
+
+def create_fingerprint_recorder(path: str, bench_module, seed: int, interval: int):
+    from core.replay.fingerprint_stream import FingerprintStreamRecorder
+
+    return FingerprintStreamRecorder(
+        path,
+        benchmark_id=bench_module.BENCHMARK_ID,
+        seed=seed,
+        interval=interval,
+    )
+
+
+def second_fingerprint_path(path: str) -> str:
+    fingerprint_path = Path(path)
+    return str(fingerprint_path.with_name(f"{fingerprint_path.stem}.run2{fingerprint_path.suffix}"))
+
+
 def main():
     parser = argparse.ArgumentParser(description="Run a benchmark")
     parser.add_argument("benchmark_path", help="Path to benchmark python file")
@@ -36,6 +66,13 @@ def main():
     parser.add_argument("--out", help="Output JSON path")
     parser.add_argument(
         "--verify-determinism", action="store_true", help="Run twice and assert identical output"
+    )
+    parser.add_argument("--fingerprint-out", help="Write periodic snapshot fingerprints as JSONL")
+    parser.add_argument(
+        "--fingerprint-every",
+        type=int,
+        default=100,
+        help="Fingerprint interval in frames (default: 100)",
     )
 
     args = parser.parse_args()
@@ -52,11 +89,41 @@ def main():
         print(f"Running benchmark: {bench_module.BENCHMARK_ID} (Seed: {args.seed})...")
 
         # Run 1
-        result1 = bench_module.run(args.seed)
+        recorder = None
+        if args.fingerprint_out:
+            recorder = create_fingerprint_recorder(
+                args.fingerprint_out,
+                bench_module,
+                args.seed,
+                args.fingerprint_every,
+            )
+        try:
+            result1 = run_benchmark(bench_module, args.seed, recorder)
+            if recorder is not None:
+                recorder.finish(result1)
+        except Exception:
+            if recorder is not None:
+                recorder.close()
+            raise
 
         if args.verify_determinism:
             print("Verifying determinism (Run 2)...")
-            result2 = bench_module.run(args.seed)
+            recorder2 = None
+            if args.fingerprint_out:
+                recorder2 = create_fingerprint_recorder(
+                    second_fingerprint_path(args.fingerprint_out),
+                    bench_module,
+                    args.seed,
+                    args.fingerprint_every,
+                )
+            try:
+                result2 = run_benchmark(bench_module, args.seed, recorder2)
+                if recorder2 is not None:
+                    recorder2.finish(result2)
+            except Exception:
+                if recorder2 is not None:
+                    recorder2.close()
+                raise
 
             # Compare critical fields
             score_diff = abs(result1["score"] - result2["score"])
@@ -65,6 +132,17 @@ def main():
                     f"FATAL: Non-deterministic result! Score {result1['score']} != {result2['score']}"
                 )
                 sys.exit(1)
+
+            if args.fingerprint_out:
+                from core.replay.fingerprint_stream import compare_fingerprint_streams
+
+                comparison = compare_fingerprint_streams(
+                    args.fingerprint_out, second_fingerprint_path(args.fingerprint_out)
+                )
+                print(f"Fingerprint comparison: {json.dumps(comparison, sort_keys=True)}")
+                if comparison["rounded"] is not None:
+                    print("FATAL: Rounded snapshot fingerprints diverged.")
+                    sys.exit(1)
 
             # Compare metadata recursively if needed, but score is the main gate
             print("Determinism check PASSED.")

--- a/tools/verify_all_champions.py
+++ b/tools/verify_all_champions.py
@@ -69,6 +69,17 @@ def main():
                 "--out",
                 out_file,
             ]
+            if bench_id.startswith("tank/"):
+                cmd.extend(
+                    [
+                        "--fingerprint-out",
+                        f"verify_{os.path.basename(bench_id)}.fingerprints.jsonl",
+                        "--fingerprint-every",
+                        "100",
+                    ]
+                )
+            if bench_id == "tank/ecosystem_health_10k":
+                cmd.append("--verify-determinism")
 
             subprocess.check_call(cmd)
 


### PR DESCRIPTION
…tion

Implement backlog item 1.0 - fingerprint instrumentation for tracking cross-environment determinism divergences.

New:
- core/replay/fingerprint_stream.py: FingerprintStreamRecorder with dual exact/rounded snapshot hashes, entity-type component hashes/counts, and environment manifests at configurable intervals
- tools/compare_fingerprint_streams.py: CLI to report first exact and rounded divergent frames between two JSONL streams
- tests/test_fingerprint_stream.py: 4 tests covering recording, comparison, path generation, and edge cases

Modified:
- benchmarks/tank/{survival_5k,ecosystem_health_10k}.py: optional fingerprint_callback parameter (backwards-compatible)
- tools/run_bench.py: --fingerprint-out, --fingerprint-every flags; auto-compare streams when --verify-determinism is used
- tools/verify_all_champions.py: auto-enable fingerprints for tank benchmarks; ecosystem gets --verify-determinism (2x runs)
- .github/workflows/bench.yml: upload .jsonl fingerprint artifacts
- docs/REPLAY.md, docs/IMPROVEMENT_PROPOSALS.md: usage docs and status

Validation:
- 1771 passed, 4 skipped, 2 xpassed
- Black, Ruff clean
- No observer effect: fingerprinting does not alter benchmark scores