### PR TITLE
feat(evolution): live trait-drift telemetry + evolution-health study tool

### DIFF
--- a/.claude/commands/study-sim.md
+++ b/.claude/commands/study-sim.md
@@ -1,0 +1,69 @@
+---
+description: Study the running simulation's evolution health and recommend (or implement) improvements
+argument-hint: "[url | probe | stats <file> | history <file>] [improve]"
+---
+
+You are helping the user study a Tank World simulation that is (usually) running
+right now, and answer: **how well are the fish evolving, and what should we change
+to improve it?** The end goal is improving evolution on a long-running sim (days+).
+
+Arguments (optional): `$ARGUMENTS`
+- A URL (e.g. `http://127.0.0.1:8000`) selects a live server. Default when no
+  source is given: `http://127.0.0.1:8000`.
+- `probe` runs a fresh deterministic probe instead of attaching to a server.
+- `stats <file>` analyses an exported stats JSON; `history <file>` analyses a
+  metrics-history payload or watch-journal (JSONL).
+- `improve` (may be combined with a source) means: don't stop at the report -
+  carry the top recommendation through to an implemented, validated change.
+
+## 1. Assess (always do this first)
+
+Run the read-only report tool with structured output and read its JSON:
+
+```bash
+python tools/evolution_report.py --url http://127.0.0.1:8000 --json
+```
+
+(Substitute `--probe`, `--stats <file>`, or `--history <file>` per the arguments.)
+If a live server was requested but is unreachable, say so and offer to run
+`--probe` instead rather than silently switching.
+
+Then give the user a **concise** assessment, not a raw dump:
+- the overall **verdict** and the per-axis grades;
+- the **trait-drift** highlights - call out which traits are under directional
+  selection (>=5%) vs flat. Flat traits despite generation turnover = churn
+  without selection (the thing we most want to fix);
+- the top 1-3 **recommendations**, each with the file to change and the
+  diagnostic that confirms it.
+
+Reference `AGENTS.md` -> "Studying a Running Simulation" and the "Healthy
+Ecosystem Indicators" table for what the numbers mean. For a multi-day run,
+suggest leaving a watch-journal running so the long-horizon trend survives the
+in-memory buffer wrap (`--watch --interval 300 --journal evolution_journal.jsonl`).
+
+## 2. Improve (only when the user asks, or `improve` was passed)
+
+Drive the top-ranked recommendation through the **Evolution Loop** - never
+hand-wave a fix:
+
+1. Reproduce the problem with the diagnostic the report named
+   (e.g. `scripts/diagnose_food_seeking.py`, `scripts/diagnose_evolution.py`).
+2. Make the **smallest** change. Keep Layer 1 (algorithm/config in `core/`)
+   separate from any Layer 2 change (this tool, benchmarks, telemetry, gates).
+3. `python tools/smoke_gate.py`, then `python tools/fast_gate.py`.
+4. Benchmark the candidate and compare against `champions/`. The
+   evolution-quality benchmark is `benchmarks/tank/ecosystem_health_10k.py`;
+   confirm trait drift actually moved with `scripts/diagnose_evolution.py`.
+   ecosystem_health is trajectory-sensitive on one seed - verify on a couple of
+   extra seeds (e.g. 7, 123) before trusting a win.
+5. Only claim an improvement with a reproduction command, seed, score, and
+   metadata. Commit on a feature branch with that evidence in the message, then
+   open a PR.
+
+## Guardrails
+
+- The report tool is read-only; it never perturbs the running sim. Keep it that way.
+- Determinism is non-negotiable - benchmarks use fixed seeds.
+- Do not claim a benchmark improvement without reproduction evidence.
+- If a recommendation is ambiguous or would require a large refactor, summarize
+  the options and ask the user before implementing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,83 @@ Every agent session should follow this loop:
 
 ---
 
+## Studying a Running Simulation (Live)
+
+Use this when the human asks **"how well are the fish evolving?"** or **"what
+should we change to improve the simulation?"** about a simulation that is
+*currently running* - typically the web-server mode (`python main.py`) left up
+for hours or days. You do not stop it; you observe it, score it, and recommend.
+
+The `/study-sim` slash command wraps this whole workflow. The engine underneath
+it is one read-only tool:
+
+```bash
+# Attach to the running server and print a health report (human-readable)
+python tools/evolution_report.py --url http://127.0.0.1:8000
+
+# Same, but emit structured JSON you can parse and reason over
+python tools/evolution_report.py --url http://127.0.0.1:8000 --json
+```
+
+It pulls the live telemetry (`/api/worlds/<id>/snapshot` and
+`/api/world/<id>/metrics/history`) and returns:
+
+- a **verdict** (`healthy`, `treading_water`, `stalled`, `struggling`,
+  `collapsing`, `insufficient_data`) and per-axis grades (turnover, **selection**,
+  foraging, diversity, population stability), graded against the *Healthy
+  Ecosystem Indicators* table below;
+- a **trait-drift table** - the population mean of the heritable foraging traits
+  (`pursuit_aggression`, `prediction_skill`, `hunting_stamina`, `aggression`)
+  plus speed/size, first sample -> last sample. **This is the key signal:** a
+  population can churn through generations while its mean traits stay flat (pure
+  drift). A consistent drift (>=5%) is direct evidence of *directional selection*,
+  i.e. real Layer 0 evolution rather than mere reproduction; and
+- **ranked, knob-specific recommendations** that name the actual file and the
+  diagnostic to confirm each one (e.g. the ball-pursuit-vs-food-seeking gotcha,
+  energy sinks suppressing births, weak selection pressure).
+
+These same trait means are now retained over time in the metrics-history buffer
+(schema v2) and drawn as the **Trait Drift** chart in the UI's Trends tab, so
+long-running selection is visible live, not just churn.
+
+### Other data sources
+
+```bash
+# No server up? Run a fresh deterministic probe and report on it
+python tools/evolution_report.py --probe --frames 20000 --seed 42
+
+# Analyse an exported stats JSON (main.py --export-stats)
+python tools/evolution_report.py --stats results.json
+```
+
+### Multi-day runs: stream a journal
+
+The in-memory history buffer keeps the most recent ~1M frames (2000 samples x
+500), so on a days-long run the early history scrolls off. To keep the full
+long-horizon trend, stream an append-only journal and analyse it later:
+
+```bash
+# Leave this running alongside the sim (Ctrl-C to stop)
+python tools/evolution_report.py --watch --interval 300 --journal evolution_journal.jsonl
+
+# Later, report over the entire journal (beyond what the live buffer holds)
+python tools/evolution_report.py --history evolution_journal.jsonl
+```
+
+### From assessment to improvement
+
+When the human asks you to *act* on the findings, drive the top-ranked
+recommendation through the normal **Evolution Loop** (do not hand-wave a fix):
+reproduce it with the named diagnostic, make the smallest change, run the smoke
+then fast gate, benchmark the candidate against the `champions/` registry
+(`ecosystem_health_10k` is the evolution-quality benchmark), and only claim an
+improvement with a reproduction command, seed, score, and metadata. Keep Layer 1
+(algorithm/config) changes separate from any Layer 2 change to the report tool,
+benchmarks, or telemetry. Confirm selection is genuinely occurring (trait drift),
+not just generation churn, with `scripts/diagnose_evolution.py`.
+
+---
+
 ## Step 1: Run Simulations
 
 ### Headless Mode (Use This)

--- a/backend/metrics_history.py
+++ b/backend/metrics_history.py
@@ -7,6 +7,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Bumped to 2 when per-trait means ("traits") were added to each sample so the
+# running UI/API can show directional selection over time, not just churn.
+SCHEMA_VERSION = 2
+
 
 def get_val(obj: Any, attr: str, default: Any = 0) -> Any:
     """Safely get value from dictionary or object."""
@@ -26,7 +30,7 @@ class MetricsHistory:
         sample_interval_frames: int = 500,
         max_samples: int = 2000,
     ) -> None:
-        self.schema_version = 1
+        self.schema_version = SCHEMA_VERSION
         self.world_id = world_id or "unknown"
         self.sample_interval_frames = sample_interval_frames
         self.max_samples = max_samples
@@ -38,6 +42,15 @@ class MetricsHistory:
         self.soccer_matches_skipped = 0
         self.processed_soccer_match_ids: set[str] = set()
 
+    def is_sample_due(self, frame: int) -> bool:
+        """Whether ``frame`` lands on a sampling boundary.
+
+        Exposed so callers can compute expensive per-sample data (e.g. trait
+        means over the live population) only on frames that will be recorded,
+        rather than on every stats collection.
+        """
+        return frame > 0 and frame % self.sample_interval_frames == 0
+
     def maybe_sample(
         self,
         frame: int,
@@ -45,8 +58,15 @@ class MetricsHistory:
         poker: Any,
         soccer: Any,
         auto_eval: Any,
+        trait_means: dict[str, float] | None = None,
     ) -> None:
-        """Sample metrics if the frame interval is reached."""
+        """Sample metrics if the frame interval is reached.
+
+        ``trait_means`` is an optional mapping of heritable trait key -> current
+        population mean (see ``core.services.stats.trait_trends``). It is stored
+        under ``"traits"`` so the history exposes directional selection over
+        time. When omitted (or empty) the field is recorded as ``{}``.
+        """
         # 1. Update cumulative soccer counters from the events list passed
         if soccer:
             for event in soccer:
@@ -119,6 +139,7 @@ class MetricsHistory:
                         "baseline_match_score_diff": None,
                     },
                     "diversity_score": round(get_val(stats, "diversity_score", 0.0), 4),
+                    "traits": dict(trait_means) if trait_means else {},
                 }
 
                 self.samples.append(sample)
@@ -149,7 +170,7 @@ class MetricsHistory:
             return
 
         try:
-            self.schema_version = payload.get("schema_version", 1)
+            self.schema_version = payload.get("schema_version", SCHEMA_VERSION)
             self.world_id = payload.get("world_id", self.world_id)
             self.sample_interval_frames = payload.get(
                 "sample_interval_frames", self.sample_interval_frames

--- a/backend/runner/state_publisher.py
+++ b/backend/runner/state_publisher.py
@@ -182,6 +182,8 @@ class StatePublisher:
                         fish_energy=s["fish_energy"],
                         poker=MetricsPokerSamplePayload(**s["poker"]),
                         soccer=MetricsSoccerSamplePayload(**s["soccer"]),
+                        diversity_score=s.get("diversity_score", 0.0),
+                        traits=s.get("traits", {}),
                     )
                 )
 
@@ -280,6 +282,8 @@ class StatePublisher:
                     fish_energy=s["fish_energy"],
                     poker=MetricsPokerSamplePayload(**s["poker"]),
                     soccer=MetricsSoccerSamplePayload(**s["soccer"]),
+                    diversity_score=s.get("diversity_score", 0.0),
+                    traits=s.get("traits", {}),
                 )
 
         return DeltaStatePayload(

--- a/backend/runner/stats_collector.py
+++ b/backend/runner/stats_collector.py
@@ -151,12 +151,39 @@ def collect_stats(
             except Exception:
                 pass
 
+        # Trait means are only meaningful (and only worth iterating fish for) on
+        # frames that will actually be recorded as a sample.
+        trait_means = None
+        if runner.metrics_history.is_sample_due(frame):
+            trait_means = _collect_trait_means(runner)
+
         runner.metrics_history.maybe_sample(
             frame=frame,
             stats=stats_payload,
             poker=poker_stats,
             soccer=soccer_events,
             auto_eval=auto_eval,
+            trait_means=trait_means,
         )
 
     return stats_payload
+
+
+def _collect_trait_means(runner: SimulationRunner) -> dict[str, float]:
+    """Population mean of the tracked heritable traits across living fish.
+
+    Read-only and defensive: any failure (e.g. a non-tank world without an
+    ``entities_list``) yields an empty mapping rather than disturbing the step
+    loop or stats collection.
+    """
+    try:
+        from core.entities import Fish
+        from core.services.stats.trait_trends import compute_trait_means
+
+        entities = getattr(runner.world, "entities_list", None)
+        if not entities:
+            return {}
+        living = [e for e in entities if isinstance(e, Fish) and not e.is_dead()]
+        return compute_trait_means(living)
+    except Exception:
+        return {}

--- a/backend/state_payloads.py
+++ b/backend/state_payloads.py
@@ -68,6 +68,9 @@ class MetricsSamplePayload:
     poker: MetricsPokerSamplePayload
     soccer: MetricsSoccerSamplePayload
     diversity_score: float = 0.0
+    # Population mean of tracked heritable traits at this sample (may be empty
+    # for pre-trait history or non-fish worlds). See trait_trends.py.
+    traits: dict[str, float] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         data = _to_dict(self)

--- a/core/services/stats/trait_trends.py
+++ b/core/services/stats/trait_trends.py
@@ -1,0 +1,101 @@
+"""Shared definition of the heritable traits we track to measure Layer 0 evolution.
+
+A population can churn through many generations while its mean traits stay flat
+(pure genetic drift, no selection). To tell *directional selection* from noise we
+track the population mean of the heritable traits that most directly drive
+survival and foraging, plus the expressed speed and size modifiers.
+
+This module is the single source of truth for that trait set, so the live
+metrics-history buffer (``backend/metrics_history.py``), the offline diagnostics
+(``scripts/diagnose_evolution.py``), and the evolution report tool
+(``tools/evolution_report.py``) all agree on what "trait drift" means and report
+the same numbers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from core.genetics.trait_utils import get_trait_value
+
+# Heritable behavioral traits that most directly affect survival/foraging.
+# Order is significant: it is the series order used by reports and charts.
+BEHAVIORAL_TRAIT_KEYS: tuple[str, ...] = (
+    "pursuit_aggression",
+    "prediction_skill",
+    "hunting_stamina",
+    "aggression",
+)
+
+# Expressed (derived) trait keys, appended after the behavioral ones.
+DERIVED_TRAIT_KEYS: tuple[str, ...] = ("speed", "size")
+
+# Full ordered set of trait-mean keys exposed in samples/reports.
+EVOLUTION_TRAIT_KEYS: tuple[str, ...] = BEHAVIORAL_TRAIT_KEYS + DERIVED_TRAIT_KEYS
+
+
+def _mean(total: float, count: int) -> float | None:
+    return round(total / count, 5) if count else None
+
+
+def compute_trait_means(fish_list: Iterable[Any]) -> dict[str, float]:
+    """Return the population mean of each tracked trait across the given fish.
+
+    The caller is expected to pass the *living* fish. This function is read-only:
+    it only reads genome attributes and never mutates simulation state or touches
+    the RNG, so it is safe to call inside the deterministic step loop.
+
+    Traits are averaged independently with per-trait counts, so a partially
+    initialised population (a fish missing a trait) still yields sane means for
+    the traits it does have. Returns an empty dict when there are no fish with a
+    genome, so callers can treat "no data" uniformly.
+
+    Args:
+        fish_list: Iterable of fish-like objects exposing ``.genome``.
+
+    Returns:
+        Mapping of trait key -> mean value, restricted to keys that had data.
+    """
+    fish = [f for f in fish_list if getattr(f, "genome", None) is not None]
+    if not fish:
+        return {}
+
+    means: dict[str, float] = {}
+
+    for key in BEHAVIORAL_TRAIT_KEYS:
+        total = 0.0
+        count = 0
+        for f in fish:
+            behavioral = getattr(f.genome, "behavioral", None)
+            value = get_trait_value(getattr(behavioral, key, None), default=None)
+            if value is not None:
+                total += float(value)
+                count += 1
+        mean = _mean(total, count)
+        if mean is not None:
+            means[key] = mean
+
+    speed_total = 0.0
+    speed_count = 0
+    size_total = 0.0
+    size_count = 0
+    for f in fish:
+        speed = getattr(f.genome, "speed_modifier", None)
+        if speed is not None:
+            speed_total += float(speed)
+            speed_count += 1
+        physical = getattr(f.genome, "physical", None)
+        size_val = get_trait_value(getattr(physical, "size_modifier", None), default=None)
+        if size_val is not None:
+            size_total += float(size_val)
+            size_count += 1
+
+    speed_mean = _mean(speed_total, speed_count)
+    if speed_mean is not None:
+        means["speed"] = speed_mean
+    size_mean = _mean(size_total, size_count)
+    if size_mean is not None:
+        means["size"] = size_mean
+
+    return means

--- a/frontend/src/components/tank_tabs/TankTrendsTab.tsx
+++ b/frontend/src/components/tank_tabs/TankTrendsTab.tsx
@@ -30,7 +30,19 @@ interface AggregatedPoint {
         goals_per_1k_frames: number;
     };
     diversity_score: number;
+    traits?: Record<string, number>;
 }
+
+// Heritable traits tracked for directional-selection (drift) visualization.
+// Order/colors are stable; only keys actually present in the data are drawn.
+const TRAIT_SERIES: { key: string; label: string; color: string }[] = [
+    { key: 'pursuit_aggression', label: 'Pursuit', color: '#f59e0b' },
+    { key: 'prediction_skill', label: 'Prediction', color: '#8b5cf6' },
+    { key: 'hunting_stamina', label: 'Stamina', color: '#10b981' },
+    { key: 'aggression', label: 'Aggression', color: '#ef4444' },
+    { key: 'speed', label: 'Speed', color: '#3b82f6' },
+    { key: 'size', label: 'Size', color: '#ec4899' },
+];
 
 // Helper to calculate trend delta and percentage change between first and last quartiles
 function calculateTrend(values: number[]): { delta: number; pct: number } {
@@ -195,6 +207,8 @@ export function TankTrendsTab({ history }: TankTrendsTabProps) {
             birthsSum: number;
             deathsSum: number;
             diversitySum: number;
+            traitsSum: Record<string, number>;
+            traitsCount: Record<string, number>;
         }> = {};
 
         samples.forEach(s => {
@@ -209,6 +223,8 @@ export function TankTrendsTab({ history }: TankTrendsTabProps) {
                     birthsSum: 0,
                     deathsSum: 0,
                     diversitySum: 0,
+                    traitsSum: {},
+                    traitsCount: {},
                 };
             }
             const g = genMap[gen];
@@ -220,6 +236,12 @@ export function TankTrendsTab({ history }: TankTrendsTabProps) {
             g.birthsSum += s.births_total;
             g.deathsSum += s.deaths_total;
             g.diversitySum += s.diversity_score ?? 0;
+            if (s.traits) {
+                for (const [k, v] of Object.entries(s.traits)) {
+                    g.traitsSum[k] = (g.traitsSum[k] ?? 0) + v;
+                    g.traitsCount[k] = (g.traitsCount[k] ?? 0) + 1;
+                }
+            }
         });
 
         data = Object.keys(genMap)
@@ -240,6 +262,12 @@ export function TankTrendsTab({ history }: TankTrendsTabProps) {
                     births_total: Number((g.birthsSum / g.count).toFixed(2)),
                     deaths_total: Number((g.deathsSum / g.count).toFixed(2)),
                     diversity_score: Number((g.diversitySum / g.count).toFixed(4)),
+                    traits: Object.fromEntries(
+                        Object.keys(g.traitsSum).map(k => [
+                            k,
+                            Number((g.traitsSum[k] / g.traitsCount[k]).toFixed(5)),
+                        ])
+                    ),
                 };
             });
     }
@@ -313,6 +341,13 @@ export function TankTrendsTab({ history }: TankTrendsTabProps) {
         letterSpacing: '0.05em',
         color: 'var(--color-text-muted)'
     };
+
+    // Only draw trait lines for keys that actually appear (pre-schema-v2 history
+    // has no trait means, so the card is hidden entirely in that case).
+    const presentTraitSeries = TRAIT_SERIES.filter(t =>
+        processedData.some(d => d.traits && d.traits[t.key] !== undefined)
+    );
+    const hasTraitData = presentTraitSeries.length > 0;
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
@@ -711,6 +746,59 @@ export function TankTrendsTab({ history }: TankTrendsTabProps) {
                         </ResponsiveContainer>
                     </div>
                 </div>
+
+                {/* Trait Drift: population mean of heritable traits over time.
+                    Directional movement here is evidence of real selection, not
+                    just generational churn. Hidden when no trait data is present. */}
+                {hasTraitData && (
+                    <div style={cardStyle}>
+                        <div style={cardHeaderStyle}>
+                            <span style={cardTitleStyle}>🧬 Trait Drift (Population Mean)</span>
+                            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                                {presentTraitSeries.map(t => (
+                                    <span key={t.key} style={{ color: t.color, fontSize: '10px', fontWeight: 600 }}>
+                                        {t.label}
+                                    </span>
+                                ))}
+                            </div>
+                        </div>
+                        <div style={{ flex: 1, minHeight: 0 }}>
+                            <ResponsiveContainer width="100%" height="100%">
+                                <LineChart data={processedData} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+                                    <CartesianGrid stroke="rgba(255,255,255,0.05)" vertical={false} />
+                                    <XAxis
+                                        dataKey={xAxisMode === 'frames' ? 'frame' : 'max_generation'}
+                                        stroke="rgba(255,255,255,0.3)"
+                                        fontSize={10}
+                                        tickFormatter={(v) => xAxisMode === 'frames' ? `${(v / 1000).toFixed(0)}k` : `${v}`}
+                                    />
+                                    <YAxis
+                                        stroke="rgba(255,255,255,0.3)"
+                                        fontSize={10}
+                                        domain={['auto', 'auto']}
+                                        tickFormatter={(v) => Number(v).toFixed(2)}
+                                    />
+                                    <Tooltip content={<CustomTooltip xAxisMode={xAxisMode} />} />
+                                    {xAxisMode === 'frames' && genMarkers.map((m, idx) => (
+                                        <ReferenceLine key={idx} x={m.frame} stroke="rgba(255,255,255,0.15)" strokeDasharray="2 2" />
+                                    ))}
+                                    {presentTraitSeries.map(t => (
+                                        <Line
+                                            key={t.key}
+                                            type="monotone"
+                                            dataKey={`traits.${t.key}`}
+                                            stroke={t.color}
+                                            strokeWidth={1.5}
+                                            name={t.label}
+                                            dot={false}
+                                            connectNulls
+                                        />
+                                    ))}
+                                </LineChart>
+                            </ResponsiveContainer>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -796,6 +796,9 @@ export interface MetricsSample {
     poker: MetricsPokerSample;
     soccer: MetricsSoccerSample;
     diversity_score: number;
+    // Population mean of tracked heritable traits at this sample (schema v2+).
+    // Optional so pre-trait history (older schemas) still type-checks.
+    traits?: Record<string, number>;
 }
 
 export interface MetricsHistory {

--- a/tests/test_evolution_report.py
+++ b/tests/test_evolution_report.py
@@ -1,0 +1,122 @@
+"""Tests for the evolution_report study tool's pure analysis/verdict logic."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "evolution_report", Path(__file__).resolve().parents[1] / "tools" / "evolution_report.py"
+)
+assert _SPEC and _SPEC.loader
+er = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(er)
+
+
+def _sample(frame, gen, pop, div, traits, births=0, deaths=0):
+    return {
+        "frame": frame,
+        "max_generation": gen,
+        "population": pop,
+        "births_total": births,
+        "deaths_total": deaths,
+        "diversity_score": div,
+        "traits": traits,
+    }
+
+
+def test_extractors_tolerate_shapes() -> None:
+    payload = {"samples": [{"frame": 1}]}
+    assert er.extract_history_samples(payload) == [{"frame": 1}]
+    snapshot = {"metrics_history": {"samples": [{"frame": 2}]}, "stats": {"population": 30}}
+    assert er.extract_history_samples(snapshot) == [{"frame": 2}]
+    assert er.extract_stats(snapshot) == {"population": 30}
+    # A raw export dict is already the stats block.
+    assert er.extract_stats({"population": 5})["population"] == 5
+    assert er.extract_history_samples(None) == []
+
+
+def test_starvation_fraction_from_causes() -> None:
+    assert er.starvation_fraction({"starvation_rate": 0.9}) == 0.9
+    assert er.starvation_fraction({"death_causes": {"starvation": 8, "predation": 2}}) == 0.8
+    assert er.starvation_fraction({"death_causes": {}}) is None
+
+
+def test_trait_drift_flags_selection() -> None:
+    samples = [
+        _sample(1000, 1, 30, 0.6, {"pursuit_aggression": 0.40, "speed": 1.00}),
+        _sample(2000, 3, 31, 0.6, {"pursuit_aggression": 0.50, "speed": 1.005}),
+    ]
+    hist = er.analyze_history(samples)
+    drift = hist["trait_drift"]
+    # +25% pursuit_aggression is directional selection; +0.5% speed is not.
+    assert drift["pursuit_aggression"]["selection"] is True
+    assert drift["speed"]["selection"] is False
+    assert hist["selection_detected"] is True
+
+
+def test_healthy_run_verdict() -> None:
+    samples = [
+        _sample(i * 1000, i, 35, 0.65, {"pursuit_aggression": 0.40 + i * 0.02}, births=i * 5)
+        for i in range(1, 12)
+    ]
+    stats = {
+        "max_generation": 11,
+        "population": 35,
+        "death_causes": {"starvation": 30, "predation": 40},  # ~43% starvation
+        "diversity_stats": {"diversity_score": 0.65, "unique_algorithms": 12},
+    }
+    report = er.build_report(samples, stats, "test")
+    assert report["axes"]["selection"] == "active"
+    assert report["axes"]["foraging"] == "ok"
+    assert report["axes"]["turnover"] == "healthy"
+    assert report["verdict"] == "healthy"
+    # The all-clear recommendation is still present and low priority.
+    assert report["recommendations"][0]["priority"] == "low"
+
+
+def test_struggling_run_flags_and_recommendations() -> None:
+    # Flat traits (drift only), slow turnover, high starvation.
+    samples = [
+        _sample(i * 1000, 1, 12, 0.2, {"pursuit_aggression": 0.40, "speed": 1.0})
+        for i in range(1, 12)
+    ]
+    stats = {
+        "max_generation": 1,
+        "population": 12,
+        "death_causes": {"starvation": 97, "predation": 3},  # 97% starvation -> broken
+        "diversity_stats": {"diversity_score": 0.2, "unique_algorithms": 2},
+    }
+    report = er.build_report(samples, stats, "test")
+    assert report["axes"]["foraging"] == "broken"
+    assert report["axes"]["selection"] == "drift_only"
+    assert report["axes"]["turnover"] == "stalled"
+    assert report["verdict"] in {"struggling", "stalled"}
+    # The top recommendation is high priority and food-seeking points at the ball gotcha.
+    assert report["recommendations"][0]["priority"] == "high"
+    joined = json.dumps(report["recommendations"])
+    assert "diagnose_food_seeking" in joined
+    assert "movement_strategy" in joined
+
+
+def test_insufficient_data_verdict() -> None:
+    report = er.build_report([_sample(1000, 1, 30, 0.6, {})], {}, "test")
+    assert report["verdict"] == "insufficient_data"
+    assert any("history sample" in r["finding"] for r in report["recommendations"])
+
+
+def test_new_samples_since() -> None:
+    samples = [{"frame": 100}, {"frame": 200}, {"frame": 300}]
+    assert er._new_samples_since(150, samples) == [{"frame": 200}, {"frame": 300}]
+    assert er._new_samples_since(300, samples) == []
+
+
+def test_format_human_runs() -> None:
+    samples = [
+        _sample(1000, 1, 30, 0.6, {"pursuit_aggression": 0.40}),
+        _sample(2000, 4, 31, 0.6, {"pursuit_aggression": 0.50}),
+    ]
+    text = er.format_human(er.build_report(samples, {"population": 31}, "test"))
+    assert "EVOLUTION HEALTH REPORT" in text
+    assert "RECOMMENDATIONS" in text

--- a/tests/test_metrics_trends.py
+++ b/tests/test_metrics_trends.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from backend.metrics_history import MetricsHistory
-from backend.state_payloads import StatsPayload, PokerStatsPayload
+from backend.state_payloads import PokerStatsPayload, StatsPayload
 from backend.world_registry import create_world
 
 
@@ -64,6 +64,73 @@ def test_metrics_history_capacity_and_interval() -> None:
     assert history.samples[0]["frame"] == 10
     assert history.samples[1]["frame"] == 15
     assert history.samples[2]["frame"] == 20
+    # Every sample carries a (possibly empty) traits mapping for schema v2.
+    assert all("traits" in sample for sample in history.samples)
+    assert history.schema_version == 2
+
+
+def test_is_sample_due_matches_interval() -> None:
+    """is_sample_due should only be true on interval boundaries (and never frame 0)."""
+    history = MetricsHistory(world_id="test-world", sample_interval_frames=5, max_samples=3)
+    assert not history.is_sample_due(0)
+    assert not history.is_sample_due(4)
+    assert history.is_sample_due(5)
+    assert history.is_sample_due(10)
+    assert not history.is_sample_due(11)
+
+
+def test_maybe_sample_records_trait_means() -> None:
+    """Trait means passed to maybe_sample are stored under the sample's 'traits' key."""
+    history = MetricsHistory(world_id="test-world", sample_interval_frames=5, max_samples=3)
+    stats = StatsPayload(
+        frame=5,
+        population=10,
+        generation=1,
+        max_generation=1,
+        births=0,
+        deaths=0,
+        capacity="10%",
+        time="Day",
+        death_causes={},
+        fish_count=10,
+        food_count=5,
+        plant_count=5,
+        total_energy=1000.0,
+        food_energy=100.0,
+        live_food_count=2,
+        live_food_energy=20.0,
+        fish_energy=800.0,
+        plant_energy=100.0,
+    )
+    poker = PokerStatsPayload(
+        total_games=0,
+        total_fish_games=0,
+        total_plant_games=0,
+        total_plant_energy_transferred=0.0,
+        total_wins=0,
+        total_losses=0,
+        total_ties=0,
+        total_energy_won=0.0,
+        total_energy_lost=0.0,
+        net_energy=0.0,
+        best_hand_rank=0,
+        best_hand_name="None",
+        showdown_win_rate="0.0%",
+    )
+
+    history.maybe_sample(
+        frame=5,
+        stats=stats,
+        poker=poker,
+        soccer=[],
+        auto_eval=None,
+        trait_means={"pursuit_aggression": 0.51, "speed": 1.02},
+    )
+
+    assert history.samples[-1]["traits"] == {"pursuit_aggression": 0.51, "speed": 1.02}
+    # Omitting trait_means yields an empty mapping rather than a missing key.
+    history.maybe_sample(frame=10, stats=stats, poker=poker, soccer=[], auto_eval=None)
+    assert history.samples[-1]["traits"] == {}
 
 
 def test_metrics_history_serialization_roundtrip() -> None:
@@ -230,3 +297,22 @@ def test_metrics_history_samples_without_state_request() -> None:
     runner.step()
 
     assert [sample["frame"] for sample in runner.metrics_history.samples] == [1]
+
+
+def test_runner_samples_populate_trait_means() -> None:
+    """A live tank runner should record real population trait means in samples."""
+    from backend.simulation_runner import SimulationRunner
+    from core.services.stats.trait_trends import EVOLUTION_TRAIT_KEYS
+
+    runner = SimulationRunner(seed=42, world_type="tank")
+    runner.metrics_history.sample_interval_frames = 1
+
+    for _ in range(3):
+        runner.step()
+
+    assert runner.metrics_history.samples, "expected at least one sample"
+    traits = runner.metrics_history.samples[-1]["traits"]
+    # A freshly seeded tank has fish, so trait means should be present and valid.
+    assert traits, "expected non-empty trait means for a populated tank"
+    assert set(traits).issubset(set(EVOLUTION_TRAIT_KEYS))
+    assert all(isinstance(v, float) for v in traits.values())

--- a/tools/evolution_report.py
+++ b/tools/evolution_report.py
@@ -1,0 +1,806 @@
+#!/usr/bin/env python3
+"""Evolution health report for a long-running Tank World simulation.
+
+This is the tool an AI agent (or a human) runs to answer two questions about a
+*running* simulation: "how well are the fish evolving?" and "what should we
+change to improve it?". It is deliberately read-only and side-effect free with
+respect to the simulation - it observes, scores, and recommends; it never edits
+the world or the code.
+
+It turns the scattered raw telemetry (the live metrics-history endpoint, a world
+snapshot, an exported stats JSON, or a fresh probe run) into a single structured
+report with:
+
+  * health indicators across several axes (turnover, selection, foraging,
+    diversity, population stability), graded against the thresholds documented
+    in CLAUDE.md ("Healthy Ecosystem Indicators");
+  * a trait-drift table (first -> last population mean) that distinguishes real
+    directional selection from mere generational churn; and
+  * ranked, knob-specific recommendations that point at the actual files and
+    diagnostics to act on.
+
+Data sources (pick one):
+
+    # Attach to a running web-server simulation (the common case for long runs)
+    python tools/evolution_report.py --url http://127.0.0.1:8000
+
+    # Analyse an exported stats JSON (from main.py --export-stats)
+    python tools/evolution_report.py --stats results.json
+
+    # Analyse a metrics-history payload or a watch-journal (JSONL)
+    python tools/evolution_report.py --history evolution_journal.jsonl
+
+    # No server? Run a fresh, deterministic probe and report on it
+    python tools/evolution_report.py --probe --frames 20000 --seed 42
+
+    # Long runs: stream samples to an append-only journal so the multi-day
+    # trend survives the in-memory history buffer wrapping (~1M frames).
+    python tools/evolution_report.py --watch --interval 300 --journal evolution_journal.jsonl
+
+Add --json (or --out FILE) to emit the structured report for an agent to parse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from typing import Any
+from urllib.request import urlopen
+
+# ---------------------------------------------------------------------------
+# Thresholds (kept in sync with the "Healthy Ecosystem Indicators" table and the
+# "Common Gotchas" notes in CLAUDE.md). Centralised so the verdict logic and the
+# recommendations agree on what "healthy" means.
+# ---------------------------------------------------------------------------
+TRAIT_DRIFT_SELECTION_PCT = 5.0  # |rel change| >= this => directional selection
+GEN_RATE_HEALTHY_PER_10K = 5.0  # generations per 10k frames
+GEN_RATE_SLOW_PER_10K = 3.0
+STARVATION_STRAINED = 0.80  # fraction of deaths that are starvation
+STARVATION_BROKEN = 0.95
+POP_STABLE_MIN = 20.0  # stable population floor (fish)
+POP_CV_UNSTABLE = 0.35  # coefficient of variation above this => boom/bust
+DIVERSITY_LOW = 0.30  # diversity_score below this => converging
+MIN_SAMPLES_FOR_TREND = 3
+
+
+# ---------------------------------------------------------------------------
+# Field extraction (tolerant: the snapshot stats, the export JSON, and the
+# probe metrics differ in shape and naming, so we try several known locations).
+# ---------------------------------------------------------------------------
+def _first_present(obj: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in obj and obj[key] is not None:
+            return obj[key]
+    return None
+
+
+def extract_history_samples(payload: Any) -> list[dict[str, Any]]:
+    """Pull the ordered list of metric samples out of any supported container."""
+    if payload is None:
+        return []
+    if isinstance(payload, list):
+        return [s for s in payload if isinstance(s, dict)]
+    if isinstance(payload, dict):
+        # Metrics-history payload, or a full snapshot embedding one.
+        if isinstance(payload.get("samples"), list):
+            return [s for s in payload["samples"] if isinstance(s, dict)]
+        mh = payload.get("metrics_history")
+        if isinstance(mh, dict) and isinstance(mh.get("samples"), list):
+            return [s for s in mh["samples"] if isinstance(s, dict)]
+    return []
+
+
+def extract_stats(obj: Any) -> dict[str, Any]:
+    """Pull the instantaneous stats block out of any supported container."""
+    if not isinstance(obj, dict):
+        return {}
+    # A full snapshot nests the curated stats under "stats".
+    if isinstance(obj.get("stats"), dict):
+        return obj["stats"]
+    # An exported get_current_metrics() dict is already the stats block.
+    return obj
+
+
+def _diversity_block(stats: dict[str, Any]) -> dict[str, Any]:
+    block = stats.get("diversity_stats")
+    return block if isinstance(block, dict) else {}
+
+
+def starvation_fraction(stats: dict[str, Any]) -> float | None:
+    """Fraction of deaths attributable to starvation, or None if unknown."""
+    rate = _first_present(stats, "starvation_rate")
+    if isinstance(rate, (int, float)):
+        return float(rate)
+    causes = stats.get("death_causes")
+    if isinstance(causes, dict) and causes:
+        total = sum(v for v in causes.values() if isinstance(v, (int, float)))
+        starved = causes.get("starvation", 0) or causes.get("starved", 0)
+        if total > 0 and isinstance(starved, (int, float)):
+            return float(starved) / float(total)
+    return None
+
+
+def population_value(stats: dict[str, Any]) -> float | None:
+    val = _first_present(
+        stats,
+        "population",
+        "fish_count",
+        "mean_population",
+        "avg_pop",
+        "final_population",
+        "final_fish_count",
+    )
+    return float(val) if isinstance(val, (int, float)) else None
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+def _coefficient_of_variation(values: list[float]) -> float:
+    n = len(values)
+    if n < 2:
+        return 0.0
+    mean = sum(values) / n
+    if mean == 0:
+        return 0.0
+    var = sum((v - mean) ** 2 for v in values) / n
+    return (var**0.5) / abs(mean)
+
+
+def analyze_history(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    """Time-series signals: trait drift, turnover, diversity trend, stability."""
+    result: dict[str, Any] = {
+        "n_samples": len(samples),
+        "sufficient": len(samples) >= MIN_SAMPLES_FOR_TREND,
+    }
+    if not samples:
+        return result
+
+    first, last = samples[0], samples[-1]
+    result["frame_first"] = first.get("frame")
+    result["frame_last"] = last.get("frame")
+    result["frames_covered"] = (last.get("frame", 0) or 0) - (first.get("frame", 0) or 0)
+
+    # Generation turnover.
+    gen_first = first.get("max_generation", 0) or 0
+    gen_last = last.get("max_generation", 0) or 0
+    result["generation_first"] = gen_first
+    result["generation_last"] = gen_last
+    result["generations_advanced"] = gen_last - gen_first
+    frames = result["frames_covered"] or 0
+    result["generation_rate_per_10k"] = (
+        round((gen_last - gen_first) / (frames / 10000.0), 3) if frames > 0 else None
+    )
+
+    # Population stability across the window.
+    pops = [
+        float(s["population"]) for s in samples if isinstance(s.get("population"), (int, float))
+    ]
+    if pops:
+        result["population_mean"] = round(sum(pops) / len(pops), 2)
+        result["population_min"] = min(pops)
+        result["population_max"] = max(pops)
+        result["population_cv"] = round(_coefficient_of_variation(pops), 3)
+        result["population_last"] = pops[-1]
+
+    # Diversity trend.
+    div = [
+        float(s["diversity_score"])
+        for s in samples
+        if isinstance(s.get("diversity_score"), (int, float))
+    ]
+    if div:
+        result["diversity_first"] = div[0]
+        result["diversity_last"] = div[-1]
+        result["diversity_delta"] = round(div[-1] - div[0], 4)
+
+    # Birth/death deltas over the window.
+    if isinstance(first.get("births_total"), (int, float)) and isinstance(
+        last.get("births_total"), (int, float)
+    ):
+        result["births_in_window"] = last["births_total"] - first["births_total"]
+    if isinstance(first.get("deaths_total"), (int, float)) and isinstance(
+        last.get("deaths_total"), (int, float)
+    ):
+        result["deaths_in_window"] = last["deaths_total"] - first["deaths_total"]
+
+    # Trait drift (first -> last population mean), the selection-vs-churn signal.
+    result["trait_drift"] = _trait_drift(samples)
+    result["selection_detected"] = any(d["selection"] for d in result["trait_drift"].values())
+    return result
+
+
+def _trait_drift(samples: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Per-trait first->last drift across samples that carry trait means."""
+    with_traits = [s for s in samples if isinstance(s.get("traits"), dict) and s["traits"]]
+    drift: dict[str, dict[str, Any]] = {}
+    if len(with_traits) < 2:
+        return drift
+    first, last = with_traits[0], with_traits[-1]
+    keys = [k for k in first["traits"] if k in last["traits"]]
+    for key in keys:
+        start = float(first["traits"][key])
+        end = float(last["traits"][key])
+        delta = end - start
+        rel = (delta / start * 100.0) if start else 0.0
+        drift[key] = {
+            "start": round(start, 5),
+            "end": round(end, 5),
+            "delta": round(delta, 5),
+            "pct": round(rel, 2),
+            "selection": abs(rel) >= TRAIT_DRIFT_SELECTION_PCT,
+        }
+    return drift
+
+
+def analyze_stats(stats: dict[str, Any]) -> dict[str, Any]:
+    """Instantaneous signals from the current stats block."""
+    result: dict[str, Any] = {}
+    if not stats:
+        return result
+    div = _diversity_block(stats)
+    result["max_generation"] = _first_present(stats, "max_generation", "current_generation")
+    result["population"] = population_value(stats)
+    result["starvation_fraction"] = starvation_fraction(stats)
+    result["diversity_score"] = _first_present(stats, "diversity_score") or div.get(
+        "diversity_score"
+    )
+    result["unique_algorithms"] = div.get("unique_algorithms")
+    result["unique_species"] = div.get("unique_species")
+
+    repro = stats.get("reproduction_stats")
+    if isinstance(repro, dict):
+        attempts = repro.get("total_mating_attempts") or 0
+        offspring = repro.get("total_offspring") or 0
+        result["reproduction_offspring"] = offspring
+        result["reproduction_attempts"] = attempts
+        if attempts:
+            result["reproduction_success_pct"] = round(100.0 * offspring / attempts, 1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Verdict + recommendations
+# ---------------------------------------------------------------------------
+def assess(hist: dict[str, Any], inst: dict[str, Any]) -> dict[str, Any]:
+    """Grade each axis and roll up to an overall verdict + findings."""
+    axes: dict[str, str] = {}
+    findings: list[str] = []
+
+    # Population axis.
+    pop = inst.get("population")
+    if pop is None:
+        pop = hist.get("population_last")
+    pop_cv = hist.get("population_cv")
+    if pop is not None and pop <= 0:
+        axes["population"] = "extinct"
+        findings.append("Population has collapsed to zero (extinction).")
+    elif pop is not None and pop < POP_STABLE_MIN:
+        axes["population"] = "fragile"
+        findings.append(f"Population is low ({pop:.0f} < {POP_STABLE_MIN:.0f} stable floor).")
+    elif isinstance(pop_cv, (int, float)) and pop_cv >= POP_CV_UNSTABLE:
+        axes["population"] = "unstable"
+        findings.append(f"Population is boom/bust (CV={pop_cv:.2f} >= {POP_CV_UNSTABLE}).")
+    elif pop is not None:
+        axes["population"] = "stable"
+
+    # Turnover axis.
+    rate = hist.get("generation_rate_per_10k")
+    if isinstance(rate, (int, float)):
+        if rate < GEN_RATE_SLOW_PER_10K:
+            axes["turnover"] = "stalled"
+            findings.append(
+                f"Generation turnover is slow ({rate:.1f} < {GEN_RATE_SLOW_PER_10K} per 10k frames)."
+            )
+        elif rate < GEN_RATE_HEALTHY_PER_10K:
+            axes["turnover"] = "slow"
+            findings.append(f"Generation turnover is moderate ({rate:.1f} per 10k frames).")
+        else:
+            axes["turnover"] = "healthy"
+
+    # Selection axis (the heart of "are they actually evolving").
+    drift = hist.get("trait_drift") or {}
+    if drift:
+        if hist.get("selection_detected"):
+            axes["selection"] = "active"
+        else:
+            axes["selection"] = "drift_only"
+            findings.append(
+                "Generational churn without directional selection: no tracked trait "
+                f"drifted >= {TRAIT_DRIFT_SELECTION_PCT:.0f}% (drift-dominated or near a "
+                "fitness optimum)."
+            )
+    elif hist.get("sufficient"):
+        findings.append("No trait-mean data in history (older schema); cannot judge selection.")
+
+    # Foraging axis.
+    starv = inst.get("starvation_fraction")
+    if isinstance(starv, (int, float)):
+        if starv >= STARVATION_BROKEN:
+            axes["foraging"] = "broken"
+            findings.append(
+                f"Starvation is {starv*100:.0f}% of deaths (>= {STARVATION_BROKEN*100:.0f}%): "
+                "food-seeking is likely broken."
+            )
+        elif starv >= STARVATION_STRAINED:
+            axes["foraging"] = "strained"
+            findings.append(f"Starvation is {starv*100:.0f}% of deaths (food economy is tight).")
+        else:
+            axes["foraging"] = "ok"
+
+    # Diversity axis.
+    div_score = inst.get("diversity_score")
+    if div_score is None:
+        div_score = hist.get("diversity_last")
+    div_delta = hist.get("diversity_delta")
+    uniq = inst.get("unique_algorithms")
+    if isinstance(div_score, (int, float)):
+        declining = isinstance(div_delta, (int, float)) and div_delta < 0
+        if div_score < DIVERSITY_LOW and declining:
+            axes["diversity"] = "converging"
+            findings.append(
+                f"Genetic diversity is low and falling (score={div_score:.2f}, "
+                f"unique_algorithms={uniq}): risk of premature convergence."
+            )
+        else:
+            axes["diversity"] = "ok"
+
+    verdict = _roll_up(axes, hist)
+    return {"verdict": verdict, "axes": axes, "findings": findings}
+
+
+def _roll_up(axes: dict[str, str], hist: dict[str, Any]) -> str:
+    if not hist.get("sufficient") and not axes:
+        return "insufficient_data"
+    if axes.get("population") == "extinct":
+        return "collapsing"
+    bad = {
+        "fragile",
+        "unstable",
+        "stalled",
+        "broken",
+        "converging",
+    }
+    if any(v in bad for v in axes.values()):
+        # Distinguish a foraging/population crisis from an evolution-quality stall.
+        if axes.get("foraging") == "broken" or axes.get("population") in {"fragile", "unstable"}:
+            return "struggling"
+        return "stalled"
+    if (
+        axes.get("selection") == "drift_only"
+        or axes.get("turnover") == "slow"
+        or axes.get("foraging") == "strained"
+    ):
+        return "treading_water"
+    if not hist.get("sufficient"):
+        return "insufficient_data"
+    return "healthy"
+
+
+def recommend(assessment: dict[str, Any], hist: dict[str, Any], inst: dict[str, Any]) -> list[dict]:
+    """Map findings to ranked, knob-specific actions referencing real files."""
+    axes = assessment["axes"]
+    recs: list[dict[str, Any]] = []
+
+    def add(priority: str, finding: str, action: str, validate: str) -> None:
+        recs.append(
+            {"priority": priority, "finding": finding, "action": action, "validate": validate}
+        )
+
+    if axes.get("population") == "extinct":
+        add(
+            "high",
+            "The population went extinct.",
+            "Check the energy economy and emergency-spawn floor in "
+            "core/reproduction_service.py and core/config/fish.py; confirm food supply "
+            "(core/config/food.py, main.py --auto-food-spawn-rate).",
+            "python scripts/analyze_population.py",
+        )
+
+    if axes.get("foraging") in {"broken", "strained"}:
+        add(
+            "high" if axes["foraging"] == "broken" else "medium",
+            "Most deaths are starvation; fish are not foraging effectively.",
+            "First rule out ball pursuit pre-empting food seeking (core/movement_strategy.py: "
+            "ball priority 2 runs before composable food pursuit priority 4, and the ball exists "
+            "even when soccer is off). Then review food detection/spawn in core/config/food.py and "
+            "the food-seeking sub-behavior in core/algorithms/composable/actions.py.",
+            "python scripts/diagnose_food_seeking.py",
+        )
+
+    if axes.get("turnover") in {"stalled", "slow"}:
+        add(
+            "high" if axes["turnover"] == "stalled" else "medium",
+            "Generation turnover is below the healthy >5 per 10k frames.",
+            "Reproduction is funded by energy banked ABOVE max_energy, so energy sinks (ball play, "
+            "poker) suppress births. Audit max_energy and reproduction thresholds in "
+            "core/config/fish.py and the spend logic in core/reproduction_service.py.",
+            "python scripts/analyze_energy.py",
+        )
+
+    if axes.get("selection") == "drift_only":
+        add(
+            "medium",
+            "Generations turn over but mean traits are not under directional selection.",
+            "Confirm it is genuine (not single-window noise) over a longer horizon, then if traits "
+            "are truly flat, selection pressure is too weak: review mutation bounds in "
+            "core/algorithms/composable/definitions.py and whether fitness meaningfully "
+            "differentiates the tracked traits.",
+            "python scripts/diagnose_evolution.py --frames 20000 --seed 42",
+        )
+
+    if axes.get("diversity") == "converging":
+        add(
+            "medium",
+            "Genetic diversity is low and falling.",
+            "Review mutation rate/strength and HGT probability bounds "
+            "(core/algorithms/composable/definitions.py, core/genetics/) and mate preferences; "
+            "premature convergence freezes evolution.",
+            "python main.py --headless --max-frames 30000 --export-stats results.json --seed 42",
+        )
+
+    if axes.get("population") == "unstable":
+        add(
+            "medium",
+            "Population swings between boom and bust.",
+            "Smooth the energy economy and emergency-spawn behaviour "
+            "(core/reproduction_service.py, core/config/fish.py); large swings perturb the "
+            "single-seed trajectory and the ecosystem_health benchmark.",
+            "python scripts/analyze_population.py",
+        )
+
+    if not hist.get("sufficient"):
+        add(
+            "low",
+            f"Only {hist.get('n_samples', 0)} history sample(s); trends are not yet reliable.",
+            "Let the simulation run longer, or stream a journal so the multi-day trend survives "
+            "the in-memory buffer wrap: "
+            "python tools/evolution_report.py --watch --interval 300 --journal evolution_journal.jsonl",
+            "re-run this report once more samples have accrued",
+        )
+
+    if not recs:
+        add(
+            "low",
+            "No problems detected on the measured axes.",
+            "Evolution looks healthy. To push further, raise selection pressure or enrich the "
+            "niche and compare on the ecosystem_health benchmark.",
+            "python tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 42",
+        )
+
+    order = {"high": 0, "medium": 1, "low": 2}
+    recs.sort(key=lambda r: order.get(r["priority"], 3))
+    return recs
+
+
+def build_report(
+    samples: list[dict[str, Any]], stats: dict[str, Any], source: str
+) -> dict[str, Any]:
+    hist = analyze_history(samples)
+    inst = analyze_stats(stats)
+    assessment = assess(hist, inst)
+    recs = recommend(assessment, hist, inst)
+    return {
+        "source": source,
+        "verdict": assessment["verdict"],
+        "axes": assessment["axes"],
+        "findings": assessment["findings"],
+        "history": hist,
+        "current": inst,
+        "recommendations": recs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Human-readable rendering
+# ---------------------------------------------------------------------------
+def format_human(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    hist = report["history"]
+    inst = report["current"]
+    lines.append("=" * 78)
+    lines.append("TANK WORLD - EVOLUTION HEALTH REPORT")
+    lines.append("=" * 78)
+    lines.append(f"source : {report['source']}")
+    lines.append(f"verdict: {report['verdict'].upper()}")
+    if hist.get("frame_last") is not None:
+        lines.append(
+            f"window : frame {hist.get('frame_first')} -> {hist.get('frame_last')} "
+            f"({hist.get('n_samples')} samples)"
+        )
+
+    lines.append("")
+    lines.append("AXES")
+    lines.append("-" * 78)
+    if report["axes"]:
+        for axis, grade in report["axes"].items():
+            lines.append(f"  {axis:>12}: {grade}")
+    else:
+        lines.append("  (not enough data to grade any axis)")
+
+    lines.append("")
+    lines.append("KEY METRICS")
+    lines.append("-" * 78)
+    gen_rate = hist.get("generation_rate_per_10k")
+    lines.append(f"  max generation        : {inst.get('max_generation', '?')}")
+    lines.append(
+        f"  generation rate /10k  : {gen_rate if gen_rate is not None else '?'} "
+        f"(healthy > {GEN_RATE_HEALTHY_PER_10K})"
+    )
+    lines.append(
+        f"  population            : "
+        f"{inst.get('population', hist.get('population_last', '?'))} "
+        f"(mean {hist.get('population_mean', '?')}, CV {hist.get('population_cv', '?')})"
+    )
+    starv = inst.get("starvation_fraction")
+    lines.append(
+        f"  starvation fraction   : {round(starv, 3) if isinstance(starv, float) else '?'} "
+        f"(healthy < {STARVATION_STRAINED})"
+    )
+    lines.append(
+        f"  diversity score       : {inst.get('diversity_score', hist.get('diversity_last', '?'))} "
+        f"(unique algorithms {inst.get('unique_algorithms', '?')})"
+    )
+
+    drift = hist.get("trait_drift") or {}
+    lines.append("")
+    lines.append("TRAIT DRIFT (population mean, first -> last)")
+    lines.append("-" * 78)
+    if drift:
+        for trait, d in drift.items():
+            mark = "  <- selection" if d["selection"] else ""
+            lines.append(
+                f"  {trait:>18}: {d['start']:8.4f} -> {d['end']:8.4f} "
+                f"({d['delta']:+.4f}, {d['pct']:+6.1f}%){mark}"
+            )
+    else:
+        lines.append("  (no trait-mean history available - need >=2 samples with traits)")
+
+    lines.append("")
+    lines.append("FINDINGS")
+    lines.append("-" * 78)
+    if report["findings"]:
+        for f in report["findings"]:
+            lines.append(f"  - {f}")
+    else:
+        lines.append("  - none")
+
+    lines.append("")
+    lines.append("RECOMMENDATIONS (ranked)")
+    lines.append("-" * 78)
+    for i, rec in enumerate(report["recommendations"], 1):
+        lines.append(f"  {i}. [{rec['priority'].upper()}] {rec['finding']}")
+        lines.append(f"     action  : {rec['action']}")
+        lines.append(f"     validate: {rec['validate']}")
+    lines.append("=" * 78)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# IO: live server, files, probe, watch
+# ---------------------------------------------------------------------------
+def _http_get_json(url: str, timeout: float = 10.0) -> Any:
+    # Trusted, user-supplied local/LAN URL pointing at their own simulation server.
+    with urlopen(url, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def resolve_world_id(base_url: str, world_id: str | None) -> str:
+    if world_id:
+        return world_id
+    data = _http_get_json(f"{base_url}/api/worlds/default/id")
+    return data["world_id"]
+
+
+def fetch_live(base_url: str, world_id: str | None) -> tuple[list[dict], dict, str]:
+    """Fetch samples + current stats from a running server.
+
+    Prefers the snapshot endpoint (stats + metrics_history in one call); falls
+    back to the metrics-history endpoint alone.
+    """
+    base_url = base_url.rstrip("/")
+    wid = resolve_world_id(base_url, world_id)
+    try:
+        snap = _http_get_json(f"{base_url}/api/worlds/{wid}/snapshot")
+        samples = extract_history_samples(snap)
+        stats = extract_stats(snap)
+        if samples or stats:
+            return samples, stats, f"live:{base_url} world={wid} (snapshot)"
+    except Exception:
+        pass
+    payload = _http_get_json(f"{base_url}/api/world/{wid}/metrics/history")
+    return extract_history_samples(payload), {}, f"live:{base_url} world={wid} (metrics/history)"
+
+
+def load_history_file(path: str) -> list[dict]:
+    """Load a metrics-history payload (JSON) or a watch-journal (JSONL)."""
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    try:
+        payload = json.loads(text)
+        return extract_history_samples(payload)
+    except json.JSONDecodeError:
+        samples: list[dict] = []
+        for line in text.splitlines():
+            line = line.strip()
+            if line:
+                samples.append(json.loads(line))
+        return samples
+
+
+def run_probe(frames: int, seed: int, interval: int) -> tuple[list[dict], dict, str]:
+    """Run a fresh, deterministic headless sim, sampling trait means as we go."""
+    import os
+
+    sys.path.insert(0, os.getcwd())
+    from core.entities import Fish
+    from core.services.stats.trait_trends import compute_trait_means
+    from core.worlds import WorldRegistry
+
+    config = {
+        "headless": True,
+        "screen_width": 2000,
+        "screen_height": 2000,
+        "max_population": 60,
+        "soccer_enabled": False,
+        "plants_enabled": False,
+        "poker_activity_enabled": False,
+        "auto_food_spawn_rate": 9,
+    }
+    world = WorldRegistry.create_world("tank", seed=seed, config=config)
+    world.reset(seed=seed, config=config)
+
+    samples: list[dict] = []
+    for i in range(frames):
+        world.step()
+        if (i + 1) % interval == 0:
+            stats = world.get_stats(include_distributions=False)
+            living = [e for e in world.entities_list if isinstance(e, Fish) and not e.is_dead()]
+            div = stats.get("diversity_stats", {})
+            samples.append(
+                {
+                    "frame": i + 1,
+                    "max_generation": stats.get("max_generation", 0),
+                    "population": stats.get("fish_count", 0),
+                    "births_total": stats.get("total_births", stats.get("births", 0)),
+                    "deaths_total": stats.get("total_deaths", stats.get("deaths", 0)),
+                    "diversity_score": div.get("diversity_score", 0.0),
+                    "traits": compute_trait_means(living),
+                }
+            )
+    final = world.get_current_metrics(include_distributions=True)
+    return samples, extract_stats(final), f"probe frames={frames} seed={seed} interval={interval}"
+
+
+def _new_samples_since(last_frame: int, samples: list[dict]) -> list[dict]:
+    """Samples strictly newer than last_frame (for incremental journaling)."""
+    return [s for s in samples if isinstance(s.get("frame"), int) and s["frame"] > last_frame]
+
+
+def watch(base_url: str, world_id: str | None, interval: float, journal: str | None) -> None:
+    """Poll the running server and stream new samples to an append-only journal.
+
+    Runs until interrupted. This is how multi-day trends survive the in-memory
+    history buffer (which wraps after max_samples) - the journal is unbounded.
+    """
+    base_url = base_url.rstrip("/")
+    wid = resolve_world_id(base_url, world_id)
+    last_frame = -1
+    print(
+        f"[watch] world={wid} interval={interval}s journal={journal or '(none)'} - Ctrl-C to stop",
+        flush=True,
+    )
+    while True:
+        try:
+            payload = _http_get_json(f"{base_url}/api/world/{wid}/metrics/history")
+            samples = extract_history_samples(payload)
+            fresh = _new_samples_since(last_frame, samples)
+            if fresh:
+                last_frame = fresh[-1]["frame"]
+                if journal:
+                    with open(journal, "a", encoding="utf-8") as jf:
+                        for s in fresh:
+                            jf.write(json.dumps(s) + "\n")
+                latest = fresh[-1]
+                drift = _trait_drift(samples)
+                top = ""
+                if drift:
+                    key = max(drift, key=lambda k: abs(drift[k]["pct"]))
+                    top = f" topdrift={key}{drift[key]['pct']:+.1f}%"
+                print(
+                    f"[watch] frame={latest.get('frame')} gen={latest.get('max_generation')} "
+                    f"pop={latest.get('population')} div={latest.get('diversity_score')}{top}",
+                    flush=True,
+                )
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:  # transient server hiccups should not kill the watch
+            print(f"[watch] poll failed: {exc}", flush=True)
+        try:
+            time.sleep(interval)
+        except KeyboardInterrupt:
+            print("\n[watch] stopped.", flush=True)
+            return
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    src = parser.add_mutually_exclusive_group()
+    src.add_argument("--url", help="Base URL of a running simulation (e.g. http://127.0.0.1:8000)")
+    src.add_argument("--stats", help="Path to an exported stats JSON (main.py --export-stats)")
+    src.add_argument(
+        "--history", help="Path to a metrics-history payload (JSON) or journal (JSONL)"
+    )
+    src.add_argument("--probe", action="store_true", help="Run a fresh headless probe simulation")
+    parser.add_argument("--world", help="World id (defaults to the server's default world)")
+    parser.add_argument("--frames", type=int, default=20000, help="Probe length in frames")
+    parser.add_argument("--seed", type=int, default=42, help="Probe seed")
+    parser.add_argument("--interval", type=int, default=1000, help="Probe sampling interval frames")
+    parser.add_argument(
+        "--watch", action="store_true", help="Stream samples to a journal (long runs)"
+    )
+    parser.add_argument("--watch-interval", type=float, default=300.0, help="Watch poll seconds")
+    parser.add_argument("--journal", help="Append-only JSONL journal path for --watch")
+    parser.add_argument("--json", action="store_true", help="Emit the structured report as JSON")
+    parser.add_argument("--out", help="Write the structured report JSON to this file")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+
+    if args.watch:
+        base = args.url or "http://127.0.0.1:8000"
+        try:
+            watch(base, args.world, args.watch_interval, args.journal)
+        except KeyboardInterrupt:
+            print("\n[watch] stopped.", flush=True)
+        return 0
+
+    try:
+        if args.stats:
+            with open(args.stats, encoding="utf-8") as f:
+                blob = json.load(f)
+            samples = extract_history_samples(blob)
+            stats = extract_stats(blob)
+            source = f"stats:{args.stats}"
+        elif args.history:
+            samples = load_history_file(args.history)
+            stats = {}
+            source = f"history:{args.history}"
+        elif args.probe:
+            samples, stats, source = run_probe(args.frames, args.seed, args.interval)
+        else:
+            base = args.url or "http://127.0.0.1:8000"
+            samples, stats, source = fetch_live(base, args.world)
+    except Exception as exc:
+        print(f"error: could not load simulation data: {exc}", file=sys.stderr)
+        if not (args.stats or args.history or args.probe):
+            print(
+                "hint: is the simulation running? start it with `python main.py`, or analyse an "
+                "export with --stats / run a fresh probe with --probe.",
+                file=sys.stderr,
+            )
+        return 2
+
+    report = build_report(samples, stats, source)
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, default=str)
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print(format_human(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Make it possible for an agent (or a human) to **study a running, long-lived simulation** and answer two questions: *"how well are the fish evolving?"* and *"what should we change to improve it?"* — the workflow you'd reach for on a sim left up for hours or days.

The gap today: a population can churn through generations while its mean traits stay flat (pure drift). The one signal that distinguishes **real directional selection from mere churn** — trait means over time — was computed only by a throwaway diagnostic (`scripts/diagnose_evolution.py` on a fresh sim), never retained for the live sim, and never interpreted for an agent. `scripts/analyze_sim.py` (the only existing "study the running sim" script) points at dead endpoints and is poker-only.

This is a **Layer 2 change only** — tooling, telemetry, and instructions. No algorithm or config edits.

## What's in here

**Backend telemetry (metrics-history schema v2)**
- New shared helper `core/services/stats/trait_trends.py` — single source of truth for the tracked trait set (`pursuit_aggression`, `prediction_skill`, `hunting_stamina`, `aggression`, `speed`, `size`) and how to mean them.
- `MetricsHistory` now records population trait means per sample, gated by `is_sample_due` so fish are only iterated on frames that are actually kept. Sampling is read-only — the existing determinism guard test still passes.
- Trait means flow through both serialization paths (REST `/metrics/history` and the WebSocket snapshot/delta). Restored a `diversity_score` that was being silently dropped on the snapshot path along the way.

**Study tool — `tools/evolution_report.py` (read-only)**
- Sources: live server (`--url`), exported stats JSON (`--stats`), a metrics-history payload or watch-journal (`--history`), or a fresh deterministic probe (`--probe`).
- Emits a **verdict** + per-axis grades (turnover, selection, foraging, diversity, population stability) graded against CLAUDE.md's "Healthy Ecosystem Indicators", a **trait-drift table**, and **ranked, knob-specific recommendations** that name the file to change and the diagnostic to confirm it. `--json` for agents.
- `--watch` streams samples to an append-only journal so multi-day trends survive the in-memory buffer wrap (~1M frames).

**Frontend**
- A "Trait Drift" multi-line chart in the Trends tab (works in both frames and generations modes), hidden for pre-v2 history.

**Docs / UX**
- `AGENTS.md` gains a "Studying a Running Simulation" section.
- A `/study-sim` Claude Code command wraps *assess → recommend → (on request) implement* via the Evolution Loop.

## Validation

- `python tools/smoke_gate.py` ✓
- `python tools/fast_gate.py` ✓ (1780 passed, 4 skipped)
- `python -m mypy core/` ✓ (clean, 338 files)
- Frontend `npm run build` + `npm run lint` + `vitest` ✓ (22 passed)
- `tools/evolution_report.py --probe` exercised end-to-end (it auto-surfaced the known ball-pursuit/starvation issue).

The live-attach HTTP path uses the confirmed REST endpoints with tolerant parsing (unit-tested against the real payload shapes); a server was not booted in-session to exercise it live.

## Notes / optional follow-ups

- `scripts/diagnose_evolution.py` still has its own copy of the trait logic; left untouched to limit risk, but it could adopt the shared helper.
- `--watch` is client-side polling, not a server-managed daemon.

https://claude.ai/code/session_015iAkrkkwth8raznn99wS3u

---
_Generated by [Claude Code](https://claude.ai/code/session_015iAkrkkwth8raznn99wS3u)_