### PR TITLE
docs: add worker-agent task sample for the soccer/poker Trends tab

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,6 +21,7 @@ This index provides a guide to all documentation in the Tank World project.
 | [VISION.md](VISION.md) | Long-term goals and the multi-layer evolution paradigm |
 | [ROADMAP.md](ROADMAP.md) | Development roadmap and milestones |
 | [IMPROVEMENT_PROPOSALS.md](IMPROVEMENT_PROPOSALS.md) | Prioritized engineering backlog with implementation plans |
+| [UI_IMPROVEMENTS.md](UI_IMPROVEMENTS.md) | Must-implement UI roadmap, including soccer/poker skill-over-time tracking |
 | [MULTILEVEL_EVOLUTION_STRATEGY.md](MULTILEVEL_EVOLUTION_STRATEGY.md) | Multi-level evolutionary optimization strategy |
 
 ### Architecture

--- a/docs/UI_IMPROVEMENTS.md
+++ b/docs/UI_IMPROVEMENTS.md
@@ -74,6 +74,11 @@ If every fish gets better at poker at the same rate, internal win rates stay fla
 tab and see, in one glance, whether poker ELO vs. baseline and soccer scoring rate
 went up, down, or flat — and the data survives a page refresh.
 
+**Ready-to-hand-off task brief**: a complete worker-agent sample for this item —
+task prompt, data contracts, file-by-file change map, component skeleton, and
+acceptance checklist — lives at
+[examples/ui_trends_worker_task.md](examples/ui_trends_worker_task.md).
+
 ---
 
 ## 2. Ecosystem Time-Series Charts ★★★

--- a/docs/UI_IMPROVEMENTS.md
+++ b/docs/UI_IMPROVEMENTS.md
@@ -1,0 +1,219 @@
+# UI Improvements: The Must-Implement List
+
+> Prioritized list of UI improvements we should **100% implement** to make Tank World
+> more appealing and easier to use. Each item is grounded in the current codebase
+> (file paths included) so an agent or human can pick one up and start immediately.
+>
+> Visual/design rules live in [UI_SPEC.md](UI_SPEC.md) — everything here must conform
+> to that spec. Smaller engineering items are tracked in
+> [IMPROVEMENT_PROPOSALS.md](IMPROVEMENT_PROPOSALS.md); this document is the strategic
+> UI roadmap and cross-references those proposals where they overlap.
+
+---
+
+## The Gap This List Closes
+
+The web UI today is a good **live observatory**: real-time canvas, ecosystem stats,
+poker and soccer leaderboards, energy-flow panels. What it almost completely lacks is
+**memory**. Every panel shows the current frame; refresh the page and all history is
+gone. For a project whose entire premise is *evolution* — change over time — the UI
+cannot currently answer its most interesting question:
+
+> **"Is the population actually getting better at anything?"**
+
+Items 1–3 fix that. Items 4–8 lower the barrier to entry and deepen engagement.
+
+---
+
+## 1. Soccer & Poker Skill-Over-Time Tracking ★★★ (the headline feature)
+
+**What**: Persistent time-series charts showing whether the fish population is
+*improving* at soccer and poker across frames, generations, and sessions.
+
+**Why this is #1**: It is the single most compelling story the UI can tell — visible
+proof that evolution works. Today the only longitudinal signal is the 20-point,
+in-memory sparkline in `frontend/src/components/PokerScoreDisplay.tsx`, which is lost
+on page refresh. Soccer has no trend view at all (`SoccerLeagueLive.tsx` shows only
+the current match and leaderboard).
+
+**The measurement trap to avoid**: win rates *within* the population are zero-sum.
+If every fish gets better at poker at the same rate, internal win rates stay flat at
+~50%. Improvement is only measurable against a **fixed reference**:
+
+- **Poker**: the auto-evaluation machinery already plays fish against scripted
+  baseline opponents (see `EvolutionBenchmarkDisplay`, the auto-eval stats in
+  `frontend/src/components/tank_tabs/TankPokerTab.tsx`, and
+  `core/poker_stats_manager.py`). Record the population's mean/median ELO vs. these
+  frozen baselines at a regular frame interval.
+- **Soccer**: record per-match aggregate skill proxies from
+  `core/systems/soccer_system.py` / `core/minigames/soccer/` — goals per 1k frames,
+  goal-progress events per match, and (ideally) periodic exhibition matches against a
+  frozen baseline team, mirroring the poker auto-eval pattern.
+
+**Implementation sketch**:
+
+1. **Backend metrics history service**: a ring buffer (e.g., one sample per 500
+   frames, last N=2000 samples) collected in `backend/runner/stats_collector.py`,
+   persisted alongside the existing auto-save (`backend/auto_save_service.py`) so
+   history survives restarts.
+2. **API**: a `GET /api/world/{world_id}/metrics/history` endpoint plus an initial
+   `MetricsHistoryPayload` on WebSocket connect (extend
+   `backend/state_payloads.py`); subsequent samples ride the existing delta stream.
+3. **Frontend**: a new **Trends tab** alongside the existing tank tabs in
+   `frontend/src/components/tank_tabs/`, with line charts for:
+   - Poker: population ELO vs. baseline, showdown win rate, net energy from poker
+   - Soccer: goals/1k frames, baseline-match results, kick/possession events
+   - Overlaid generation markers so skill gains can be tied to genetic turnover
+   `recharts` is already in `frontend/package.json` (currently unused) — use it
+   rather than hand-rolling charts, styled per UI_SPEC tokens.
+4. **Per-generation aggregation**: bucket samples by `max_generation` so the x-axis
+   can toggle between *frames* and *generations* — "Gen 12 plays measurably better
+   poker than Gen 3" is the headline claim this feature exists to support.
+
+**Acceptance**: after a 30k-frame headless or live run, a user can open the Trends
+tab and see, in one glance, whether poker ELO vs. baseline and soccer scoring rate
+went up, down, or flat — and the data survives a page refresh.
+
+---
+
+## 2. Ecosystem Time-Series Charts ★★★
+
+**What**: Line charts for population, births/deaths per interval, generation count,
+algorithm diversity (Shannon entropy), and mean energy over time.
+
+**Why**: `StatsPanel.tsx` and `TankEcosystemTab.tsx` show instantaneous values only.
+A population crash, a starvation spiral, or a diversity collapse is invisible unless
+you happen to be watching. These are exactly the "Healthy Ecosystem Indicators"
+already defined in CLAUDE.md — the UI should chart them, not just snapshot them.
+
+**Implementation**: same metrics-history pipeline as item 1 (build the buffer once,
+feed both features). All values already exist per-frame in `StatsPayload`
+(`backend/state_payloads.py`); this is purely retention + charting.
+
+---
+
+## 3. Champion Progress Dashboard ★★
+
+**What**: A view (UI panel or `/evolution` route) that renders the
+`champions/*/*.json` registries — current score per benchmark plus the `history`
+array of retired champions — as a "best known solution over time" chart.
+
+**Why**: Layer 1 evolution (AI agents improving algorithms via PRs) is the project's
+core thesis, and it is completely invisible in the UI. The data already exists and is
+versioned (`champions/tank/survival_5k.json`, `champions/tank/ecosystem_health_10k.json`,
+`champions/soccer/training_3k.json`, `champions/soccer/training_5k.json`); each file
+carries score, seed, timestamp, and full champion history. A simple static read +
+chart makes the whole evolution loop legible to newcomers — and answers "is the
+*codebase* improving at soccer?" the same way item 1 answers it for the live
+population.
+
+**Implementation**: a small backend endpoint that serves the champions directory as
+JSON, plus a recharts step-chart per benchmark (score vs. timestamp, one point per
+champion entry).
+
+---
+
+## 4. Entity Inspector ★★
+
+**What**: Clicking a fish opens an inspector panel: genome traits (physical *and*
+behavioral), behavior algorithm name + parameters, energy/age/generation, poker
+record (games, win rate, best hand), and soccer involvement (kicks, goals).
+
+**Why**: Today, clicking an entity only opens the transfer dialog
+(`frontend/src/components/TransferDialog.tsx`). The simulation's stated design value
+is *interpretable algorithms*, yet there is no way to ask "what is this fish and why
+is it doing that?" — the single most natural question a viewer has. The backend
+already strips behavior parameters from entity snapshots
+(`backend/runner/state_publisher.py`); the inspector needs an on-demand
+`get entity detail` command over the existing WebSocket command channel rather than
+bloating the broadcast stream.
+
+**Bonus**: surface **behavioral genes** (threat response, food approach, social mode,
+poker engagement) side-by-side with the physical ones — `EcosystemStats.tsx` shows
+population-level distributions, but no per-fish view exists.
+
+---
+
+## 5. One-Command Startup ★★★
+
+**What**: `python start.py` launches backend + frontend together (dev mode), prints
+one URL, and handles ctrl-C cleanly.
+
+**Why**: The current two-terminal dance (`python main.py` + `cd frontend && npm run dev`)
+is the first friction every new user hits. Easiest single win for "easy to use."
+Already specced as proposal **4.1** in
+[IMPROVEMENT_PROPOSALS.md](IMPROVEMENT_PROPOSALS.md) — listed here because it is a
+hard prerequisite for the project being appealing to anyone new.
+
+---
+
+## 6. First-Run Onboarding Overlay ★★
+
+**What**: A dismissible "what am I looking at?" overlay (or `?` keyboard shortcut)
+that labels the canvas and panels: these are fish (colors = genome), this is food,
+that's the soccer ball, fish bet energy at poker, energy above max funds offspring.
+
+**Why**: Tank World's premise is unusual; a first-time visitor sees colorful dots and
+has no idea that a full evolutionary economy is running. One overlay converts
+confusion into the "wait, the fish play *poker*?" hook. Follow the existing modal
+pattern (UI_SPEC §14, phylogenetic tree overlay) — no new design system needed.
+
+---
+
+## 7. Visual Assets in the README ★★★
+
+**What**: An animated GIF of the live tank plus 2–3 screenshots (poker tab, soccer
+match, ecosystem charts once item 2 lands) at the top of `README.md`.
+
+**Why**: This is the project's storefront and currently text-only. For a project that
+is literally a living aquarium, not showing it is the biggest missed marketing
+opportunity. Already specced as proposal **5.1**; bundling it here because items 1–3
+create the screenshots worth showing.
+
+---
+
+## 8. Event Timeline Scrubber ★
+
+**What**: A horizontal timeline strip under the canvas marking notable events
+(goals, big poker pots, births, deaths, extinctions, generation milestones), with
+hover tooltips. Pairs naturally with the deterministic replay harness
+(`backend/replay.py`, [REPLAY.md](REPLAY.md)) for an eventual "jump back and watch
+that goal" interaction.
+
+**Why**: Events currently scroll away in per-tab logs (`PokerEvents.tsx`,
+`SoccerLeagueEvents.tsx`) and are easy to miss. A timeline gives the simulation a
+narrative. Ranked last because items 1–2 deliver more insight per unit effort — but
+it is the most "alive"-feeling feature on the list.
+
+---
+
+## Sequencing & Shared Infrastructure
+
+| Order | Item | Depends on |
+|-------|------|------------|
+| 1 | Metrics history buffer + persistence (backend) | — |
+| 2 | Trends tab: soccer/poker skill over time (item 1) | metrics buffer |
+| 3 | Ecosystem time-series charts (item 2) | metrics buffer |
+| 4 | One-command startup (item 5) | — (independent, do anytime) |
+| 5 | Champion progress dashboard (item 3) | — (static data, independent) |
+| 6 | Entity inspector (item 4) | WebSocket command channel (exists) |
+| 7 | Onboarding overlay (item 6) | — |
+| 8 | README visuals (item 7) | best after charts exist |
+| 9 | Event timeline scrubber (item 8) | nice-to-have |
+
+**Build the metrics-history buffer once; three features feed off it.** Charts should
+use the `recharts` dependency already present in `frontend/package.json`, styled with
+UI_SPEC tokens (no raw hex, glass-panel/dashboard-card containers, JetBrains Mono for
+numbers).
+
+## Ground Rules
+
+- Every chart must remain correct under fast-forward and across reconnects
+  (delta-stream resync happens every 90 frames — see
+  `backend/runner/state_publisher.py`).
+- Skill metrics must be measured against **fixed baselines**, never only intra-population
+  win rates (zero-sum trap, see item 1).
+- These are Layer 2 (tooling/UI) changes: keep them in separate PRs from any Layer 1
+  algorithm changes, per [EVO_CONTRIBUTING.md](EVO_CONTRIBUTING.md).
+- Determinism is non-negotiable: metrics collection must not perturb simulation
+  state or RNG consumption.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -30,3 +30,4 @@ python scripts/submit_solution.py report --print
 ## Files
 
 - **ai_tournament_results.json**: Sample AI poker tournament results from Dec 2025. Shows tournament structure with Elo ratings, skill tiers, and head-to-head matchup data between different AI models.
+- **ui_trends_worker_task.md**: Hand-off sample for a worker agent implementing the soccer/poker skill-over-time Trends tab ([UI_IMPROVEMENTS.md](../UI_IMPROVEMENTS.md) item 1): task prompt, data contracts, change map, acceptance checklist.

--- a/docs/examples/ui_trends_worker_task.md
+++ b/docs/examples/ui_trends_worker_task.md
@@ -1,0 +1,180 @@
+# Worker Task Sample: Soccer & Poker Skill-Over-Time (Trends Tab)
+
+> **This file is a hand-off sample.** Give it to a worker agent verbatim. It
+> implements item 1 (and the shared infrastructure for item 2) of
+> [../UI_IMPROVEMENTS.md](../UI_IMPROVEMENTS.md). It contains the task prompt,
+> the exact data contracts to implement, the file-by-file change map, a frontend
+> skeleton, and the acceptance checklist.
+
+---
+
+## Task Prompt (copy-paste to the worker agent)
+
+> Implement the "Trends" feature described in `docs/UI_IMPROVEMENTS.md` item 1,
+> following the contracts and file map in `docs/examples/ui_trends_worker_task.md`
+> exactly. Build the backend metrics-history buffer, expose it over the existing
+> WebSocket/REST surface, and add a Trends tab to the frontend showing whether
+> the population is improving at poker and soccer over time. Do not change any
+> simulation behavior, RNG consumption, or benchmark scoring — this is a Layer 2
+> (tooling/UI) change and must be a separate PR from any algorithm work. Run
+> `python tools/smoke_gate.py` before coding and `python tools/fast_gate.py`
+> plus `cd frontend && npm run lint && npm run build` before pushing.
+
+---
+
+## 1. What "improving" means (read this first)
+
+Win rates *inside* the population are zero-sum: if every fish gets better at the
+same rate, internal win rates stay flat at ~50%. Improvement is only measurable
+against **fixed references**:
+
+- **Poker**: the auto-evaluation system already plays fish against scripted
+  baseline opponents and reports ELO (`AutoEvaluateStatsPayload` in
+  `backend/state_payloads.py`, surfaced today as a 20-point ephemeral sparkline
+  in `frontend/src/components/PokerScoreDisplay.tsx`). Sample that ELO over time.
+- **Soccer**: there is no baseline opponent yet, so use absolute production
+  rates as the v1 proxy: goals per 1k frames and completed matches, computed
+  from the soccer events already collected by
+  `backend/runner/hooks/soccer_mixin.py`. Leave a `baseline_match_score_diff`
+  field in the schema as `null` for the future frozen-baseline exhibition match.
+
+Overlay `max_generation` on every sample so the charts can answer the headline
+question: *"does Gen 12 play better than Gen 3?"*
+
+## 2. Data contract
+
+### 2.1 MetricsSample (one row, collected every `sample_interval_frames`)
+
+```json
+{
+  "frame": 12000,
+  "max_generation": 7,
+  "population": 34,
+  "births_total": 61,
+  "deaths_total": 47,
+  "fish_energy": 2841.6,
+  "poker": {
+    "auto_eval_elo": 1287.4,
+    "total_games": 96,
+    "showdown_win_rate": 0.54,
+    "net_energy_total": 412.5
+  },
+  "soccer": {
+    "goals_total": 11,
+    "goals_per_1k_frames": 0.92,
+    "matches_completed": 4,
+    "matches_skipped": 2,
+    "baseline_match_score_diff": null
+  }
+}
+```
+
+Field sources (all already exist — no new simulation instrumentation):
+
+| Field | Source |
+|---|---|
+| `frame`, `population`, `births_total`, `deaths_total`, `max_generation`, `fish_energy` | `StatsPayload` fields built in `backend/runner/stats_collector.py` |
+| `poker.auto_eval_elo` | auto-eval ELO history (`AutoEvaluateStatsPayload.performance_history`, `backend/state_payloads.py:595`) |
+| `poker.total_games`, `poker.showdown_win_rate`, `poker.net_energy_total` | `PokerStatsPayload` (`backend/state_payloads.py:181`) |
+| `soccer.*` | cumulative counters over `SoccerEventPayload` events (`score_left + score_right`, `skipped`, `skip_reason`) collected by `backend/runner/hooks/soccer_mixin.py` |
+
+### 2.2 MetricsHistoryPayload (the buffer)
+
+```json
+{
+  "schema_version": 1,
+  "world_id": "tank-1",
+  "sample_interval_frames": 500,
+  "max_samples": 2000,
+  "samples": [ "...MetricsSample, oldest first..." ]
+}
+```
+
+- Ring buffer: one sample per 500 frames, capacity 2000 (≈1M frames of history).
+- Persistence: serialize the buffer with the existing auto-save
+  (`backend/auto_save_service.py`) so history survives restarts; tolerate a
+  missing/old-schema buffer on load (start empty, never crash).
+
+### 2.3 Transport
+
+- **REST**: `GET /api/world/{world_id}/metrics/history` → `MetricsHistoryPayload`
+  (add a router under `backend/routers/`, register in `backend/app_factory.py`).
+- **WebSocket**: include the full `MetricsHistoryPayload` once in the initial
+  full state (`FullStatePayload`, `backend/state_payloads.py:609`); afterwards,
+  append-only — attach a new sample to the delta frame on the frame it is taken
+  (extend the delta payload the same way `soccer_league_live` is attached).
+  Bump `STATE_SCHEMA_VERSION`.
+
+## 3. File-by-file change map
+
+| File | Change |
+|---|---|
+| `backend/metrics_history.py` (new) | `MetricsHistory` ring buffer: `maybe_sample(frame, stats, poker, soccer, auto_eval)`, `to_payload()`, `load()/dump()` for auto-save |
+| `backend/state_payloads.py` | Add `MetricsSamplePayload` + `MetricsHistoryPayload` dataclasses (follow the existing `_to_dict` pattern); add optional field to full/delta payloads; bump `STATE_SCHEMA_VERSION` |
+| `backend/runner/stats_collector.py` | Call `metrics_history.maybe_sample(...)` from the existing per-frame stats build (read-only inputs; must not touch engine state) |
+| `backend/auto_save_service.py` | Persist/restore the buffer alongside existing snapshot data |
+| `backend/routers/metrics.py` (new) | `GET /api/world/{world_id}/metrics/history` |
+| `frontend/src/types/simulation.ts` | `MetricsSample`, `MetricsHistory` interfaces mirroring §2 |
+| `frontend/src/hooks/useWebSocket.ts` | Store history from initial state; append samples from deltas; cap at `max_samples` |
+| `frontend/src/components/tank_tabs/TankTrendsTab.tsx` (new) | The Trends tab (skeleton in §4) |
+| `frontend/src/components/TankView.tsx` | Register the tab + panel toggle next to `TankSoccerTab`/`TankPokerTab` (`frontend/src/components/TankView.tsx:377`) |
+| `tests/` | Unit tests: ring-buffer capacity/interval, payload round-trip, determinism guard (running with collection on/off yields identical sim state hashes) |
+
+## 4. Frontend skeleton
+
+`recharts` (v2.15.4) is already in `frontend/package.json` — use it. Style per
+[UI_SPEC.md](../UI_SPEC.md): dashboard-card containers, CSS variable colors
+(poker = `--color-secondary` violet, soccer = `--color-success` emerald,
+population = `--color-primary` cyan), JetBrains Mono for numbers, no raw hex.
+
+```tsx
+// frontend/src/components/tank_tabs/TankTrendsTab.tsx
+import { LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine, ResponsiveContainer } from 'recharts';
+import type { MetricsHistory } from '../../types/simulation';
+
+interface TankTrendsTabProps {
+    history: MetricsHistory | null;
+}
+
+type XAxisMode = 'frames' | 'generations';
+
+export function TankTrendsTab({ history }: TankTrendsTabProps) {
+    // 1. Empty state: "Collecting samples… first point at frame 500."
+    // 2. X-axis toggle: frames | generations (bucket samples by max_generation,
+    //    plot the per-generation mean when in generation mode).
+    // 3. Charts (one dashboard-card each, ~180px tall, ResponsiveContainer):
+    //    a. Poker ELO vs baseline   — samples[].poker.auto_eval_elo
+    //       + ReferenceLine at the first sample's ELO ("starting skill")
+    //    b. Soccer goals / 1k frames — samples[].soccer.goals_per_1k_frames
+    //    c. Population & generation — population line + max_generation step line
+    // 4. Generation markers: vertical ReferenceLines where max_generation increments.
+    // 5. Trend badge per chart: Δ between mean of first and last quartile of
+    //    samples, rendered ▲ green / ▼ red / ◆ gray (see UI_SPEC §2.6 deltas).
+}
+```
+
+## 5. Acceptance checklist
+
+- [ ] `python main.py --headless --max-frames 30000 --export-stats results.json --seed 42`
+      runs unchanged: byte-identical `results.json` vs. master at the same seed
+      (determinism guard — collection must not perturb the sim).
+- [ ] After a live 30k-frame run, the Trends tab shows poker ELO, soccer
+      goals/1k frames, and population charts with ≥ 50 samples.
+- [ ] Page refresh and backend restart both preserve history (auto-save).
+- [ ] X-axis toggles between frames and generations; generation markers render.
+- [ ] Empty/fresh world shows the empty state, not a crash or blank panel.
+- [ ] Reconnect mid-run does not duplicate or reorder samples (delta resync
+      happens every 90 frames — see `backend/runner/state_publisher.py`).
+- [ ] `python tools/fast_gate.py` passes; `cd frontend && npm run lint && npm run build` pass.
+- [ ] No UI_SPEC violations: tokens only, dashboard-card pattern, panel toggle
+      added with `aria-pressed`.
+- [ ] PR contains only Layer 2 changes (no `core/algorithms/`, `core/config/`,
+      `benchmarks/`, or `champions/` edits).
+
+## 6. Out of scope (do not do in this PR)
+
+- Frozen-baseline soccer exhibition matches (schema slot reserved:
+  `baseline_match_score_diff`).
+- Champion progress dashboard (UI_IMPROVEMENTS item 3).
+- Entity inspector (item 4).
+- Any change to poker/soccer gameplay, rewards, or energy accounting.


### PR DESCRIPTION
## Summary

Follow-up to #596. Adds `docs/examples/ui_trends_worker_task.md` — a complete, self-contained hand-off sample a worker agent can be given verbatim to implement **UI_IMPROVEMENTS.md item 1** (soccer/poker skill-over-time tracking).

## What's in the sample

- **Copy-paste task prompt** for the worker agent, including the validation gates to run.
- **Data contracts**: `MetricsSample` and `MetricsHistoryPayload` JSON schemas, with every field mapped to its existing source (`StatsPayload`, `PokerStatsPayload`, `AutoEvaluateStatsPayload.performance_history`, soccer events from `soccer_mixin.py`) — no new simulation instrumentation needed.
- **File-by-file change map** across backend (ring buffer, payloads, stats collector hook, auto-save persistence, REST router) and frontend (types, WebSocket hook, new `TankTrendsTab`, registration in `TankView.tsx`).
- **Component skeleton** using the `recharts` dependency already in `package.json`, with UI_SPEC-conformant styling notes.
- **Acceptance checklist**, headlined by a determinism guard: byte-identical `results.json` at seed 42 vs. master, since metrics collection must not perturb the sim.
- **Explicit out-of-scope list** to keep the PR Layer 2-only (frozen-baseline soccer matches reserved in the schema as `baseline_match_score_diff: null`).

Also links the sample from UI_IMPROVEMENTS.md item 1 and the examples README.

Docs-only change; `pre-commit` passes.

https://claude.ai/code/session_01AvkzgSuUwVLQYMfHVN5ahi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvkzgSuUwVLQYMfHVN5ahi)_