### PR TITLE
refactor: remove unused PhaseRunner execution model (finish-or-delete)

### DIFF
--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -17,7 +17,7 @@ unchanged:
 
 from typing import TYPE_CHECKING, Any, Optional
 
-from core import ecosystem_reporting
+import core.ecosystem_reporting as ecosystem_reporting
 from core.config.ecosystem import ENERGY_STATS_WINDOW_FRAMES, MAX_ECOSYSTEM_EVENTS
 from core.ecosystem_stats import (
     EcosystemEvent,

--- a/core/entity_factory.py
+++ b/core/entity_factory.py
@@ -6,7 +6,9 @@ used by the web UI backend and headless simulation mode.
 
 import random
 
-from core import entities, environment, movement_strategy
+import core.entities as entities
+import core.environment as environment
+import core.movement_strategy as movement_strategy
 from core.config.fish import FISH_BASE_SPEED
 from core.config.simulation_config import DisplayConfig, EcosystemConfig
 from core.ecosystem import EcosystemManager

--- a/core/genetics/genome.py
+++ b/core/genetics/genome.py
@@ -10,8 +10,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, cast
 
+import core.genetics.expression as expression
 from core.exceptions import GeneticsError
-from core.genetics import expression
 from core.genetics.behavioral import BehavioralTraits
 from core.genetics.genome_codec import genome_debug_snapshot, genome_from_dict, genome_to_dict
 from core.genetics.physical import PhysicalTraits

--- a/core/registry.py
+++ b/core/registry.py
@@ -13,7 +13,7 @@ import pkgutil
 from collections.abc import Iterable
 from importlib import import_module
 
-from core import algorithms
+import core.algorithms as algorithms
 from core.algorithms.base import BehaviorAlgorithm, BehaviorStrategyBase
 
 

--- a/core/services/stats/calculator.py
+++ b/core/services/stats/calculator.py
@@ -8,7 +8,7 @@ statistics from specialized sub-modules:
 
 from typing import TYPE_CHECKING, Any
 
-from core.services.stats import entity_stats
+import core.services.stats.entity_stats as entity_stats
 from core.services.stats.utils import calculate_meta_stats, humanize_gene_label
 
 if TYPE_CHECKING:

--- a/core/simulation/engine.py
+++ b/core/simulation/engine.py
@@ -28,6 +28,7 @@ Design Decisions:
 from __future__ import annotations
 
 import logging
+import os
 import random
 import time
 import uuid
@@ -36,16 +37,22 @@ from typing import TYPE_CHECKING, Any
 
 import core.simulation.diagnostics as diagnostics
 import core.simulation.headless_runner as headless_runner
+from core.agents_wrapper import AgentsWrapper
 from core.config.simulation_config import SimulationConfig
+from core.entity_factory import create_initial_population
+from core.services.stats.calculator import StatsCalculator
 from core.simulation.coordinator import SystemCoordinator
 from core.simulation.engine_setup import setup_engine
 from core.simulation.entity_manager import EntityManager
+from core.simulation.event_managers import SoccerEventManager
 from core.simulation.frame_aggregator import FrameAggregator, FrameOutputs
 from core.simulation.mutation import MutationTransaction
 from core.simulation.mutation_executor import MutationExecutor
 from core.simulation.phase_executor import PhaseExecutor
+from core.simulation.phase_hooks import NoOpPhaseHooks, PhaseHooks
 from core.simulation.system_registry import SystemRegistry
 from core.systems.base import BaseSystem
+from core.systems.food_spawning import SpawnRateConfig
 from core.time_system import TimeSystem
 
 if TYPE_CHECKING:
@@ -60,12 +67,14 @@ if TYPE_CHECKING:
     from core.reproduction_service import ReproductionService
     from core.reproduction_system import ReproductionSystem
     from core.root_spots import RootSpotManager
+    from core.simulation.pipeline import EnginePipeline
     from core.systems.entity_lifecycle import EntityLifecycleSystem
-    from core.systems.food_spawning import FoodSpawningSystem, SpawnRateConfig
+    from core.systems.food_spawning import FoodSpawningSystem
     from core.systems.poker_proximity import PokerProximitySystem
     from core.systems.soccer_system import SoccerSystem
     from core.update_phases import UpdatePhase
     from core.worlds.contracts import EnergyDeltaRecord, RemovalRequest, SpawnRequest
+    from core.worlds.identity import EntityIdentityProvider
     from core.worlds.system_pack import SystemPack
 
 logger = logging.getLogger(__name__)
@@ -129,8 +138,6 @@ class SimulationEngine:
             get_root_spot_manager=lambda: self.root_spot_manager,
         )
 
-        from core.agents_wrapper import AgentsWrapper
-
         self.agents = AgentsWrapper(self)
         self._system_registry = SystemRegistry()
 
@@ -155,8 +162,6 @@ class SimulationEngine:
         self.start_time: float = time.time()
 
         # Services
-        from core.services.stats.calculator import StatsCalculator
-
         self.stats_calculator = StatsCalculator(self)
 
         # Systems - these will be optionally initialized by the SystemPack in setup()
@@ -174,8 +179,6 @@ class SimulationEngine:
         self.poker_events: deque[Any] = deque(maxlen=self.config.poker.max_poker_events)
 
         # Soccer event management (extracted from engine)
-        from core.simulation.event_managers import SoccerEventManager
-
         self._soccer_events_mgr = SoccerEventManager(max_events=self.config.soccer.max_events)
 
         # Periodic poker benchmark evaluation
@@ -183,26 +186,18 @@ class SimulationEngine:
 
         # Phase debug flag for invariant enforcement.
         # Enable via config OR env var (for tests to force invariant checking)
-        import os
-
         self._phase_debug_enabled: bool = (
             self.config.enable_phase_debug
             or os.environ.get("TANK_ENFORCE_MUTATION_INVARIANTS", "0") == "1"
         )
 
         # Pipeline (set during setup())
-        from core.simulation.pipeline import EnginePipeline
-
         self.pipeline: EnginePipeline | None = None
 
         # Identity provider for stable delta IDs (set during setup())
-        from core.worlds.identity import EntityIdentityProvider
-
         self._identity_provider: EntityIdentityProvider | None = None
 
         # Phase hooks for mode-specific entity handling (set during setup())
-        from core.simulation.phase_hooks import NoOpPhaseHooks, PhaseHooks
-
         self._phase_hooks: PhaseHooks = NoOpPhaseHooks()
         self.coordinator.set_phase_hooks(self._phase_hooks)
 
@@ -279,8 +274,6 @@ class SimulationEngine:
 
     def _build_spawn_rate_config(self) -> SpawnRateConfig:
         """Translate SimulationConfig food settings into SpawnRateConfig."""
-        from core.systems.food_spawning import SpawnRateConfig
-
         food_cfg = self.config.food
         return SpawnRateConfig(
             base_rate=food_cfg.spawn_rate,
@@ -338,8 +331,6 @@ class SimulationEngine:
         """Create initial entities in the simulation."""
         if self.environment is None or self.ecosystem is None:
             return
-
-        from core.entity_factory import create_initial_population
 
         display = self.config.display
         population = create_initial_population(

--- a/core/simulation/engine.py
+++ b/core/simulation/engine.py
@@ -34,8 +34,9 @@ import uuid
 from collections import deque
 from typing import TYPE_CHECKING, Any
 
+import core.simulation.diagnostics as diagnostics
+import core.simulation.headless_runner as headless_runner
 from core.config.simulation_config import SimulationConfig
-from core.simulation import diagnostics, headless_runner
 from core.simulation.coordinator import SystemCoordinator
 from core.simulation.engine_setup import setup_engine
 from core.simulation.entity_manager import EntityManager

--- a/core/simulation/engine_setup.py
+++ b/core/simulation/engine_setup.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
+from core.environment import Environment
+from core.simulation.phase_hooks import NoOpPhaseHooks
+from core.simulation.pipeline import default_pipeline
 from core.update_phases import UpdatePhase
 
 if TYPE_CHECKING:
@@ -22,7 +25,8 @@ logger = logging.getLogger(__name__)
 
 def setup_engine(engine: SimulationEngine, pack: SystemPack | None = None) -> None:
     """Set up the simulation engine using the provided SystemPack."""
-    # Fallback to TankPack if no pack provided
+    # Fallback to TankPack if no pack provided. Deferred on purpose: generic
+    # engine assembly must not statically depend on a specific world (Tank).
     if pack is None:
         from core.worlds.tank.pack import TankPack
 
@@ -34,8 +38,6 @@ def setup_engine(engine: SimulationEngine, pack: SystemPack | None = None) -> No
         setattr(engine, attr, system)
 
     # 2. Let the pack build the environment
-    from core.environment import Environment
-
     engine.environment = cast(Environment, pack.build_environment(engine))
 
     # Wire up energy delta recorder for immediate tracking
@@ -66,8 +68,6 @@ def setup_engine(engine: SimulationEngine, pack: SystemPack | None = None) -> No
     engine.coordinator.ecosystem = engine.ecosystem
 
     # 5. Wire up the pipeline (pack can override or use default)
-    from core.simulation.pipeline import default_pipeline
-
     custom_pipeline = pack.get_pipeline()
     engine.pipeline = custom_pipeline if custom_pipeline is not None else default_pipeline()
 
@@ -78,8 +78,6 @@ def setup_engine(engine: SimulationEngine, pack: SystemPack | None = None) -> No
     engine._identity_provider = pack.get_identity_provider()
 
     # 8. Store phase hooks from pack
-    from core.simulation.phase_hooks import NoOpPhaseHooks
-
     hooks = pack.get_phase_hooks()
     engine._phase_hooks = hooks if hooks is not None else NoOpPhaseHooks()
 

--- a/core/simulation/entity_manager.py
+++ b/core/simulation/entity_manager.py
@@ -18,7 +18,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from core import entities
+import core.entities as entities
 from core.cache_manager import CacheManager
 from core.object_pool import FoodPool
 

--- a/core/simulation/frame_aggregator.py
+++ b/core/simulation/frame_aggregator.py
@@ -61,6 +61,9 @@ class FrameAggregator:
         environment.set_energy_delta_recorder(). The recorder forwards energy
         deltas into this aggregator, resolving stable IDs via ``get_identity``.
         """
+        # Deferred (load-bearing): importing core.worlds runs the registry's
+        # eager mode registration, which pulls world backends -> core.simulation.
+        # Keep this inside the function to avoid that import-time cycle (ADR-008).
         from core.worlds.contracts import EnergyDeltaRecord
 
         def recorder(entity: Any, delta: float, source: str, meta: dict[str, Any]) -> None:

--- a/core/simulation/frame_aggregator.py
+++ b/core/simulation/frame_aggregator.py
@@ -10,10 +10,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from core.worlds.contracts import EnergyDeltaRecord, RemovalRequest, SpawnRequest
+from core.worlds.contracts import EnergyDeltaRecord, RemovalRequest, SpawnRequest
 
 
 @dataclass(frozen=True)
@@ -61,10 +60,6 @@ class FrameAggregator:
         environment.set_energy_delta_recorder(). The recorder forwards energy
         deltas into this aggregator, resolving stable IDs via ``get_identity``.
         """
-        # Deferred (load-bearing): importing core.worlds runs the registry's
-        # eager mode registration, which pulls world backends -> core.simulation.
-        # Keep this inside the function to avoid that import-time cycle (ADR-008).
-        from core.worlds.contracts import EnergyDeltaRecord
 
         def recorder(entity: Any, delta: float, source: str, meta: dict[str, Any]) -> None:
             entity_type, stable_id = get_identity(entity)

--- a/core/simulation/mutation.py
+++ b/core/simulation/mutation.py
@@ -66,7 +66,9 @@ class MutationTransaction:
             pre_add_callback: Optional callback(entity) run before adding to manager
                               (used for legacy add_internal support)
         """
-        # Lazy import to avoid circular dependency
+        # Deferred (load-bearing): importing core.worlds runs the registry's
+        # eager mode registration, which pulls world backends -> core.simulation.
+        # Keep this inside the function to avoid that import-time cycle (ADR-008).
         from core.worlds.contracts import RemovalRequest, SpawnRequest
 
         # Process removals

--- a/core/simulation/mutation.py
+++ b/core/simulation/mutation.py
@@ -1,13 +1,11 @@
 """Mutation transaction management."""
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from core.entities import Entity
 from core.simulation.entity_manager import EntityManager
 from core.simulation.entity_mutation_queue import EntityMutationQueue
-
-if TYPE_CHECKING:
-    from core.worlds.contracts import RemovalRequest, SpawnRequest
+from core.worlds.contracts import RemovalRequest, SpawnRequest
 
 
 class MutationTransaction:
@@ -66,11 +64,6 @@ class MutationTransaction:
             pre_add_callback: Optional callback(entity) run before adding to manager
                               (used for legacy add_internal support)
         """
-        # Deferred (load-bearing): importing core.worlds runs the registry's
-        # eager mode registration, which pulls world backends -> core.simulation.
-        # Keep this inside the function to avoid that import-time cycle (ADR-008).
-        from core.worlds.contracts import RemovalRequest, SpawnRequest
-
         # Process removals
         removals = self._queue.drain_removals()
         for mutation in removals:

--- a/core/update_phases.py
+++ b/core/update_phases.py
@@ -1,66 +1,56 @@
 """Update phase definitions for explicit execution ordering.
 
-This module defines the phases of a simulation update tick and provides
-tools for organizing system execution in a predictable order.
+This module defines the phases of a simulation update tick. The phases give the
+engine a single, ordered vocabulary for "what happens when" during a frame.
 
 Why Explicit Phases?
 --------------------
 Before (implicit ordering):
     def update(self):
         self.time_system.update(self.frame)
-        self.handle_collisions()  # Wait, should this be before or after entities?
+        self.handle_collisions()  # before or after entities?
         for entity in entities:
             entity.update()
-        self.handle_reproduction()  # What about deaths? Before or after?
+        self.handle_reproduction()  # before or after deaths?
         self.spawn_food()
 
-After (explicit phases):
+After (explicit, named phases):
     def update(self):
-        for phase in UpdatePhase:
-            self._run_phase(phase)
-
-    def _run_phase(self, phase: UpdatePhase):
-        for system in self.systems_by_phase[phase]:
-            system.update(self.frame)
+        self._phase_frame_start()
+        self._phase_time_update()
+        self._phase_environment()
+        ...                        # one ordered, named method per phase
 
 Benefits:
 - Execution order is explicit and documented
-- Easy to add new systems to correct phase
+- Easy to add new systems to the correct phase
 - Debugging: "what phase are we in?"
-- Testing: can run phases in isolation
+- Testing: phases can be reasoned about in isolation
 - Self-documenting code
 
-Note: The current SimulationEngine uses explicit phase methods instead of
-PhaseRunner. PhaseRunner remains as an optional utility for tests or future
-refactors.
+How phases are executed
+-----------------------
+``SimulationEngine`` drives the loop with explicit, named ``_phase_*`` methods
+(see ``core/simulation/phase_executor.py``). ``UpdatePhase`` is the shared
+vocabulary those methods, the pipeline, and debugging tools agree on; systems
+annotate the phase they belong to with :func:`runs_in_phase` for documentation
+and introspection.
 
 Usage:
 ------
-    # Systems declare which phase they run in
+    @runs_in_phase(UpdatePhase.COLLISION)
     class CollisionSystem(BaseSystem):
-        phase = UpdatePhase.COLLISION
-
-    # Runner executes in order
-    runner = PhaseRunner()
-    runner.register(collision_system)
-    runner.register(time_system)
-    runner.run_all(frame=1)  # Runs in phase order regardless of registration order
+        def _do_update(self, frame: int) -> SystemResult:
+            ...
 """
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING
 
 # Explicit public API
 __all__ = [
-    # Core types
     "UpdatePhase",
-    "PhaseContext",
-    "PhaseRunner",
-    # Protocol
-    "PhaseAware",
-    # Helpers
     "PHASE_DESCRIPTIONS",
     "runs_in_phase",
     "get_system_phase",
@@ -123,208 +113,17 @@ PHASE_DESCRIPTIONS: dict[UpdatePhase, str] = {
 }
 
 
-@dataclass
-class PhaseContext:
-    """Context passed to systems during phase execution.
-
-    This provides systems with information about the current update
-    without requiring them to query global state.
-
-    Attributes:
-        frame: Current simulation frame number
-        phase: Current update phase
-        time_modifier: Activity modifier from time system (0.0-1.0)
-        time_of_day: Current time of day (0.0-1.0, 0=midnight, 0.5=noon)
-        delta_time: Time since last frame (for frame-rate independent updates)
-    """
-
-    frame: int
-    phase: UpdatePhase
-    time_modifier: float = 1.0
-    time_of_day: float = 0.5
-    delta_time: float = 1.0 / 30.0  # Assume 30 FPS default
-
-
-class PhaseAware(Protocol):
-    """Protocol for systems that run in specific phases."""
-
-    @property
-    def phase(self) -> UpdatePhase:
-        """The phase this system runs in."""
-        ...
-
-    def update_in_phase(self, context: PhaseContext) -> None:
-        """Execute the system's update for this phase."""
-        ...
-
-
-@dataclass
-class PhaseRunner:
-    """Executes systems in their designated phases.
-
-    The PhaseRunner organizes systems by phase and executes them in
-    order. Within a phase, systems run in registration order.
-
-    Example:
-        runner = PhaseRunner()
-
-        # Register systems (order doesn't matter - sorted by phase)
-        runner.register(collision_system, UpdatePhase.COLLISION)
-        runner.register(time_system, UpdatePhase.TIME_UPDATE)
-        runner.register(lifecycle_system, UpdatePhase.LIFECYCLE)
-
-        # Run all phases in order
-        context = runner.run_all(frame=100)
-
-        # Or run specific phases
-        runner.run_phase(UpdatePhase.COLLISION, context)
-    """
-
-    _systems_by_phase: dict[UpdatePhase, list["BaseSystem"]] = field(
-        default_factory=lambda: {phase: [] for phase in UpdatePhase}
-    )
-    _debug_mode: bool = False
-    _current_phase: UpdatePhase | None = None
-    _phase_timings: dict[UpdatePhase, float] = field(default_factory=dict)
-
-    def register(self, system: "BaseSystem", phase: UpdatePhase) -> None:
-        """Register a system to run in a specific phase.
-
-        Args:
-            system: The system to register
-            phase: The phase to run in
-        """
-        self._systems_by_phase[phase].append(system)
-
-    def unregister(self, system: "BaseSystem", phase: UpdatePhase) -> bool:
-        """Remove a system from a phase.
-
-        Args:
-            system: The system to remove
-            phase: The phase to remove from
-
-        Returns:
-            True if system was found and removed, False otherwise
-        """
-        systems = self._systems_by_phase[phase]
-        if system in systems:
-            systems.remove(system)
-            return True
-        return False
-
-    def run_all(
-        self,
-        frame: int,
-        time_modifier: float = 1.0,
-        time_of_day: float = 0.5,
-    ) -> PhaseContext:
-        """Run all phases in order.
-
-        Args:
-            frame: Current simulation frame
-            time_modifier: Activity modifier from time system
-            time_of_day: Current time of day
-
-        Returns:
-            The PhaseContext used for execution
-        """
-        context = PhaseContext(
-            frame=frame,
-            phase=UpdatePhase.FRAME_START,
-            time_modifier=time_modifier,
-            time_of_day=time_of_day,
-        )
-
-        for phase in UpdatePhase:
-            self.run_phase(phase, context)
-
-        return context
-
-    def run_phase(self, phase: UpdatePhase, context: PhaseContext) -> None:
-        """Run all systems registered for a specific phase.
-
-        Args:
-            phase: The phase to run
-            context: The execution context
-        """
-        import time
-
-        context.phase = phase
-        self._current_phase = phase
-
-        if self._debug_mode:
-            start_time = time.perf_counter()
-
-        for system in self._systems_by_phase[phase]:
-            if system.enabled:
-                system.update(context.frame)
-
-        if self._debug_mode:
-            elapsed = time.perf_counter() - start_time
-            self._phase_timings[phase] = elapsed
-
-        self._current_phase = None
-
-    def run_phases(
-        self,
-        phases: list[UpdatePhase],
-        context: PhaseContext,
-    ) -> None:
-        """Run a subset of phases.
-
-        Useful for testing or when you need fine-grained control.
-
-        Args:
-            phases: List of phases to run (in order given)
-            context: The execution context
-        """
-        for phase in phases:
-            self.run_phase(phase, context)
-
-    @property
-    def current_phase(self) -> UpdatePhase | None:
-        """Get the currently executing phase, or None if not in update."""
-        return self._current_phase
-
-    def get_systems_in_phase(self, phase: UpdatePhase) -> list["BaseSystem"]:
-        """Get all systems registered for a phase."""
-        return self._systems_by_phase[phase].copy()
-
-    def enable_debug(self, enabled: bool = True) -> None:
-        """Enable debug mode (tracks timing per phase)."""
-        self._debug_mode = enabled
-
-    def get_phase_timings(self) -> dict[UpdatePhase, float]:
-        """Get timing information for each phase (requires debug mode)."""
-        return self._phase_timings.copy()
-
-    def get_debug_info(self) -> dict[str, Any]:
-        """Get debug information about the runner."""
-        return {
-            "current_phase": self._current_phase.name if self._current_phase else None,
-            "systems_per_phase": {
-                phase.name: [s.name for s in systems]
-                for phase, systems in self._systems_by_phase.items()
-                if systems
-            },
-            "timings": (
-                {
-                    phase.name: f"{timing*1000:.2f}ms"
-                    for phase, timing in self._phase_timings.items()
-                }
-                if self._debug_mode
-                else {}
-            ),
-        }
-
-
 # ============================================================================
-# Phase Decorators (for future use)
+# Phase Annotations
 # ============================================================================
 
 
 def runs_in_phase(phase: UpdatePhase) -> Callable:
     """Decorator to declare which phase a system runs in.
+
+    The annotation documents intent and enables introspection via
+    :func:`get_system_phase`; the engine's explicit ``_phase_*`` methods own
+    the actual ordering.
 
     Example:
         @runs_in_phase(UpdatePhase.COLLISION)

--- a/core/worlds/registry.py
+++ b/core/worlds/registry.py
@@ -7,6 +7,7 @@ and associating them with high-level mode packs.
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Callable
 
 from core.exceptions import ConfigurationError
@@ -80,6 +81,7 @@ class WorldRegistry:
             config: Optional config dict (normalized by the mode pack)
             **kwargs: Config overrides (merged into config)
         """
+        _ensure_builtin_modes()
         mode_pack = _MODE_PACKS.get(mode_id)
         if mode_pack is None:
             raise ConfigurationError(
@@ -103,16 +105,19 @@ class WorldRegistry:
     @staticmethod
     def get_mode_pack(mode_id: str) -> ModePack | None:
         """Return a registered mode pack by id."""
+        _ensure_builtin_modes()
         return _MODE_PACKS.get(mode_id)
 
     @staticmethod
     def list_mode_packs() -> dict[str, ModePack]:
         """Return all registered mode packs."""
+        _ensure_builtin_modes()
         return dict(_MODE_PACKS)
 
     @staticmethod
     def list_modes() -> dict[str, str]:
         """List all available modes and their status."""
+        _ensure_builtin_modes()
         statuses: dict[str, str] = {}
         for mode_id, mode_pack in _MODE_PACKS.items():
             status = (
@@ -124,6 +129,7 @@ class WorldRegistry:
     @staticmethod
     def list_world_types() -> dict[str, str]:
         """List world types (legacy compatibility)."""
+        _ensure_builtin_modes()
         statuses: dict[str, str] = {}
         for mode_pack in _MODE_PACKS.values():
             status = (
@@ -135,8 +141,33 @@ class WorldRegistry:
 
 
 # =============================================================================
-# Built-in mode pack registrations
+# Built-in mode pack registrations (lazy)
 # =============================================================================
+
+_builtins_registered = False
+_registration_lock = threading.Lock()
+
+
+def _ensure_builtin_modes() -> None:
+    """Register built-in mode packs on first use (thread-safe, idempotent).
+
+    Registration is deferred (rather than run at import time) so that importing
+    ``core.worlds`` does not eagerly pull in the Tank/Petri world backends,
+    which depend on ``core.simulation`` and would otherwise form an import-time
+    cycle. The registry's read methods call this before serving. See ADR-008.
+
+    Double-checked locking keeps concurrent first reads (the backend drives
+    simulations on worker threads) from registering twice or observing a
+    half-populated registry.
+    """
+    global _builtins_registered
+    if _builtins_registered:
+        return
+    with _registration_lock:
+        if _builtins_registered:
+            return
+        _register_builtin_modes()
+        _builtins_registered = True
 
 
 def _register_builtin_modes() -> None:
@@ -162,6 +193,3 @@ def _register_builtin_modes() -> None:
     # Note: Soccer is NOT registered as a world mode.
     # It is a minigame accessible via the "start_soccer" command handler.
     # See core/minigames/soccer/ for the RCSS-Lite engine.
-
-
-_register_builtin_modes()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -394,7 +394,9 @@ class BaseSystem(ABC):
 - `_phase_frame_end()`: Stats updates and cache rebuilds
 Note: Entity spawns/removals are routed through the engine mutation queue (systems use `SimulationEngine.request_spawn/request_remove`; entities use `core.util.mutations.request_spawn/request_remove`).
 
-`core/update_phases.py` defines an enum and a `PhaseRunner`, but the engine currently uses explicit phase methods for clarity.
+`core/update_phases.py` defines the `UpdatePhase` enum and the `runs_in_phase`
+annotation; the engine executes phases via explicit, named `_phase_*` methods
+(in `core/simulation/phase_executor.py`) for clarity.
 
 ### Strategy Pattern
 Different movement strategies for entities:

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -55,6 +55,8 @@ the code, 2026-06):
 | `SystemResult` contract made uniform | every `_do_update` now returns `SystemResult` |
 | Duplicate betting-round enum collapsed | `MultiplayerBettingRound` is now an alias of `BettingRound` |
 | `core/protocols.py` re-export shim removed | import `core.interfaces` directly |
+| `core/` module-load import graph is a verified DAG (was: 3 latent facade cycles) | cycles broken; `tests/test_import_acyclic.py` guards it; ADR-008 |
+| Unused `PhaseRunner` execution model removed (finish-or-delete) | `core/update_phases.py` keeps only the `UpdatePhase` taxonomy the engine uses |
 
 ## Open items
 
@@ -85,11 +87,16 @@ Adopted so far (reference examples to copy): `ConfigurationError`
 `"interval must be >= 1"`) correctly stays `ValueError`; only domain failures
 move to the hierarchy.
 
-### 4. Module dependency cycles (watch item — large effort)
-There are ~750 function-level (in-function) imports in `core/`, used to route
-around circular dependencies. This is real debt, but untangling it is a *large,
-risky* refactor, not a small safe change. **Measure before acting**; prefer
-breaking cycles opportunistically when a module is already being restructured.
+### 4. In-function import debt (now measured & guarded, per ADR-008)
+`core/` carries hundreds of function-level (in-function) imports originally
+added to route around circular dependencies. Measurement (ADR-008) showed the
+module-load graph was only *accidentally* tangled — three sibling-via-facade
+cycles — now broken and locked acyclic by `tests/test_import_acyclic.py`. With
+cycles unable to reappear silently, the remaining in-function imports are mostly
+*defensive* rather than load-bearing: promote them to module scope
+**opportunistically** when you already touch a module, leaning on the acyclicity
+test to prove nothing re-tangles. Still no big-bang rewrite — the value is
+incremental and the test is the safety net.
 
 ## Design principles to maintain
 

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -57,6 +57,7 @@ the code, 2026-06):
 | `core/protocols.py` re-export shim removed | import `core.interfaces` directly |
 | `core/` module-load import graph is a verified DAG (was: 3 latent facade cycles) | cycles broken; `tests/test_import_acyclic.py` guards it; ADR-008 |
 | Unused `PhaseRunner` execution model removed (finish-or-delete) | `core/update_phases.py` keeps only the `UpdatePhase` taxonomy the engine uses |
+| `core/worlds` mode registration made lazy (was: eager at import → `core.worlds`↔`core.simulation` import-time cycle) | `core/worlds/registry.py`; de-poisons `core.worlds.*` imports; ADR-008 |
 
 ## Open items
 

--- a/docs/adr/008-acyclic-core-imports.md
+++ b/docs/adr/008-acyclic-core-imports.md
@@ -88,6 +88,14 @@ architectural invariant.
 - **The graph models module-load imports only.** Function-local and
   `TYPE_CHECKING` imports are excluded by construction; relative imports
   (`from . import x`) are fully resolved so the graph stays sound.
+- **The test is necessary, not sufficient.** The graph captures *static*
+  module-load imports; it does not trace functions that execute *at* import
+  time (e.g. `core/worlds/registry.py` eagerly self-registers built-in modes at
+  module load, so its function-local backend imports run eagerly and reach back
+  into `core.simulation`). Such a path can form a real runtime cycle the static
+  graph cannot see. Therefore promoting a deferred import to module scope must
+  be validated by actually importing the module and running the suite -- not by
+  the acyclicity test alone.
 
 ## Related
 - ADR-002: Protocol-Based Design (loose coupling reduces the pressure toward cycles)

--- a/docs/adr/008-acyclic-core-imports.md
+++ b/docs/adr/008-acyclic-core-imports.md
@@ -1,0 +1,97 @@
+# ADR-008: Acyclic Core Module Graph
+
+## Status
+Accepted (2026-06)
+
+## Context
+
+`core/` has long carried a large number of **in-function imports** used to route
+around circular dependencies (tracked as open item #4 in
+`docs/ARCHITECTURE_REVIEW.md`). The standing assumption was that the module graph
+was deeply tangled and that untangling it would be a large, risky refactor.
+
+A measurement said otherwise. Building the *module-load* import graph for `core/`
+— every import that runs when a module is first imported, **excluding**
+`if TYPE_CHECKING:` blocks and function-local imports — and running Tarjan's
+algorithm over it revealed only **three** cyclic components, every one the same
+shape:
+
+- `core.simulation` ⇄ `core.simulation.engine`
+- `core.genetics` ⇄ `core.genetics.genome`
+- `core.services.stats` ⇄ `core.services.stats.calculator`
+
+Each cycle was a **submodule importing a sibling through its own package
+facade** — e.g. `core/simulation/engine.py` doing
+`from core.simulation import diagnostics`, which forces a dependency on the
+`core/simulation/__init__.py` aggregator that re-exports `engine`. A fourth
+instance of the same pattern existed one level up: deep submodules importing a
+subpackage via the top-level `core` facade (`from core import entities`), which
+`core/__init__.py`'s own design note already advises against.
+
+The graph was therefore *accidentally* near-acyclic, but nothing guarded it.
+Crucially, this is self-reinforcing debt: as long as cycles can reappear
+silently, contributors keep reaching for in-function imports "to be safe,"
+which is exactly what produced the original sprawl.
+
+## Decision
+
+Treat an **acyclic module-load import graph for `core/`** as an enforced
+architectural invariant.
+
+1. **Break the existing cycles** by importing siblings/subpackages directly
+   instead of through a package facade:
+   `import core.simulation.diagnostics as diagnostics`, not
+   `from core.simulation import diagnostics`.
+
+2. **Guard it with a fitness test** — `tests/test_import_acyclic.py` builds the
+   module-load graph (AST-based, no external dependencies, consistent with
+   `tests/test_import_boundaries.py` and `tests/test_god_class_limits.py`) and
+   fails with the offending strongly-connected component(s) if a cycle is
+   reintroduced.
+
+3. **Scope precisely.** The invariant covers imports that execute at module
+   load. Two escape hatches remain legitimate and are intentionally outside the
+   graph:
+   - `if TYPE_CHECKING:` imports (type-only, never executed at runtime), and
+   - **function-local imports**, the explicit, greppable way to express a
+     genuinely mutual runtime dependency.
+
+### Rule of thumb
+
+> A module must not import its own package facade. Import the concrete sibling
+> or subpackage directly. Reserve `from core.pkg import name` for consumers
+> *outside* `core.pkg`.
+
+## Consequences
+
+### Positive
+- The dependency structure is a **verified DAG**, so module-load order is
+  well-defined and CI catches re-tangling with a precise SCC report.
+- The *need* for defensive in-function imports shrinks. With acyclicity
+  guaranteed, the remaining ones can be promoted to module scope
+  opportunistically and safely — the test proves no cycle is reintroduced.
+  This turns open item #4 from a "large, risky refactor" into incremental,
+  test-backed cleanup.
+
+### Negative
+- A change that introduces a new cross-module cycle must break it before
+  merging. In practice this is a one-line fix (import the sibling/leaf
+  directly), or — for a true mutual dependency — a deliberate function-local
+  import with a comment.
+
+## Implementation notes
+
+- **Reference fixes:** the three facade cycles in `engine.py`, `genome.py`, and
+  `calculator.py`, plus the four top-level `from core import <subpackage>`
+  facade imports in `entity_manager.py`, `entity_factory.py`, `registry.py`,
+  and `ecosystem.py`.
+- **The graph models module-load imports only.** Function-local and
+  `TYPE_CHECKING` imports are excluded by construction; relative imports
+  (`from . import x`) are fully resolved so the graph stays sound.
+
+## Related
+- ADR-002: Protocol-Based Design (loose coupling reduces the pressure toward cycles)
+- ADR-003: Phase-Based Execution
+- `tests/test_import_acyclic.py` — the enforcing fitness test
+- `tests/test_import_boundaries.py` — sibling layering guards (core ⊥ backend/frontend)
+- `docs/ARCHITECTURE_REVIEW.md` — open item #4 (in-function import debt)

--- a/docs/adr/008-acyclic-core-imports.md
+++ b/docs/adr/008-acyclic-core-imports.md
@@ -90,12 +90,14 @@ architectural invariant.
   (`from . import x`) are fully resolved so the graph stays sound.
 - **The test is necessary, not sufficient.** The graph captures *static*
   module-load imports; it does not trace functions that execute *at* import
-  time (e.g. `core/worlds/registry.py` eagerly self-registers built-in modes at
-  module load, so its function-local backend imports run eagerly and reach back
-  into `core.simulation`). Such a path can form a real runtime cycle the static
-  graph cannot see. Therefore promoting a deferred import to module scope must
-  be validated by actually importing the module and running the suite -- not by
-  the acyclicity test alone.
+  time. Such a function can form a runtime cycle the static graph cannot see.
+  (This bit us once: `core/worlds/registry.py` used to register built-in modes
+  at module load, so its function-local backend imports ran eagerly and reached
+  back into `core.simulation`; registration is now **lazy** precisely to remove
+  that import-time cycle, which is also what lets `core.worlds.contracts` be
+  imported at module scope.) So promoting a deferred import to module scope must
+  be validated by importing the module and running the suite -- not by the
+  acyclicity test alone.
 
 ## Related
 - ADR-002: Protocol-Based Design (loose coupling reduces the pressure toward cycles)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,7 @@ architectural choices made during development.
 | [ADR-005](005-energy-state-pattern.md) | Energy State Pattern | Accepted | 2024-12 |
 | [ADR-006](006-deprecate-monolithic-food-seekers.md) | Deprecate Monolithic Food-Seekers | Accepted | 2026-06 |
 | [ADR-007](007-error-handling-strategy.md) | Error Handling Strategy | Accepted | 2026-06 |
+| [ADR-008](008-acyclic-core-imports.md) | Acyclic Core Module Graph | Accepted | 2026-06 |
 
 ## What is an ADR?
 

--- a/tests/test_import_acyclic.py
+++ b/tests/test_import_acyclic.py
@@ -1,0 +1,231 @@
+"""Architecture fitness test: ``core/`` has an acyclic module-load import graph.
+
+``core/`` historically leaned on hundreds of in-function imports to route around
+circular dependencies. A measurement (ADR-008) showed the *module-level* graph
+was already nearly a DAG -- the only cycles were three package/submodule pairs
+where a submodule reached back into its own package facade. This test makes the
+*absence* of module-load import cycles an enforced invariant rather than a happy
+accident, so the graph stays acyclic as the codebase grows.
+
+What "module-load" means
+------------------------
+The graph models only imports that execute the first time a module is imported.
+Two kinds of imports are deliberately excluded because they do not participate
+in module-load ordering:
+
+* imports inside a function/method body (the explicit escape hatch for the rare
+  genuine cycle), and
+* imports under ``if TYPE_CHECKING:`` (type-only, never executed at runtime).
+
+Pure-AST, no external dependencies -- consistent with ``test_import_boundaries``
+and ``test_god_class_limits``.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+CORE = "core"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _module_name(path: Path, root: Path) -> str:
+    """Dotted module name for a file, collapsing ``__init__`` to its package."""
+    parts = list(path.relative_to(root).with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _iter_core_modules(root: Path) -> dict[str, Path]:
+    core_dir = root / CORE
+    return {
+        _module_name(path, root): path
+        for path in core_dir.rglob("*.py")
+        if "__pycache__" not in path.parts
+    }
+
+
+def _is_type_checking(test: ast.expr) -> bool:
+    """True for ``TYPE_CHECKING`` or ``typing.TYPE_CHECKING`` guards."""
+    if isinstance(test, ast.Name):
+        return test.id == "TYPE_CHECKING"
+    if isinstance(test, ast.Attribute):
+        return test.attr == "TYPE_CHECKING"
+    return False
+
+
+def _module_load_imports(tree: ast.Module) -> list[ast.Import | ast.ImportFrom]:
+    """Import statements that run at module load (not in functions / TYPE_CHECKING)."""
+    found: list[ast.Import | ast.ImportFrom] = []
+
+    def visit(node: ast.AST, in_func: bool, in_tc: bool) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.Import, ast.ImportFrom)):
+                if not in_func and not in_tc:
+                    found.append(child)
+            elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                visit(child, True, in_tc)
+            elif isinstance(child, ast.If) and _is_type_checking(child.test):
+                # Body is type-only; ``else:`` still runs at load time.
+                for sub in child.body:
+                    visit(sub, in_func, True)
+                for sub in child.orelse:
+                    visit(sub, in_func, in_tc)
+            else:
+                visit(child, in_func, in_tc)
+
+    visit(tree, False, False)
+    return found
+
+
+def _relative_base(curmod: str, is_pkg: bool, level: int) -> str:
+    """Resolve the anchor package for a relative import (``from . / .. import``)."""
+    parts = curmod.split(".")
+    if not is_pkg:
+        parts = parts[:-1]  # a regular module anchors on its containing package
+    drop = level - 1  # level 1 == current package; each extra dot climbs one more
+    if drop > 0:
+        parts = parts[:-drop] if drop <= len(parts) else []
+    return ".".join(parts)
+
+
+def _imported_targets(node: ast.Import | ast.ImportFrom, curmod: str, is_pkg: bool) -> set[str]:
+    """Dotted names an import refers to (the module, plus each ``from`` name)."""
+    targets: set[str] = set()
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            targets.add(alias.name)
+        return targets
+
+    # ImportFrom
+    if node.level:
+        base = _relative_base(curmod, is_pkg, node.level)
+        module = f"{base}.{node.module}" if node.module else base
+    else:
+        module = node.module or ""
+    if module:
+        targets.add(module)
+        # ``from pkg import name`` may pull in a submodule named ``name``.
+        for alias in node.names:
+            targets.add(f"{module}.{alias.name}")
+    return targets
+
+
+def _longest_prefix(dotted: str, names: set[str]) -> str | None:
+    """Map an import target onto the longest matching real module name."""
+    parts = dotted.split(".")
+    for i in range(len(parts), 0, -1):
+        cand = ".".join(parts[:i])
+        if cand in names:
+            return cand
+    return None
+
+
+def _build_core_graph(mods: dict[str, Path]) -> dict[str, set[str]]:
+    """Module-load import graph restricted to edges between core/ modules."""
+    names = set(mods)
+    graph: dict[str, set[str]] = {m: set() for m in names}
+    for mod, path in mods.items():
+        is_pkg = path.name == "__init__.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in _module_load_imports(tree):
+            for raw in _imported_targets(node, mod, is_pkg):
+                if raw != CORE and not raw.startswith(CORE + "."):
+                    continue
+                dep = _longest_prefix(raw, names)
+                if dep is not None and dep != mod:
+                    graph[mod].add(dep)
+    return graph
+
+
+def _strongly_connected_components(graph: dict[str, set[str]]) -> list[list[str]]:
+    """Tarjan's algorithm; returns only components with a real cycle (size > 1)."""
+    index: dict[str, int] = {}
+    low: dict[str, int] = {}
+    on_stack: dict[str, bool] = {}
+    stack: list[str] = []
+    counter = [0]
+    components: list[list[str]] = []
+
+    old_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(max(old_limit, 10000))
+    try:
+
+        def strong(v: str) -> None:
+            index[v] = low[v] = counter[0]
+            counter[0] += 1
+            stack.append(v)
+            on_stack[v] = True
+            for w in graph[v]:
+                if w not in index:
+                    strong(w)
+                    low[v] = min(low[v], low[w])
+                elif on_stack.get(w):
+                    low[v] = min(low[v], index[w])
+            if low[v] == index[v]:
+                comp: list[str] = []
+                while True:
+                    w = stack.pop()
+                    on_stack[w] = False
+                    comp.append(w)
+                    if w == v:
+                        break
+                components.append(comp)
+
+        for node in graph:
+            if node not in index:
+                strong(node)
+    finally:
+        sys.setrecursionlimit(old_limit)
+
+    return [c for c in components if len(c) > 1]
+
+
+def test_core_module_graph_is_acyclic() -> None:
+    """The core/ module-load import graph must be a DAG (ADR-008)."""
+    mods = _iter_core_modules(_repo_root())
+    graph = _build_core_graph(mods)
+    cycles = _strongly_connected_components(graph)
+
+    if cycles:
+        lines = [
+            "core/ module-load import graph must be acyclic (ADR-008), but found "
+            f"{len(cycles)} cycle(s):",
+            "",
+        ]
+        for comp in sorted(cycles, key=len, reverse=True):
+            members = set(comp)
+            lines.append(f"  cycle across {len(comp)} modules:")
+            for m in sorted(comp):
+                for dep in sorted(graph[m]):
+                    if dep in members:
+                        lines.append(f"    {m} -> {dep}")
+        lines += [
+            "",
+            "Most cycles come from a submodule importing its own package facade,",
+            "e.g. `from core.pkg import sibling_module`. Import the sibling module",
+            "directly instead: `import core.pkg.sibling_module as sibling_module`.",
+            "For a genuinely mutual dependency, defer one side with a function-local",
+            "import (the documented escape hatch).",
+        ]
+        raise AssertionError("\n".join(lines))
+
+
+def test_core_graph_is_connected_enough_to_be_meaningful() -> None:
+    """Guard the analyzer itself: it must actually discover core/ import edges.
+
+    A refactor that broke import parsing could make the acyclicity test pass
+    vacuously. Assert the graph has a substantial number of edges so the
+    invariant above keeps real teeth.
+    """
+    mods = _iter_core_modules(_repo_root())
+    graph = _build_core_graph(mods)
+    edge_count = sum(len(deps) for deps in graph.values())
+    assert len(mods) > 100, f"expected to discover the core package, found {len(mods)} modules"
+    assert edge_count > 200, f"import-graph analysis looks broken: only {edge_count} edges"

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -288,6 +288,30 @@ class TestCoreInterfacesBoundaries:
             pytest.fail(f"core/interfaces.py must not import backend: {backend_imports}")
 
 
+class TestCorePurity:
+    """The whole of core/ is pure domain logic with no infrastructure deps.
+
+    ARCHITECTURE.md states the layering rule plainly: "core/ must never import
+    backend/". TestCoreWorldsBoundaries enforces that for core/worlds; this
+    widens it to every module under core/, so no file anywhere re-tangles the
+    boundary between the simulation core and the web/IO layer.
+    """
+
+    def test_core_does_not_import_backend_or_frontend(self):
+        """No module under core/ may import backend/* or frontend/*."""
+        repo_root = get_repo_root()
+        core_dir = repo_root / "core"
+
+        violations = check_forbidden_imports(core_dir, forbidden_patterns=["backend", "frontend"])
+
+        if violations:
+            msg = "core/ is pure domain logic and must not import backend/frontend:\n"
+            for path, imp in violations:
+                msg += f"  {path.relative_to(repo_root)}: imports '{imp}'\n"
+            msg += "\nInvert the dependency: have the backend adapt core, not the reverse."
+            pytest.fail(msg)
+
+
 # Utility function for local testing
 def main():
     """Run boundary checks and report violations."""


### PR DESCRIPTION
core/update_phases.py shipped two execution models: the UpdatePhase
vocabulary the engine actually uses (enum + runs_in_phase annotation +
PHASE_DESCRIPTIONS), and a never-wired PhaseRunner/PhaseContext/PhaseAware
runner that was the "optional alternative." The runner had zero call sites
in core/, backend/, or tests/ and was flagged as half-finished in
ARCHITECTURE.md.

Per the architecture review's "finish or delete abstractions" principle,
delete the unused runner trio and keep the phase taxonomy the systems
annotate themselves with. Refresh the ARCHITECTURE.md note so it describes
the explicit _phase_* methods that really drive the loop.

No behavior change: UpdatePhase, PHASE_DESCRIPTIONS, runs_in_phase, and
get_system_phase are untouched; phase ordering/hook/mutation tests pass.