### PR TITLE
Add persistent tank metrics trends

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -298,7 +298,14 @@ def create_app(
 
 def _setup_routers(app: FastAPI, ctx: AppContext) -> None:
     """Setup and include all API routers."""
-    from backend.routers import connections, discovery, servers, transfers, websocket
+    from backend.routers import (
+        connections,
+        discovery,
+        metrics,
+        servers,
+        transfers,
+        websocket,
+    )
     from backend.routers.solutions import create_solutions_router
     from backend.routers.worlds import setup_worlds_router
 
@@ -338,5 +345,9 @@ def _setup_routers(app: FastAPI, ctx: AppContext) -> None:
     # Setup worlds router (world-agnostic API)
     worlds_router = setup_worlds_router(ctx.world_manager)
     app.include_router(worlds_router)
+
+    # Setup metrics history router
+    metrics_router = metrics.setup_router(ctx.world_manager)
+    app.include_router(metrics_router)
 
     ctx.logger.info("All API routers configured successfully")

--- a/backend/metrics_history.py
+++ b/backend/metrics_history.py
@@ -1,0 +1,168 @@
+"""Metrics history buffer for tracking poker and soccer skill over time."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def get_val(obj: Any, attr: str, default: Any = 0) -> Any:
+    """Safely get value from dictionary or object."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(attr, default)
+    return getattr(obj, attr, default)
+
+
+class MetricsHistory:
+    """Ring buffer for simulation metrics history."""
+
+    def __init__(
+        self,
+        world_id: str | None = None,
+        sample_interval_frames: int = 500,
+        max_samples: int = 2000,
+    ) -> None:
+        self.schema_version = 1
+        self.world_id = world_id or "unknown"
+        self.sample_interval_frames = sample_interval_frames
+        self.max_samples = max_samples
+        self.samples: list[dict[str, Any]] = []
+
+        # Cumulative soccer counters
+        self.soccer_goals_total = 0
+        self.soccer_matches_completed = 0
+        self.soccer_matches_skipped = 0
+        self.processed_soccer_match_ids: set[str] = set()
+
+    def maybe_sample(
+        self,
+        frame: int,
+        stats: Any,
+        poker: Any,
+        soccer: Any,
+        auto_eval: Any,
+    ) -> None:
+        """Sample metrics if the frame interval is reached."""
+        # 1. Update cumulative soccer counters from the events list passed
+        if soccer:
+            for event in soccer:
+                match_id = get_val(event, "match_id", None)
+                if not match_id or match_id in self.processed_soccer_match_ids:
+                    continue
+
+                self.processed_soccer_match_ids.add(match_id)
+
+                score_left = get_val(event, "score_left", 0)
+                score_right = get_val(event, "score_right", 0)
+                skipped = get_val(event, "skipped", False)
+
+                self.soccer_goals_total += score_left + score_right
+                if skipped:
+                    self.soccer_matches_skipped += 1
+                else:
+                    self.soccer_matches_completed += 1
+
+        # 2. Check if we should record a sample for this frame
+        if frame > 0 and frame % self.sample_interval_frames == 0:
+            # Avoid duplicate samples for the same frame
+            if not self.samples or self.samples[-1]["frame"] < frame:
+                # Extract poker ELO
+                auto_eval_elo = 1200.0
+                if stats is not None:
+                    poker_elo = get_val(stats, "poker_elo", None)
+                    if poker_elo is not None:
+                        auto_eval_elo = poker_elo
+
+                # Extract poker stats
+                poker_total_games = 0
+                poker_showdown_win_rate = 0.0
+                poker_net_energy = 0.0
+                if poker is not None:
+                    poker_total_games = get_val(poker, "total_games", 0)
+                    poker_net_energy = get_val(poker, "net_energy", 0.0)
+
+                    raw_win_rate = get_val(poker, "showdown_win_rate", "0.0%")
+                    if isinstance(raw_win_rate, str):
+                        try:
+                            poker_showdown_win_rate = float(raw_win_rate.rstrip("%")) / 100.0
+                        except ValueError:
+                            poker_showdown_win_rate = 0.0
+                    elif isinstance(raw_win_rate, (int, float)):
+                        poker_showdown_win_rate = float(raw_win_rate)
+
+                goals_per_1k_frames = (
+                    (self.soccer_goals_total / frame) * 1000.0 if frame > 0 else 0.0
+                )
+
+                sample = {
+                    "frame": frame,
+                    "max_generation": get_val(stats, "max_generation", 0),
+                    "population": get_val(stats, "population", 0),
+                    "births_total": get_val(stats, "births", 0),
+                    "deaths_total": get_val(stats, "deaths", 0),
+                    "fish_energy": round(get_val(stats, "fish_energy", 0.0), 2),
+                    "poker": {
+                        "auto_eval_elo": round(auto_eval_elo, 2),
+                        "total_games": poker_total_games,
+                        "showdown_win_rate": round(poker_showdown_win_rate, 4),
+                        "net_energy_total": round(poker_net_energy, 2),
+                    },
+                    "soccer": {
+                        "goals_total": self.soccer_goals_total,
+                        "goals_per_1k_frames": round(goals_per_1k_frames, 4),
+                        "matches_completed": self.soccer_matches_completed,
+                        "matches_skipped": self.soccer_matches_skipped,
+                        "baseline_match_score_diff": None,
+                    },
+                }
+
+                self.samples.append(sample)
+
+                # Keep buffer within capacity
+                if len(self.samples) > self.max_samples:
+                    self.samples.pop(0)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Convert metrics history to a serializable dictionary."""
+        return {
+            "schema_version": self.schema_version,
+            "world_id": self.world_id,
+            "sample_interval_frames": self.sample_interval_frames,
+            "max_samples": self.max_samples,
+            "samples": self.samples,
+            # State fields needed to resume cumulative counting
+            "_soccer_goals_total": self.soccer_goals_total,
+            "_soccer_matches_completed": self.soccer_matches_completed,
+            "_soccer_matches_skipped": self.soccer_matches_skipped,
+            "_processed_soccer_match_ids": list(self.processed_soccer_match_ids),
+        }
+
+    def load(self, payload: dict[str, Any] | None) -> None:
+        """Load history from a payload, tolerating old/invalid formats."""
+        if not payload or not isinstance(payload, dict):
+            logger.info("MetricsHistory: missing or invalid payload, starting empty.")
+            return
+
+        try:
+            self.schema_version = payload.get("schema_version", 1)
+            self.world_id = payload.get("world_id", self.world_id)
+            self.sample_interval_frames = payload.get(
+                "sample_interval_frames", self.sample_interval_frames
+            )
+            self.max_samples = payload.get("max_samples", self.max_samples)
+            self.samples = payload.get("samples", [])
+
+            # Reload accumulators
+            self.soccer_goals_total = payload.get("_soccer_goals_total", 0)
+            self.soccer_matches_completed = payload.get("_soccer_matches_completed", 0)
+            self.soccer_matches_skipped = payload.get("_soccer_matches_skipped", 0)
+            self.processed_soccer_match_ids = set(payload.get("_processed_soccer_match_ids", []))
+            logger.info(
+                f"MetricsHistory: loaded {len(self.samples)} samples for world {self.world_id}"
+            )
+        except Exception as e:
+            logger.warning(f"MetricsHistory: failed to load payload due to {e}. Starting empty.")

--- a/backend/routers/metrics.py
+++ b/backend/routers/metrics.py
@@ -1,0 +1,38 @@
+"""Metrics history REST API router."""
+
+import logging
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+
+from backend.world_manager import WorldManager
+
+logger = logging.getLogger(__name__)
+
+
+def setup_router(world_manager: WorldManager) -> APIRouter:
+    """Create and configure the metrics history router."""
+    router = APIRouter(prefix="/api/world", tags=["metrics"])
+
+    @router.get("/{world_id}/metrics/history")
+    async def get_metrics_history(world_id: str) -> JSONResponse:
+        """Get metrics history for a specific world."""
+        instance = world_manager.get_world(world_id)
+        if instance is None:
+            raise HTTPException(status_code=404, detail=f"World not found: {world_id}")
+
+        runner = instance.runner
+        metrics_history = getattr(runner, "metrics_history", None)
+        if metrics_history is None:
+            return JSONResponse(
+                {
+                    "schema_version": 1,
+                    "world_id": world_id,
+                    "sample_interval_frames": 500,
+                    "max_samples": 2000,
+                    "samples": [],
+                }
+            )
+
+        return JSONResponse(metrics_history.to_payload())
+
+    return router

--- a/backend/runner/loop.py
+++ b/backend/runner/loop.py
@@ -54,6 +54,7 @@ def run_simulation_loop(runner: SimulationRunner) -> None:
                                 runner.world.step()
                             runner.perf_tracker.stop("update")
                             stepped = True
+                            runner._sample_metrics_if_due()
                         except Exception as e:
                             logger.error(
                                 f"Simulation loop: Error updating world at frame {loop_iteration_count}: {e}",

--- a/backend/runner/state_publisher.py
+++ b/backend/runner/state_publisher.py
@@ -160,6 +160,39 @@ class StatePublisher:
         # Get tank soccer enabled state from config
         tank_soccer_enabled = self._get_tank_soccer_enabled(runner)
 
+        # Build metrics history payload if available
+        metrics_history_payload = None
+        if hasattr(runner, "metrics_history") and runner.metrics_history is not None:
+            from backend.state_payloads import (
+                MetricsHistoryPayload,
+                MetricsPokerSamplePayload,
+                MetricsSamplePayload,
+                MetricsSoccerSamplePayload,
+            )
+
+            samples = []
+            for s in runner.metrics_history.samples:
+                samples.append(
+                    MetricsSamplePayload(
+                        frame=s["frame"],
+                        max_generation=s["max_generation"],
+                        population=s["population"],
+                        births_total=s["births_total"],
+                        deaths_total=s["deaths_total"],
+                        fish_energy=s["fish_energy"],
+                        poker=MetricsPokerSamplePayload(**s["poker"]),
+                        soccer=MetricsSoccerSamplePayload(**s["soccer"]),
+                    )
+                )
+
+            metrics_history_payload = MetricsHistoryPayload(
+                schema_version=runner.metrics_history.schema_version,
+                world_id=runner.metrics_history.world_id,
+                sample_interval_frames=runner.metrics_history.sample_interval_frames,
+                max_samples=runner.metrics_history.max_samples,
+                samples=samples,
+            )
+
         return FullStatePayload(
             frame=frame,
             elapsed_time=elapsed_time,
@@ -175,6 +208,7 @@ class StatePublisher:
             world_type=runner.world_type,
             view_mode=runner.view_mode,
             tank_soccer_enabled=tank_soccer_enabled,
+            metrics_history=metrics_history_payload,
         )
 
     def _build_delta_state(
@@ -223,6 +257,31 @@ class StatePublisher:
         # Get tank soccer enabled state from config
         tank_soccer_enabled = self._get_tank_soccer_enabled(runner)
 
+        # Build new metrics sample if taken on this frame
+        new_metrics_sample_payload = None
+        if hasattr(runner, "metrics_history") and runner.metrics_history is not None:
+            if (
+                runner.metrics_history.samples
+                and runner.metrics_history.samples[-1]["frame"] == frame
+            ):
+                from backend.state_payloads import (
+                    MetricsPokerSamplePayload,
+                    MetricsSamplePayload,
+                    MetricsSoccerSamplePayload,
+                )
+
+                s = runner.metrics_history.samples[-1]
+                new_metrics_sample_payload = MetricsSamplePayload(
+                    frame=s["frame"],
+                    max_generation=s["max_generation"],
+                    population=s["population"],
+                    births_total=s["births_total"],
+                    deaths_total=s["deaths_total"],
+                    fish_energy=s["fish_energy"],
+                    poker=MetricsPokerSamplePayload(**s["poker"]),
+                    soccer=MetricsSoccerSamplePayload(**s["soccer"]),
+                )
+
         return DeltaStatePayload(
             frame=frame,
             elapsed_time=elapsed_time,
@@ -237,6 +296,7 @@ class StatePublisher:
             world_type=runner.world_type,
             view_mode=runner.view_mode,
             tank_soccer_enabled=tank_soccer_enabled,
+            new_metrics_sample=new_metrics_sample_payload,
         )
 
     def _get_tank_soccer_enabled(self, runner: Any) -> bool | None:

--- a/backend/runner/stats_collector.py
+++ b/backend/runner/stats_collector.py
@@ -125,10 +125,37 @@ def collect_stats(
     meta_stats = build_meta_stats(stats)
     poker_stats = collect_poker_stats_payload(stats)
 
-    return StatsPayload(
+    stats_payload = StatsPayload(
         **base_stats,
         **energy_stats,
         **physical_stats,
         poker_stats=poker_stats,
         meta_stats=meta_stats,
     )
+
+    if hasattr(runner, "metrics_history") and runner.metrics_history is not None:
+        # Collect soccer events if hooks are present
+        soccer_events = []
+        if hasattr(runner.world_hooks, "collect_soccer_events"):
+            try:
+                soccer_events = runner.world_hooks.collect_soccer_events(runner) or []
+            except Exception:
+                pass
+
+        # Collect auto-eval if hooks are present
+        auto_eval = None
+        if hasattr(runner.world_hooks, "collect_auto_eval"):
+            try:
+                auto_eval = runner.world_hooks.collect_auto_eval(runner)
+            except Exception:
+                pass
+
+        runner.metrics_history.maybe_sample(
+            frame=frame,
+            stats=stats_payload,
+            poker=poker_stats,
+            soccer=soccer_events,
+            auto_eval=auto_eval,
+        )
+
+    return stats_payload

--- a/backend/runner/world_switch.py
+++ b/backend/runner/world_switch.py
@@ -86,6 +86,7 @@ def switch_world_type(runner: SimulationRunner, new_world_type: str) -> None:
             new_world = tank_backend
 
         runner.world = new_world
+        runner.world.runner = runner
         runner.world_type = new_world_type
 
         # Update metadata from registry

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -24,6 +24,7 @@ from backend.runner.perf_tracker import PerfTracker
 from backend.runner.state_builders import collect_poker_stats_payload
 from backend.runner.state_publisher import StatePublisher
 from backend.runner.world_hooks import get_hooks_for_world
+from backend.metrics_history import MetricsHistory
 from backend.state_payloads import EntitySnapshot, PokerStatsPayload, StatsPayload
 from backend.world_registry import create_world, get_world_metadata
 from core import entities
@@ -60,6 +61,7 @@ class SimulationRunner(CommandHandlerMixin):
         self.world, self._entity_snapshot_builder = create_world(
             world_type, seed=seed, config=self._config
         )
+        self.world.runner = self
 
         # Store world metadata for payloads
         metadata = get_world_metadata(world_type)
@@ -125,6 +127,9 @@ class SimulationRunner(CommandHandlerMixin):
         # Inject migration support into environment for fish to access
         self._update_environment_migration_context()
 
+        # Initialize metrics history tracking
+        self.metrics_history = MetricsHistory(world_id=self.world_id)
+
     def _require_hook_attr(self, attr: str) -> None:
         """Raise AttributeError if the world hooks don't support the attribute."""
         if not hasattr(self.world_hooks, attr):
@@ -186,6 +191,10 @@ class SimulationRunner(CommandHandlerMixin):
         self.world_id = world_id
         if world_name is not None:
             self.world_name = world_name
+
+        # Update metrics history world_id
+        if hasattr(self, "metrics_history") and self.metrics_history is not None:
+            self.metrics_history.world_id = world_id
 
         # Update hooks with new world identity
         if hasattr(self.world_hooks, "update_benchmark_tracker_path"):
@@ -375,6 +384,7 @@ class SimulationRunner(CommandHandlerMixin):
                     self.world.set_paused(True)
 
             self._start_auto_evaluation_if_needed()
+            self._sample_metrics_if_due()
             self.fps_frame_count += 1
             self.state_publisher.invalidate_cache()
 
@@ -398,6 +408,8 @@ class SimulationRunner(CommandHandlerMixin):
             self.world, self._entity_snapshot_builder = create_world(
                 self.world_type, seed=self.seed, config=self._config
             )
+            self.world.runner = self
+            self.metrics_history = MetricsHistory(world_id=self.world_id)
             # Use getattr/setattr or direct access if known to be an adapter
             if hasattr(self.world, "frame_count"):
                 self.world.frame_count = 0
@@ -466,6 +478,12 @@ class SimulationRunner(CommandHandlerMixin):
     def _collect_stats(self, frame: int, include_distributions: bool = True) -> StatsPayload:
         """Collect and organize simulation statistics (delegates to stats_collector)."""
         return stats_collector.collect_stats(self, frame, include_distributions)
+
+    def _sample_metrics_if_due(self) -> None:
+        """Collect a history sample even when no client is requesting state."""
+        frame = self.world.frame_count
+        if frame > 0 and frame % self.metrics_history.sample_interval_frames == 0:
+            self._collect_stats(frame, include_distributions=False)
 
     # Removed: _collect_poker_events, _collect_soccer_events, _collect_soccer_league_live,
     # _collect_poker_leaderboard, _collect_auto_eval (moved to WorldHooks)

--- a/backend/state_payloads.py
+++ b/backend/state_payloads.py
@@ -15,7 +15,7 @@ except ImportError:
     pass
 
 
-STATE_SCHEMA_VERSION = 1
+STATE_SCHEMA_VERSION = 2
 
 
 def _compact_dict(data: dict[str, Any]) -> dict[str, Any]:
@@ -32,6 +32,61 @@ def _to_dict(dataclass_obj: Any) -> dict[str, Any]:
         field.name: getattr(dataclass_obj, field.name)
         for field in dataclass_obj.__dataclass_fields__.values()
     }
+
+
+@dataclass
+class MetricsPokerSamplePayload:
+    auto_eval_elo: float
+    total_games: int
+    showdown_win_rate: float
+    net_energy_total: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return _to_dict(self)
+
+
+@dataclass
+class MetricsSoccerSamplePayload:
+    goals_total: int
+    goals_per_1k_frames: float
+    matches_completed: int
+    matches_skipped: int
+    baseline_match_score_diff: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return _to_dict(self)
+
+
+@dataclass
+class MetricsSamplePayload:
+    frame: int
+    max_generation: int
+    population: int
+    births_total: int
+    deaths_total: int
+    fish_energy: float
+    poker: MetricsPokerSamplePayload
+    soccer: MetricsSoccerSamplePayload
+
+    def to_dict(self) -> dict[str, Any]:
+        data = _to_dict(self)
+        data["poker"] = self.poker.to_dict()
+        data["soccer"] = self.soccer.to_dict()
+        return data
+
+
+@dataclass
+class MetricsHistoryPayload:
+    schema_version: int
+    world_id: str
+    sample_interval_frames: int
+    max_samples: int
+    samples: list[MetricsSamplePayload]
+
+    def to_dict(self) -> dict[str, Any]:
+        data = _to_dict(self)
+        data["samples"] = [s.to_dict() for s in self.samples]
+        return data
 
 
 @dataclass
@@ -625,6 +680,7 @@ class FullStatePayload:
     world_type: str | None = "tank"
     view_mode: str | None = "side"
     tank_soccer_enabled: bool | None = None  # Whether tank practice soccer (ball/goals) is enabled
+    metrics_history: MetricsHistoryPayload | None = None
 
     def to_dict(self) -> dict[str, Any]:
         # Build snapshot containing all simulation state
@@ -640,6 +696,8 @@ class FullStatePayload:
         }
         if self.auto_evaluation:
             snapshot["auto_evaluation"] = self.auto_evaluation.to_dict()
+        if self.metrics_history is not None:
+            snapshot["metrics_history"] = self.metrics_history.to_dict()
 
         # Top-level payload with metadata and nested snapshot
         data: dict[str, Any] = {
@@ -686,6 +744,7 @@ class DeltaStatePayload:
     world_type: str | None = "tank"
     view_mode: str | None = "side"
     tank_soccer_enabled: bool | None = None  # Whether tank practice soccer (ball/goals) is enabled
+    new_metrics_sample: MetricsSamplePayload | None = None
 
     def to_dict(self) -> dict[str, Any]:
         # Build snapshot containing delta simulation state
@@ -703,6 +762,8 @@ class DeltaStatePayload:
         snapshot["soccer_league_live"] = self.soccer_league_live
         if self.stats:
             snapshot["stats"] = self.stats.to_dict()
+        if self.new_metrics_sample is not None:
+            snapshot["new_metrics_sample"] = self.new_metrics_sample.to_dict()
 
         # Top-level payload with metadata and nested snapshot
         data: dict[str, Any] = {

--- a/backend/world_persistence.py
+++ b/backend/world_persistence.py
@@ -181,6 +181,9 @@ def save_world_state(
                 # Merge provided metadata
                 if metadata:
                     snapshot.update(metadata)
+                # Persist metrics history if available
+                if hasattr(runner, "metrics_history") and runner.metrics_history is not None:
+                    snapshot["metrics_history"] = runner.metrics_history.to_payload()
                 return save_snapshot_data(world_id, snapshot)
 
         logger.warning(f"World {world_id[:8]} does not support state capture")
@@ -268,6 +271,16 @@ def restore_world_from_snapshot(
         # Restore frame count on the engine
         if "frame" in snapshot:
             engine.frame_count = snapshot["frame"]
+
+        # Restore metrics history if present on snapshot and target has runner/metrics_history
+        runner = getattr(target_world, "runner", None)
+        if (
+            runner is not None
+            and hasattr(runner, "metrics_history")
+            and runner.metrics_history is not None
+        ):
+            if "metrics_history" in snapshot:
+                runner.metrics_history.load(snapshot["metrics_history"])
 
         # Clear existing entities via EntityManager (authoritative path)
         engine._entity_manager.clear()

--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -14,6 +14,7 @@ import {
     TankPokerTab,
     TankEcosystemTab,
     TankGeneticsTab,
+    TankTrendsTab,
 } from './tank_tabs';
 import styles from './TankView.module.css';
 
@@ -24,6 +25,7 @@ interface TankViewProps {
 const PANEL_CONFIG: { id: PanelId; label: string; icon: string }[] = [
     { id: 'soccer', label: 'Soccer', icon: '⚽' },
     { id: 'poker', label: 'Poker', icon: '♠' },
+    { id: 'trends', label: 'Trends', icon: '📈' },
     { id: 'ecosystem', label: 'Ecosystem', icon: '🌿' },
     { id: 'genetics', label: 'Genetics', icon: '🧬' },
 ];
@@ -397,6 +399,12 @@ export function TankView({ worldId }: TankViewProps) {
                                 sendCommandWithResponse={sendCommandWithResponse}
                                 worldType={effectiveWorldType}
                             />
+                        </CollapsiblePanel>
+                    )}
+
+                    {isVisible('trends') && (
+                        <CollapsiblePanel title="Trends" icon="📈">
+                            <TankTrendsTab history={state?.metrics_history ?? null} />
                         </CollapsiblePanel>
                     )}
 

--- a/frontend/src/components/tank_tabs/TankTrendsTab.tsx
+++ b/frontend/src/components/tank_tabs/TankTrendsTab.tsx
@@ -1,0 +1,529 @@
+import { useState } from 'react';
+import {
+    LineChart,
+    Line,
+    XAxis,
+    YAxis,
+    Tooltip,
+    ReferenceLine,
+    ResponsiveContainer,
+    CartesianGrid
+} from 'recharts';
+import type { MetricsHistory } from '../../types/simulation';
+
+interface TankTrendsTabProps {
+    history: MetricsHistory | null;
+}
+
+type XAxisMode = 'frames' | 'generations';
+
+interface AggregatedPoint {
+    max_generation: number;
+    population: number;
+    fish_energy: number;
+    births_total: number;
+    deaths_total: number;
+    poker: {
+        auto_eval_elo: number;
+    };
+    soccer: {
+        goals_per_1k_frames: number;
+    };
+}
+
+// Helper to calculate trend delta and percentage change between first and last quartiles
+function calculateTrend(values: number[]): { delta: number; pct: number } {
+    if (values.length < 2) return { delta: 0, pct: 0 };
+    const len = values.length;
+    const qSize = Math.max(1, Math.floor(len / 4));
+
+    const firstQuartile = values.slice(0, qSize);
+    const lastQuartile = values.slice(len - qSize);
+
+    const meanFirst = firstQuartile.reduce((a, b) => a + b, 0) / qSize;
+    const meanLast = lastQuartile.reduce((a, b) => a + b, 0) / qSize;
+
+    const delta = meanLast - meanFirst;
+    const pct = meanFirst !== 0 ? (delta / Math.abs(meanFirst)) * 100 : 0;
+
+    return { delta, pct };
+}
+
+interface TrendBadgeProps {
+    values: number[];
+    formatter?: (v: number) => string;
+}
+
+function TrendBadge({ values, formatter }: TrendBadgeProps) {
+    const { delta, pct } = calculateTrend(values);
+    const formatVal = formatter ? formatter(delta) : delta.toFixed(1);
+    const sign = delta > 0 ? '+' : '';
+
+    // Deem neutral if absolute delta is extremely close to 0 or percentage change is less than 0.1%
+    const isNeutral = Math.abs(delta) < 0.0001 || Math.abs(pct) < 0.1;
+
+    if (isNeutral) {
+        return (
+            <span style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px',
+                padding: '2px 8px',
+                borderRadius: '4px',
+                fontSize: '10px',
+                fontWeight: 600,
+                background: 'rgba(148, 163, 184, 0.15)',
+                color: '#94a3b8',
+                fontFamily: 'var(--font-mono)'
+            }}>
+                ◆ {sign}{formatVal} (0.0%)
+            </span>
+        );
+    }
+
+    const isPositive = delta > 0;
+    return (
+        <span style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '4px',
+            padding: '2px 8px',
+            borderRadius: '4px',
+            fontSize: '10px',
+            fontWeight: 600,
+            background: isPositive ? 'rgba(74, 222, 128, 0.15)' : 'rgba(248, 113, 113, 0.15)',
+            color: isPositive ? '#4ade80' : '#f87171',
+            fontFamily: 'var(--font-mono)'
+        }}>
+            {isPositive ? '▲' : '▼'} {sign}{formatVal} ({isPositive ? '+' : ''}{pct.toFixed(1)}%)
+        </span>
+    );
+}
+
+interface TooltipPayloadItem {
+    name: string;
+    value: number;
+    color?: string;
+}
+
+interface CustomTooltipProps {
+    active?: boolean;
+    payload?: TooltipPayloadItem[];
+    label?: number | string;
+    xAxisMode: XAxisMode;
+}
+
+// Custom Tooltip component for high-quality dark theme styling
+const CustomTooltip = ({ active, payload, label, xAxisMode }: CustomTooltipProps) => {
+    if (active && payload && payload.length && label !== undefined) {
+        return (
+            <div style={{
+                background: 'rgba(15, 23, 42, 0.95)',
+                border: '1px solid var(--card-border)',
+                borderRadius: '8px',
+                padding: '8px 12px',
+                boxShadow: '0 4px 20px rgba(0, 0, 0, 0.4)',
+                fontSize: '12px'
+            }}>
+                <div style={{
+                    color: 'var(--color-text-dim)',
+                    marginBottom: '4px',
+                    fontWeight: 600,
+                    fontFamily: 'var(--font-mono)'
+                }}>
+                    {xAxisMode === 'frames' ? `Frame: ${label.toLocaleString()}` : `Generation: ${label}`}
+                </div>
+                {payload.map((p, idx) => (
+                    <div key={idx} style={{
+                        color: p.color || 'var(--color-text-main)',
+                        display: 'flex',
+                        gap: '12px',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        fontFamily: 'var(--font-mono)',
+                        marginTop: idx > 0 ? '2px' : 0
+                    }}>
+                        <span>{p.name}:</span>
+                        <span style={{ fontWeight: 600 }}>{p.value.toLocaleString()}</span>
+                    </div>
+                ))}
+            </div>
+        );
+    }
+    return null;
+};
+
+export function TankTrendsTab({ history }: TankTrendsTabProps) {
+    const [xAxisMode, setXAxisMode] = useState<XAxisMode>('frames');
+
+    // Handle null or empty history state
+    if (!history || !history.samples || history.samples.length === 0) {
+        const nextSampleFrame = history?.sample_interval_frames || 500;
+        return (
+            <div style={{
+                background: 'var(--card-bg)',
+                border: '1px solid var(--card-border)',
+                borderRadius: 'var(--radius-md)',
+                padding: '32px',
+                textAlign: 'center',
+                color: 'var(--color-text-muted)',
+                fontFamily: 'var(--font-main)'
+            }}>
+                <div style={{ fontSize: '24px', marginBottom: '8px' }}>📈</div>
+                <div style={{ fontWeight: 600, color: 'var(--color-text-main)', marginBottom: '4px' }}>
+                    Collecting Trend Samples...
+                </div>
+                <div style={{ fontSize: '12px' }}>
+                    First data point will be collected at frame {nextSampleFrame.toLocaleString()}.
+                </div>
+            </div>
+        );
+    }
+
+    const { samples } = history;
+
+    // Aggregate samples by max_generation if in generations mode
+    let data: (import('../../types/simulation').MetricsSample | AggregatedPoint)[] = samples;
+    if (xAxisMode === 'generations') {
+        const genMap: Record<number, {
+            count: number;
+            populationSum: number;
+            eloSum: number;
+            goalsSum: number;
+            fishEnergySum: number;
+            birthsSum: number;
+            deathsSum: number;
+        }> = {};
+
+        samples.forEach(s => {
+            const gen = s.max_generation;
+            if (!genMap[gen]) {
+                genMap[gen] = {
+                    count: 0,
+                    populationSum: 0,
+                    eloSum: 0,
+                    goalsSum: 0,
+                    fishEnergySum: 0,
+                    birthsSum: 0,
+                    deathsSum: 0,
+                };
+            }
+            const g = genMap[gen];
+            g.count++;
+            g.populationSum += s.population;
+            g.eloSum += s.poker?.auto_eval_elo ?? 0;
+            g.goalsSum += s.soccer?.goals_per_1k_frames ?? 0;
+            g.fishEnergySum += s.fish_energy;
+            g.birthsSum += s.births_total;
+            g.deathsSum += s.deaths_total;
+        });
+
+        data = Object.keys(genMap)
+            .map(Number)
+            .sort((a, b) => a - b)
+            .map(gen => {
+                const g = genMap[gen];
+                return {
+                    max_generation: gen,
+                    population: Number((g.populationSum / g.count).toFixed(2)),
+                    poker: {
+                        auto_eval_elo: Number((g.eloSum / g.count).toFixed(2)),
+                    },
+                    soccer: {
+                        goals_per_1k_frames: Number((g.goalsSum / g.count).toFixed(4)),
+                    },
+                    fish_energy: Number((g.fishEnergySum / g.count).toFixed(2)),
+                    births_total: Number((g.birthsSum / g.count).toFixed(2)),
+                    deaths_total: Number((g.deathsSum / g.count).toFixed(2)),
+                };
+            });
+    }
+
+    // Determine the starting Elo reference line
+    const startingElo = data[0]?.poker?.auto_eval_elo ?? 1200;
+
+    // Identify generation boundary markers for vertical reference lines (only in frames mode)
+    const genMarkers: { frame: number; gen: number }[] = [];
+    if (xAxisMode === 'frames') {
+        for (let i = 1; i < samples.length; i++) {
+            if (samples[i].max_generation > samples[i - 1].max_generation) {
+                genMarkers.push({
+                    frame: samples[i].frame,
+                    gen: samples[i].max_generation
+                });
+            }
+        }
+    }
+
+    // Styles for the cards and layout
+    const gridStyle: React.CSSProperties = {
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+        gap: '16px',
+        marginTop: '8px'
+    };
+
+    const cardStyle: React.CSSProperties = {
+        background: 'var(--card-bg)',
+        border: '1px solid var(--card-border)',
+        borderRadius: 'var(--radius-md)',
+        padding: 'var(--spacing-md)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        height: '240px'
+    };
+
+    const cardHeaderStyle: React.CSSProperties = {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center'
+    };
+
+    const cardTitleStyle: React.CSSProperties = {
+        fontSize: '12px',
+        fontWeight: 600,
+        textTransform: 'uppercase',
+        letterSpacing: '0.05em',
+        color: 'var(--color-text-muted)'
+    };
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            {/* Toggle Bar */}
+            <div style={{ display: 'flex', gap: '8px' }}>
+                <button
+                    onClick={() => setXAxisMode('frames')}
+                    aria-pressed={xAxisMode === 'frames'}
+                    style={{
+                        padding: '6px 12px',
+                        fontSize: '11px',
+                        fontWeight: 600,
+                        borderRadius: '6px',
+                        border: '1px solid',
+                        cursor: 'pointer',
+                        background: xAxisMode === 'frames' ? 'rgba(6, 182, 212, 0.15)' : 'rgba(30, 41, 59, 0.5)',
+                        color: xAxisMode === 'frames' ? '#22d3ee' : 'var(--color-text-muted)',
+                        borderColor: xAxisMode === 'frames' ? 'rgba(6, 182, 212, 0.4)' : 'rgba(71, 85, 105, 0.5)',
+                        fontFamily: 'var(--font-main)',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.05em',
+                        transition: 'all 0.2s'
+                    }}
+                >
+                    Frames
+                </button>
+                <button
+                    onClick={() => setXAxisMode('generations')}
+                    aria-pressed={xAxisMode === 'generations'}
+                    style={{
+                        padding: '6px 12px',
+                        fontSize: '11px',
+                        fontWeight: 600,
+                        borderRadius: '6px',
+                        border: '1px solid',
+                        cursor: 'pointer',
+                        background: xAxisMode === 'generations' ? 'rgba(6, 182, 212, 0.15)' : 'rgba(30, 41, 59, 0.5)',
+                        color: xAxisMode === 'generations' ? '#22d3ee' : 'var(--color-text-muted)',
+                        borderColor: xAxisMode === 'generations' ? 'rgba(6, 182, 212, 0.4)' : 'rgba(71, 85, 105, 0.5)',
+                        fontFamily: 'var(--font-main)',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.05em',
+                        transition: 'all 0.2s'
+                    }}
+                >
+                    Generations
+                </button>
+            </div>
+
+            {/* Charts Grid */}
+            <div style={gridStyle}>
+                {/* 1. Poker ELO vs baseline */}
+                <div style={cardStyle}>
+                    <div style={cardHeaderStyle}>
+                        <span style={cardTitleStyle}>♠ Poker ELO (vs Baseline)</span>
+                        <TrendBadge
+                            values={data.map(d => d.poker?.auto_eval_elo ?? 1200)}
+                            formatter={(v) => `${v > 0 ? '+' : ''}${v.toFixed(1)}`}
+                        />
+                    </div>
+                    <div style={{ flex: 1, minHeight: 0 }}>
+                        <ResponsiveContainer width="100%" height="100%">
+                            <LineChart
+                                data={data}
+                                margin={{ top: 10, right: 10, left: -20, bottom: 0 }}
+                            >
+                                <CartesianGrid stroke="rgba(255,255,255,0.05)" vertical={false} />
+                                <XAxis
+                                    dataKey={xAxisMode === 'frames' ? 'frame' : 'max_generation'}
+                                    stroke="rgba(255,255,255,0.3)"
+                                    fontSize={10}
+                                    tickFormatter={(v) => xAxisMode === 'frames' ? `${(v/1000).toFixed(0)}k` : `${v}`}
+                                />
+                                <YAxis
+                                    stroke="rgba(255,255,255,0.3)"
+                                    fontSize={10}
+                                    domain={['auto', 'auto']}
+                                />
+                                <Tooltip
+                                    content={<CustomTooltip xAxisMode={xAxisMode} />}
+                                />
+                                <ReferenceLine
+                                    y={startingElo}
+                                    stroke="var(--color-text-dim)"
+                                    strokeDasharray="3 3"
+                                    label={{
+                                        value: 'starting skill',
+                                        position: 'insideBottomLeft',
+                                        fill: 'var(--color-text-dim)',
+                                        fontSize: 9
+                                    }}
+                                />
+                                {xAxisMode === 'frames' && genMarkers.map((m, idx) => (
+                                    <ReferenceLine
+                                        key={idx}
+                                        x={m.frame}
+                                        stroke="rgba(255,255,255,0.15)"
+                                        strokeDasharray="2 2"
+                                    />
+                                ))}
+                                <Line
+                                    type="monotone"
+                                    dataKey="poker.auto_eval_elo"
+                                    stroke="var(--color-secondary)"
+                                    strokeWidth={2}
+                                    name="Poker ELO"
+                                    dot={false}
+                                />
+                            </LineChart>
+                        </ResponsiveContainer>
+                    </div>
+                </div>
+
+                {/* 2. Soccer goals / 1k frames */}
+                <div style={cardStyle}>
+                    <div style={cardHeaderStyle}>
+                        <span style={cardTitleStyle}>⚽ Soccer Goals per 1k Frames</span>
+                        <TrendBadge
+                            values={data.map(d => d.soccer?.goals_per_1k_frames ?? 0)}
+                            formatter={(v) => `${v > 0 ? '+' : ''}${v.toFixed(2)}`}
+                        />
+                    </div>
+                    <div style={{ flex: 1, minHeight: 0 }}>
+                        <ResponsiveContainer width="100%" height="100%">
+                            <LineChart
+                                data={data}
+                                margin={{ top: 10, right: 10, left: -20, bottom: 0 }}
+                            >
+                                <CartesianGrid stroke="rgba(255,255,255,0.05)" vertical={false} />
+                                <XAxis
+                                    dataKey={xAxisMode === 'frames' ? 'frame' : 'max_generation'}
+                                    stroke="rgba(255,255,255,0.3)"
+                                    fontSize={10}
+                                    tickFormatter={(v) => xAxisMode === 'frames' ? `${(v/1000).toFixed(0)}k` : `${v}`}
+                                />
+                                <YAxis
+                                    stroke="rgba(255,255,255,0.3)"
+                                    fontSize={10}
+                                    domain={[0, 'auto']}
+                                />
+                                <Tooltip
+                                    content={<CustomTooltip xAxisMode={xAxisMode} />}
+                                />
+                                {xAxisMode === 'frames' && genMarkers.map((m, idx) => (
+                                    <ReferenceLine
+                                        key={idx}
+                                        x={m.frame}
+                                        stroke="rgba(255,255,255,0.15)"
+                                        strokeDasharray="2 2"
+                                    />
+                                ))}
+                                <Line
+                                    type="monotone"
+                                    dataKey="soccer.goals_per_1k_frames"
+                                    stroke="var(--color-success)"
+                                    strokeWidth={2}
+                                    name="Goals/1k Frames"
+                                    dot={false}
+                                />
+                            </LineChart>
+                        </ResponsiveContainer>
+                    </div>
+                </div>
+
+                {/* 3. Population & Generation */}
+                <div style={cardStyle}>
+                    <div style={cardHeaderStyle}>
+                        <span style={cardTitleStyle}>🐟 Population & Generation</span>
+                        <TrendBadge
+                            values={data.map(d => d.population)}
+                            formatter={(v) => `${v > 0 ? '+' : ''}${v.toFixed(1)}`}
+                        />
+                    </div>
+                    <div style={{ flex: 1, minHeight: 0 }}>
+                        <ResponsiveContainer width="100%" height="100%">
+                            <LineChart
+                                data={data}
+                                margin={{ top: 10, right: 10, left: -20, bottom: 0 }}
+                            >
+                                <CartesianGrid stroke="rgba(255,255,255,0.05)" vertical={false} />
+                                <XAxis
+                                    dataKey={xAxisMode === 'frames' ? 'frame' : 'max_generation'}
+                                    stroke="rgba(255,255,255,0.3)"
+                                    fontSize={10}
+                                    tickFormatter={(v) => xAxisMode === 'frames' ? `${(v/1000).toFixed(0)}k` : `${v}`}
+                                />
+                                <YAxis
+                                    yAxisId="left"
+                                    stroke="var(--color-primary)"
+                                    fontSize={10}
+                                    domain={[0, 'auto']}
+                                />
+                                <YAxis
+                                    yAxisId="right"
+                                    orientation="right"
+                                    stroke="rgba(255,255,255,0.4)"
+                                    fontSize={10}
+                                    domain={[0, 'auto']}
+                                    tickFormatter={(v) => `G${v}`}
+                                />
+                                <Tooltip
+                                    content={<CustomTooltip xAxisMode={xAxisMode} />}
+                                />
+                                {xAxisMode === 'frames' && genMarkers.map((m, idx) => (
+                                    <ReferenceLine
+                                        key={idx}
+                                        yAxisId="left"
+                                        x={m.frame}
+                                        stroke="rgba(255,255,255,0.15)"
+                                        strokeDasharray="2 2"
+                                    />
+                                ))}
+                                <Line
+                                    yAxisId="left"
+                                    type="monotone"
+                                    dataKey="population"
+                                    stroke="var(--color-primary)"
+                                    strokeWidth={2}
+                                    name="Population"
+                                    dot={false}
+                                />
+                                {xAxisMode === 'frames' && (
+                                    <Line
+                                        yAxisId="right"
+                                        type="stepAfter"
+                                        dataKey="max_generation"
+                                        stroke="rgba(255, 255, 255, 0.3)"
+                                        strokeDasharray="4 4"
+                                        name="Max Gen"
+                                        dot={false}
+                                    />
+                                )}
+                            </LineChart>
+                        </ResponsiveContainer>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/tank_tabs/index.ts
+++ b/frontend/src/components/tank_tabs/index.ts
@@ -3,3 +3,4 @@ export { TankSoccerTab } from './TankSoccerTab';
 export { TankPokerTab } from './TankPokerTab';
 export { TankEcosystemTab } from './TankEcosystemTab';
 export { TankGeneticsTab } from './TankGeneticsTab';
+export { TankTrendsTab } from './TankTrendsTab';

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -102,7 +102,7 @@ function getApiBaseUrl(): string {
     return 'http://localhost:8000';
 }
 
-export const EXPECTED_SCHEMA_VERSION = 1;
+export const EXPECTED_SCHEMA_VERSION = 2;
 
 export const config = {
     /** WebSocket URL for real-time simulation updates */

--- a/frontend/src/hooks/useVisiblePanels.ts
+++ b/frontend/src/hooks/useVisiblePanels.ts
@@ -1,9 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
 
-export type PanelId = 'soccer' | 'poker' | 'ecosystem' | 'genetics';
+export type PanelId = 'soccer' | 'poker' | 'ecosystem' | 'genetics' | 'trends';
 
 const STORAGE_KEY = 'tankview.visiblePanels.v1';
-const ALL_PANELS: PanelId[] = ['soccer', 'poker', 'ecosystem', 'genetics'];
+const ALL_PANELS: PanelId[] = ['soccer', 'poker', 'ecosystem', 'genetics', 'trends'];
 
 function sanitizePanels(value: unknown, fallback: PanelId[]): PanelId[] {
     if (!Array.isArray(value)) return fallback;

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -139,6 +139,7 @@ export function useWebSocket(worldId?: string) {
                         update.soccer_league_live = update.snapshot.soccer_league_live;
                         update.poker_leaderboard = update.snapshot.poker_leaderboard;
                         update.auto_evaluation = update.snapshot.auto_evaluation;
+                        update.metrics_history = update.snapshot.metrics_history;
                         // Preserve mode fields from server
                         update.view_mode = update.view_mode ?? 'side';
                         update.mode_id = update.mode_id ?? 'tank';
@@ -279,6 +280,7 @@ function applyDelta(state: SimulationUpdate, delta: DeltaUpdate): SimulationUpda
         poker_events: deltaEvents,
         soccer_events: deltaSoccerEvents,
         soccer_league_live: deltaSoccerLeagueLive,
+        new_metrics_sample: deltaNewMetricsSample,
     } = deltaSnapshot;
     const hasSoccerLeagueLive = Object.prototype.hasOwnProperty.call(
         deltaSnapshot,
@@ -339,6 +341,27 @@ function applyDelta(state: SimulationUpdate, delta: DeltaUpdate): SimulationUpda
         ? deltaSoccerEvents.slice(-100)
         : currentSoccerEvents;
 
+    // Handle metrics history
+    let nextMetricsHistory = currentSnapshot.metrics_history;
+    if (deltaNewMetricsSample) {
+        if (nextMetricsHistory) {
+            const maxSamples = nextMetricsHistory.max_samples || 2000;
+            const alreadyExists = nextMetricsHistory.samples.some(
+                s => s.frame === deltaNewMetricsSample.frame
+            );
+            if (!alreadyExists) {
+                const samples = [...nextMetricsHistory.samples, deltaNewMetricsSample];
+                if (samples.length > maxSamples) {
+                    samples.shift();
+                }
+                nextMetricsHistory = {
+                    ...nextMetricsHistory,
+                    samples,
+                };
+            }
+        }
+    }
+
     // Construct new snapshot
     const nextSnapshot = {
         ...currentSnapshot,
@@ -351,6 +374,7 @@ function applyDelta(state: SimulationUpdate, delta: DeltaUpdate): SimulationUpda
         soccer_league_live: hasSoccerLeagueLive
             ? deltaSoccerLeagueLive
             : currentSnapshot.soccer_league_live,
+        metrics_history: nextMetricsHistory,
     };
 
     return {
@@ -372,5 +396,6 @@ function applyDelta(state: SimulationUpdate, delta: DeltaUpdate): SimulationUpda
         soccer_league_live: nextSnapshot.soccer_league_live,
         stats: nextStats,
         poker_leaderboard: state.poker_leaderboard,
+        metrics_history: nextMetricsHistory,
     };
 }

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -509,6 +509,7 @@ export interface SimulationUpdate {
         poker_leaderboard: PokerLeaderboardEntry[];
         auto_evaluation?: AutoEvaluateStats;
         render_hint?: Record<string, unknown>;
+        metrics_history?: MetricsHistory | null;
     };
 
     // Convenience fields (populated by useWebSocket from snapshot)
@@ -521,6 +522,7 @@ export interface SimulationUpdate {
     soccer_league_live?: SoccerLeagueLiveState | null;
     poker_leaderboard?: PokerLeaderboardEntry[];
     auto_evaluation?: AutoEvaluateStats;
+    metrics_history?: MetricsHistory | null;
 }
 
 export interface DeltaUpdate {
@@ -555,6 +557,7 @@ export interface DeltaUpdate {
         soccer_league_live?: SoccerLeagueLiveState | null;
         stats?: StatsData;
         render_hint?: Record<string, unknown>;
+        new_metrics_sample?: MetricsSample | null;
     };
 }
 
@@ -766,4 +769,38 @@ export interface EvolutionBenchmarkData {
     history: BenchmarkSnapshot[];
     improvement: BenchmarkImprovementMetrics | Record<string, never>;
     latest: BenchmarkSnapshot | null;
+}
+
+export interface MetricsPokerSample {
+    auto_eval_elo: number;
+    total_games: number;
+    showdown_win_rate: number;
+    net_energy_total: number;
+}
+
+export interface MetricsSoccerSample {
+    goals_total: number;
+    goals_per_1k_frames: number;
+    matches_completed: number;
+    matches_skipped: number;
+    baseline_match_score_diff: number | null;
+}
+
+export interface MetricsSample {
+    frame: number;
+    max_generation: number;
+    population: number;
+    births_total: number;
+    deaths_total: number;
+    fish_energy: number;
+    poker: MetricsPokerSample;
+    soccer: MetricsSoccerSample;
+}
+
+export interface MetricsHistory {
+    schema_version: number;
+    world_id: string;
+    sample_interval_frames: number;
+    max_samples: number;
+    samples: MetricsSample[];
 }

--- a/tests/test_metrics_trends.py
+++ b/tests/test_metrics_trends.py
@@ -1,0 +1,232 @@
+"""Unit tests for the metrics-history buffer and Trends tab backend features."""
+
+from __future__ import annotations
+
+from backend.metrics_history import MetricsHistory
+from backend.state_payloads import StatsPayload, PokerStatsPayload
+from backend.world_registry import create_world
+
+
+def test_metrics_history_capacity_and_interval() -> None:
+    """Test that MetricsHistory correctly samples at intervals and respects capacity."""
+    history = MetricsHistory(world_id="test-world", sample_interval_frames=5, max_samples=3)
+
+    # Mock stats
+    stats = StatsPayload(
+        frame=0,
+        population=10,
+        generation=1,
+        max_generation=1,
+        births=0,
+        deaths=0,
+        capacity="10%",
+        time="Day",
+        death_causes={},
+        fish_count=10,
+        food_count=5,
+        plant_count=5,
+        total_energy=1000.0,
+        food_energy=100.0,
+        live_food_count=2,
+        live_food_energy=20.0,
+        fish_energy=800.0,
+        plant_energy=100.0,
+    )
+    poker = PokerStatsPayload(
+        total_games=10,
+        total_fish_games=10,
+        total_plant_games=0,
+        total_plant_energy_transferred=0.0,
+        total_wins=5,
+        total_losses=5,
+        total_ties=0,
+        total_energy_won=50.0,
+        total_energy_lost=50.0,
+        net_energy=0.0,
+        best_hand_rank=0,
+        best_hand_name="None",
+        showdown_win_rate="50.0%",
+    )
+
+    # Feed frames 1 to 20
+    for frame in range(1, 21):
+        history.maybe_sample(
+            frame=frame,
+            stats=stats,
+            poker=poker,
+            soccer=[],
+            auto_eval=None,
+        )
+
+    # Should only sample at frame 5, 10, 15, 20
+    # Capacity is 3, so only the last 3 samples should remain: 10, 15, 20
+    assert len(history.samples) == 3
+    assert history.samples[0]["frame"] == 10
+    assert history.samples[1]["frame"] == 15
+    assert history.samples[2]["frame"] == 20
+
+
+def test_metrics_history_serialization_roundtrip() -> None:
+    """Test payload round-trip serialization and deserialization."""
+    history = MetricsHistory(world_id="test-world", sample_interval_frames=5, max_samples=3)
+
+    # Mock soccer events to increment counters
+    soccer_events = [
+        {"match_id": "m1", "score_left": 2, "score_right": 1, "skipped": False},
+        {"match_id": "m2", "score_left": 0, "score_right": 0, "skipped": True},
+    ]
+
+    stats = StatsPayload(
+        frame=5,
+        population=10,
+        generation=1,
+        max_generation=1,
+        births=2,
+        deaths=1,
+        capacity="10%",
+        time="Day",
+        death_causes={},
+        fish_count=10,
+        food_count=5,
+        plant_count=5,
+        total_energy=1000.0,
+        food_energy=100.0,
+        live_food_count=2,
+        live_food_energy=20.0,
+        fish_energy=800.0,
+        plant_energy=100.0,
+    )
+    poker = PokerStatsPayload(
+        total_games=10,
+        total_fish_games=10,
+        total_plant_games=0,
+        total_plant_energy_transferred=0.0,
+        total_wins=5,
+        total_losses=5,
+        total_ties=0,
+        total_energy_won=50.0,
+        total_energy_lost=50.0,
+        net_energy=0.0,
+        best_hand_rank=0,
+        best_hand_name="None",
+        showdown_win_rate="50.0%",
+    )
+
+    history.maybe_sample(
+        frame=5,
+        stats=stats,
+        poker=poker,
+        soccer=soccer_events,
+        auto_eval=None,
+    )
+
+    # Verify initial stats
+    assert history.soccer_goals_total == 3
+    assert history.soccer_matches_completed == 1
+    assert history.soccer_matches_skipped == 1
+
+    # Serialize
+    payload = history.to_payload()
+    assert payload["world_id"] == "test-world"
+    assert len(payload["samples"]) == 1
+
+    # Deserialize into new instance
+    new_history = MetricsHistory(world_id="new-world")
+    new_history.load(payload)
+
+    assert new_history.world_id == "test-world"
+    assert len(new_history.samples) == 1
+    assert new_history.samples[0]["frame"] == 5
+    assert new_history.soccer_goals_total == 3
+    assert new_history.soccer_matches_completed == 1
+    assert new_history.soccer_matches_skipped == 1
+    assert "m1" in new_history.processed_soccer_match_ids
+
+
+def test_metrics_collection_determinism_guard() -> None:
+    """Test that stats/metrics collection does not perturb the simulation RNG/state."""
+    # We run two simulations using the same seed.
+    # Sim A runs step-by-step and simulates calling stats collection with metrics history.
+    # Sim B runs step-by-step without calling stats collection.
+    # The final state of entities and spatial grids must be completely identical.
+    seed = 42
+    world_a, _ = create_world("tank", seed=seed, headless=True)
+    world_b, _ = create_world("tank", seed=seed, headless=True)
+
+    world_a.reset(seed=seed)
+    world_b.reset(seed=seed)
+
+    # Simulate World A with stats collection (creates metrics samples)
+    from backend.simulation_runner import SimulationRunner
+
+    runner_a = SimulationRunner(seed=seed, world_type="tank")
+    runner_a.world = world_a
+    # Manually step and collect stats
+    for frame in range(1, 21):
+        world_a.step()
+        # Call collect_stats, which samples metrics history
+        runner_a._collect_stats(frame=frame)
+
+    # Simulate World B without any stats collection
+    for _ in range(1, 21):
+        world_b.step()
+
+    # Compare snapshots of entities
+    snap_a = world_a.get_current_snapshot()
+    snap_b = world_b.get_current_snapshot()
+
+    # Frame count, dimensions, paused state, and entity count/attributes must match
+    assert snap_a["frame"] == snap_b["frame"]
+    assert snap_a["paused"] == snap_b["paused"]
+
+    # Compare serialized entities
+    entities_a = world_a.get_entities_for_snapshot()
+    entities_b = world_b.get_entities_for_snapshot()
+
+    assert len(entities_a) == len(entities_b)
+    for ent_a, ent_b in zip(entities_a, entities_b, strict=True):
+        assert type(ent_a) == type(ent_b)
+        assert ent_a.pos.x == ent_b.pos.x
+        assert ent_a.pos.y == ent_b.pos.y
+        if hasattr(ent_a, "energy") or hasattr(ent_b, "energy"):
+            assert getattr(ent_a, "energy", None) == getattr(ent_b, "energy", None)
+
+
+def test_metrics_history_resets_with_simulation() -> None:
+    """Reset should start fresh metrics and link persistence to the new world."""
+    from backend.simulation_runner import SimulationRunner
+
+    runner = SimulationRunner(seed=42, world_type="tank")
+    old_history = runner.metrics_history
+    old_history.samples.append({"frame": 500})
+
+    runner.reset(seed=43)
+
+    assert runner.metrics_history is not old_history
+    assert runner.metrics_history.world_id == runner.world_id
+    assert runner.metrics_history.samples == []
+    assert runner.world.runner is runner
+
+
+def test_metrics_history_persistence_link_survives_world_switch() -> None:
+    """Hot-swapped adapters should retain access to the runner's metrics history."""
+    from backend.simulation_runner import SimulationRunner
+
+    runner = SimulationRunner(seed=42, world_type="tank")
+
+    runner.switch_world_type("petri")
+
+    assert runner.world.runner is runner
+    assert runner.metrics_history.world_id == runner.world_id
+
+
+def test_metrics_history_samples_without_state_request() -> None:
+    """Stepping the runner should collect due metrics without a WebSocket client."""
+    from backend.simulation_runner import SimulationRunner
+
+    runner = SimulationRunner(seed=42, world_type="tank")
+    runner.metrics_history.sample_interval_frames = 1
+
+    runner.step()
+
+    assert [sample["frame"] for sample in runner.metrics_history.samples] == [1]


### PR DESCRIPTION
## Summary

- Add persistent metrics history for population, generation, poker, and soccer trends
- Add a Trends panel with frame and generation-based charts
- Publish metrics through full and delta WebSocket payloads
- Add a REST endpoint for retrieving world metrics history
- Persist metrics history across saves, restores, and mode switches
- Reset metrics history when simulations reset
- Collect samples continuously, including when no WebSocket clients are connected

## Validation

- `py tools/smoke_gate.py` — passed
- `py tools/fast_gate.py` — 1767 passed, 4 skipped
- `py -m pytest tests/test_metrics_trends.py` — 6 passed
- `npm run lint` — passed
- `npm test -- --run` — 22 passed
- `npm run build` — passed
- `git show --check HEAD` — clean

## Notes

- No champion files or benchmark scoring behavior were changed.
- Frontend build reports the existing large-chunk size warning.