### PR TITLE
[codex] Smooth tank simulation rendering

### DIFF
--- a/backend/runner/state_publisher.py
+++ b/backend/runner/state_publisher.py
@@ -17,7 +17,7 @@ class StatePublisher:
     def __init__(
         self,
         perf_tracker: PerfTracker,
-        websocket_update_interval: int = 2,
+        websocket_update_interval: int = 1,
         delta_sync_interval: int = 90,
     ):
         self.perf_tracker = perf_tracker
@@ -101,7 +101,12 @@ class StatePublisher:
         state: FullStatePayload | DeltaStatePayload
         if is_full_update:
             state = self._build_full_state(
-                runner, current_frame, elapsed_time, stats, entity_snapshots
+                runner,
+                current_frame,
+                elapsed_time,
+                stats,
+                entity_snapshots,
+                include_metrics_history=force_full or not allow_delta,
             )
             self._last_full_frame = current_frame
             self._last_entities = {e.id: e for e in entity_snapshots}
@@ -139,7 +144,13 @@ class StatePublisher:
         return serialized
 
     def _build_full_state(
-        self, runner: Any, frame: int, elapsed_time: Any, stats: Any, entities: list[EntitySnapshot]
+        self,
+        runner: Any,
+        frame: int,
+        elapsed_time: Any,
+        stats: Any,
+        entities: list[EntitySnapshot],
+        include_metrics_history: bool = True,
     ) -> FullStatePayload:
         """Construct a FullStatePayload."""
 
@@ -162,7 +173,11 @@ class StatePublisher:
 
         # Build metrics history payload if available
         metrics_history_payload = None
-        if hasattr(runner, "metrics_history") and runner.metrics_history is not None:
+        if (
+            include_metrics_history
+            and hasattr(runner, "metrics_history")
+            and runner.metrics_history is not None
+        ):
             from backend.state_payloads import (
                 MetricsHistoryPayload,
                 MetricsPokerSamplePayload,

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -109,7 +109,7 @@ class SimulationRunner(CommandHandlerMixin):
 
         # State publishing
         self.state_publisher = StatePublisher(
-            perf_tracker=self.perf_tracker, websocket_update_interval=2, delta_sync_interval=90
+            perf_tracker=self.perf_tracker, websocket_update_interval=1, delta_sync_interval=90
         )
 
         # Initialize world-specific hooks and features

--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -7,8 +7,6 @@ import type { SimulationUpdate } from '../types/simulation';
 import type { Renderer, ViewMode } from '../rendering/types';
 import { rendererRegistry } from '../rendering/registry';
 import { initRenderers } from '../renderers/init';
-import { clearAllPlantCaches, getPlantCacheSizes } from '../utils/plant';
-import { clearAvatarPathCache, getAvatarPathCacheSize } from '../renderers/avatar_renderer';
 import { ImageLoader } from '../utils/ImageLoader';
 
 interface CanvasProps {
@@ -201,47 +199,17 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
     }, [width, height, setErrorOnce, error, viewMode]); // Stable dependencies only
 
 
-    // Periodic memory cleanup to prevent unbounded memory growth during long viewing sessions.
-    // This clears plant texture caches and path caches every 10 seconds.
-    // Caches will be regenerated on demand - plants may briefly flicker but memory stays bounded.
+    // React dev-mode profiling can accumulate performance entries during long sessions.
+    // Render caches are pruned by the renderers and should stay warm between frames.
     useEffect(() => {
-        const CLEANUP_INTERVAL_MS = 10_000; // 10 seconds (more aggressive)
+        const CLEANUP_INTERVAL_MS = 30_000;
 
         const interval = setInterval(() => {
             try {
-                // Log diagnostics in dev mode before cleanup
-                if (import.meta.env.DEV) {
-                    const plantSizes = getPlantCacheSizes();
-                    const avatarSize = getAvatarPathCacheSize();
-                    const imageLoaderSizes = ImageLoader.getCacheSizes();
-                    console.debug('[Memory Diagnostics] Before cleanup:', {
-                        plantCaches: plantSizes,
-                        avatarPathCache: avatarSize,
-                        imageLoader: imageLoaderSizes,
-                    });
-                }
-
-                // Clear all plant texture and geometry caches
-                clearAllPlantCaches();
-
-                // Clear the avatar renderer's path cache
-                clearAvatarPathCache();
-
-                // Clear the renderer's path cache
-                rendererRef.current?.clearPathCache?.();
-
-                // Clear browser performance entries to prevent React dev-mode profiling
-                // from accumulating unbounded PerformanceMeasure/PerformanceMark objects.
-                // In production React doesn't create these, but dev mode does.
                 if (typeof performance !== 'undefined') {
                     performance.clearMeasures?.();
                     performance.clearMarks?.();
-                    // Also clear resource timing entries if available
                     performance.clearResourceTimings?.();
-                }
-
-                if (import.meta.env.DEV) {
-                    console.debug('[Memory Cleanup] Cleared all caches and performance entries');
                 }
             } catch {
                 // Ignore cleanup errors

--- a/frontend/src/hooks/useWebSocket.test.ts
+++ b/frontend/src/hooks/useWebSocket.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { SimulationUpdate, StatsData } from '../types/simulation';
+import { applyFullUpdate } from './useWebSocket';
 
 /**
  * Pure function to normalize a WorldUpdatePayload into SimulationUpdate format.
@@ -135,6 +136,52 @@ describe('WebSocket Update Normalization', () => {
         expect(result.elapsed_time).toBe(3.14);
         expect(result.entities).toHaveLength(1);
         expect(result.entities![0].id).toBe(1);
+    });
+
+    it('preserves metrics history when a periodic full update omits it', () => {
+        const history = {
+            schema_version: 2,
+            world_id: 'test-world',
+            sample_interval_frames: 500,
+            max_samples: 2000,
+            samples: [],
+        };
+        const current = normalizeWorldUpdate({
+            type: 'update',
+            schema_version: 1,
+            world_id: 'test-world',
+            snapshot: {
+                frame: 1,
+                elapsed_time: 0,
+                entities: [],
+                stats: {} as StatsData,
+                poker_events: [],
+                soccer_events: [],
+                soccer_league_live: null,
+                poker_leaderboard: [],
+                metrics_history: history,
+            },
+        });
+        const periodic = {
+            type: 'update',
+            schema_version: 1,
+            world_id: 'test-world',
+            snapshot: {
+                frame: 91,
+                elapsed_time: 3,
+                entities: [],
+                stats: {} as StatsData,
+                poker_events: [],
+                soccer_events: [],
+                soccer_league_live: null,
+                poker_leaderboard: [],
+            },
+        } as SimulationUpdate;
+
+        const result = applyFullUpdate(current, periodic);
+
+        expect(result.snapshot.metrics_history).toBe(history);
+        expect(result.metrics_history).toBe(history);
     });
 
 });

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -3,7 +3,7 @@
  */
 
 import { useEffect, useRef, useState, useCallback } from 'react';
-import type { SimulationUpdate, Command, CommandResponse, DeltaUpdate, EntityData } from '../types/simulation';
+import type { SimulationUpdate, Command, CommandResponse, DeltaUpdate } from '../types/simulation';
 import { config, EXPECTED_SCHEMA_VERSION } from '../config';
 
 // Reuse a single TextDecoder to avoid GC pressure from allocating one per frame.
@@ -18,6 +18,7 @@ export function useWebSocket(worldId?: string) {
     const wsRef = useRef<WebSocket | null>(null);
     const reconnectTimeoutRef = useRef<number | null>(null);
     const connectRef = useRef<(() => void) | null>(null);
+    const connectAttemptRef = useRef(0);
     const schemaMismatchRef = useRef(false);
     const responseCallbacksRef = useRef<Map<string, (data: CommandResponse) => void>>(new Map());
     const unmountedRef = useRef(false);  // Track if component is unmounted
@@ -44,6 +45,7 @@ export function useWebSocket(worldId?: string) {
     const connect = useCallback(async () => {
         // Don't connect if component is unmounted
         if (unmountedRef.current || schemaMismatchRef.current) return;
+        const connectAttempt = ++connectAttemptRef.current;
 
         // Close any existing connection before creating a new one
         if (wsRef.current) {
@@ -78,6 +80,12 @@ export function useWebSocket(worldId?: string) {
                 }
             }
 
+            // Strict Mode can restart this effect while the default-world
+            // request is in flight. Do not let that stale attempt open a socket.
+            if (unmountedRef.current || connectAttempt !== connectAttemptRef.current) {
+                return;
+            }
+
             // Store the resolved world ID so components can use it immediately
             if (resolvedWorldId) {
                 setConnectedWorldId(resolvedWorldId);
@@ -92,10 +100,15 @@ export function useWebSocket(worldId?: string) {
             ws.binaryType = 'arraybuffer';
 
             ws.onopen = () => {
+                if (connectAttempt !== connectAttemptRef.current) {
+                    ws.close();
+                    return;
+                }
                 setIsConnected(true);
             };
 
             ws.onmessage = (event) => {
+                if (connectAttempt !== connectAttemptRef.current) return;
                 try {
                     // Handle binary data (ArrayBuffer) from orjson
                     let jsonString: string;
@@ -114,36 +127,7 @@ export function useWebSocket(worldId?: string) {
                     }
 
                     if (data.type === 'update') {
-                        console.log('FULL UPDATE RECEIVED!');  // DEBUG
-                        const update = data as SimulationUpdate;
-                        // DEBUG: Check if any entities have soccer_effect_state
-                        const fishWithSoccer = update.snapshot?.entities?.filter(
-                            (e: EntityData) => e.soccer_effect_state
-                        );
-                        if (fishWithSoccer && fishWithSoccer.length > 0) {
-                            console.log(
-                                'FULL UPDATE - Fish with soccer_effect_state:',
-                                fishWithSoccer.map((e: EntityData) => ({
-                                    id: e.id,
-                                    state: e.soccer_effect_state
-                                }))
-                            );
-                        }
-                        // V1 schema: Populate convenience fields from snapshot for component access
-                        update.frame = update.snapshot.frame;
-                        update.elapsed_time = update.snapshot.elapsed_time;
-                        update.entities = update.snapshot.entities;
-                        update.stats = update.snapshot.stats;
-                        update.poker_events = update.snapshot.poker_events;
-                        update.soccer_events = update.snapshot.soccer_events;
-                        update.soccer_league_live = update.snapshot.soccer_league_live;
-                        update.poker_leaderboard = update.snapshot.poker_leaderboard;
-                        update.auto_evaluation = update.snapshot.auto_evaluation;
-                        update.metrics_history = update.snapshot.metrics_history;
-                        // Preserve mode fields from server
-                        update.view_mode = update.view_mode ?? 'side';
-                        update.mode_id = update.mode_id ?? 'tank';
-                        setState(update);
+                        setState((current) => applyFullUpdate(current, data as SimulationUpdate));
                     } else if (data.type === 'delta') {
                         setState((current) => (current ? applyDelta(current, data as DeltaUpdate) : current));
                     } else if (data.success !== undefined || data.state !== undefined || data.error !== undefined) {
@@ -162,6 +146,7 @@ export function useWebSocket(worldId?: string) {
             };
 
             ws.onclose = () => {
+                if (connectAttempt !== connectAttemptRef.current) return;
                 setIsConnected(false);
                 wsRef.current = null;
 
@@ -197,6 +182,7 @@ export function useWebSocket(worldId?: string) {
         return () => {
             // Mark as unmounted to prevent reconnection
             unmountedRef.current = true;
+            connectAttemptRef.current += 1;
 
             // Cleanup on unmount
             if (reconnectTimeoutRef.current) {
@@ -256,6 +242,35 @@ export function useWebSocket(worldId?: string) {
         /** Connected world ID (available immediately after connection, before first update) */
         connectedWorldId,
     };
+}
+
+export function applyFullUpdate(
+    current: SimulationUpdate | null,
+    update: SimulationUpdate
+): SimulationUpdate {
+    // Deltas append new samples, so periodic recovery snapshots can omit the
+    // large history. Initial and explicit snapshots still include it.
+    if (
+        update.snapshot.metrics_history === undefined
+        && current?.snapshot.metrics_history !== undefined
+    ) {
+        update.snapshot.metrics_history = current.snapshot.metrics_history;
+    }
+
+    // V1 schema: Populate convenience fields from snapshot for component access
+    update.frame = update.snapshot.frame;
+    update.elapsed_time = update.snapshot.elapsed_time;
+    update.entities = update.snapshot.entities;
+    update.stats = update.snapshot.stats;
+    update.poker_events = update.snapshot.poker_events;
+    update.soccer_events = update.snapshot.soccer_events;
+    update.soccer_league_live = update.snapshot.soccer_league_live;
+    update.poker_leaderboard = update.snapshot.poker_leaderboard;
+    update.auto_evaluation = update.snapshot.auto_evaluation;
+    update.metrics_history = update.snapshot.metrics_history;
+    update.view_mode = update.view_mode ?? 'side';
+    update.mode_id = update.mode_id ?? 'tank';
+    return update;
 }
 
 function applyDelta(state: SimulationUpdate, delta: DeltaUpdate): SimulationUpdate {

--- a/frontend/src/renderers/tank/TankSideRenderer.test.ts
+++ b/frontend/src/renderers/tank/TankSideRenderer.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TankSideRenderer } from './TankSideRenderer';
+
+const rendererMocks = vi.hoisted(() => ({
+    clear: vi.fn(),
+    dispose: vi.fn(),
+    pruneEntityFacingCache: vi.fn(),
+    prunePlantCaches: vi.fn(),
+    renderEntity: vi.fn(),
+}));
+
+vi.mock('../../utils/renderer', () => ({
+    Renderer: class {
+        clear = rendererMocks.clear;
+        dispose = rendererMocks.dispose;
+        pruneEntityFacingCache = rendererMocks.pruneEntityFacingCache;
+        prunePlantCaches = rendererMocks.prunePlantCaches;
+        renderEntity = rendererMocks.renderEntity;
+    },
+}));
+
+describe('TankSideRenderer', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('prunes caches once per entity snapshot instead of once per animation frame', () => {
+        const renderer = new TankSideRenderer();
+        const entities = [
+            { id: 1, type: 'fish', x: 10, y: 10, width: 20, height: 10 },
+            { id: 2, type: 'plant', x: 30, y: 30, width: 10, height: 20 },
+        ];
+        const frame = {
+            worldType: 'tank',
+            viewMode: 'side',
+            snapshot: {
+                snapshot: {
+                    entities,
+                    stats: {},
+                    elapsed_time: 0,
+                },
+            },
+        };
+        const ctx = {
+            restore: vi.fn(),
+            save: vi.fn(),
+            scale: vi.fn(),
+        };
+        const renderContext = {
+            canvas: { width: 1088, height: 612 },
+            ctx,
+            dpr: 1,
+            nowMs: 0,
+        };
+
+        renderer.render(frame as never, renderContext as never);
+        renderer.render(frame as never, renderContext as never);
+
+        expect(rendererMocks.pruneEntityFacingCache).toHaveBeenCalledTimes(1);
+        expect(rendererMocks.prunePlantCaches).toHaveBeenCalledTimes(1);
+
+        frame.snapshot.snapshot.entities = [...entities];
+        renderer.render(frame as never, renderContext as never);
+
+        expect(rendererMocks.pruneEntityFacingCache).toHaveBeenCalledTimes(2);
+        expect(rendererMocks.prunePlantCaches).toHaveBeenCalledTimes(2);
+    });
+
+    it('renders moving entities every frame while refreshing the plant layer at 15 Hz', () => {
+        const layerCtx = {
+            clearRect: vi.fn(),
+        };
+        vi.stubGlobal('document', {
+            createElement: vi.fn(() => ({
+                width: 0,
+                height: 0,
+                getContext: vi.fn(() => layerCtx),
+            })),
+        });
+
+        const renderer = new TankSideRenderer();
+        const entities = [
+            { id: 1, type: 'fish', x: 10, y: 10, width: 20, height: 10 },
+            { id: 2, type: 'plant', x: 30, y: 30, width: 10, height: 20 },
+        ];
+        const frame = {
+            worldType: 'tank',
+            viewMode: 'side',
+            snapshot: {
+                snapshot: {
+                    entities,
+                    stats: {},
+                    elapsed_time: 0,
+                },
+            },
+        };
+        const ctx = {
+            drawImage: vi.fn(),
+            restore: vi.fn(),
+            save: vi.fn(),
+            scale: vi.fn(),
+        };
+        const renderContext = {
+            canvas: { width: 1088, height: 612 },
+            ctx,
+            dpr: 1,
+            nowMs: 0,
+        };
+
+        renderer.render(frame as never, renderContext as never);
+        renderContext.nowMs = 16;
+        renderer.render(frame as never, renderContext as never);
+        renderContext.nowMs = 70;
+        renderer.render(frame as never, renderContext as never);
+
+        const renderedTypes = rendererMocks.renderEntity.mock.calls.map(([entity]) => entity.type);
+        expect(renderedTypes.filter(type => type === 'fish')).toHaveLength(3);
+        expect(renderedTypes.filter(type => type === 'plant')).toHaveLength(2);
+        expect(ctx.drawImage).toHaveBeenCalledTimes(3);
+    });
+});

--- a/frontend/src/renderers/tank/TankSideRenderer.ts
+++ b/frontend/src/renderers/tank/TankSideRenderer.ts
@@ -1,12 +1,21 @@
 
 import type { Renderer, RenderFrame, RenderContext } from '../../rendering/types';
+import { EntityPositionInterpolator } from '../../rendering/entityPositionInterpolator';
 import { Renderer as TankRenderer } from '../../utils/renderer';
 import type { EntityData, SimulationUpdate } from '../../types/simulation';
+
+const PLANT_LAYER_FRAME_MS = 1000 / 15;
 
 export class TankSideRenderer implements Renderer {
     id = "tank-side";
     private tankRenderer: TankRenderer | null = null;
+    private plantLayerRenderer: TankRenderer | null = null;
+    private plantLayerCanvas: HTMLCanvasElement | null = null;
+    private plantLayerCtx: CanvasRenderingContext2D | null = null;
+    private lastPlantLayerRenderMs = -Infinity;
     private currentCtx: CanvasRenderingContext2D | null = null;
+    private lastPrunedEntities: EntityData[] | null = null;
+    private positionInterpolator = new EntityPositionInterpolator();
 
     // Tank world dimensions (from core/constants.py & Canvas.tsx)
     private readonly WORLD_WIDTH = 1088;
@@ -17,7 +26,20 @@ export class TankSideRenderer implements Renderer {
             this.tankRenderer.dispose();
             this.tankRenderer = null;
         }
+        if (this.plantLayerRenderer) {
+            this.plantLayerRenderer.dispose();
+            this.plantLayerRenderer = null;
+        }
+        if (this.plantLayerCanvas) {
+            this.plantLayerCanvas.width = 0;
+            this.plantLayerCanvas.height = 0;
+            this.plantLayerCanvas = null;
+        }
+        this.plantLayerCtx = null;
+        this.lastPlantLayerRenderMs = -Infinity;
         this.currentCtx = null;
+        this.lastPrunedEntities = null;
+        this.positionInterpolator.reset();
     }
 
     render(frame: RenderFrame, rc: RenderContext) {
@@ -44,28 +66,40 @@ export class TankSideRenderer implements Renderer {
         }
 
         const r = this.tankRenderer;
+        const renderedEntities = this.positionInterpolator.interpolate(entities, rc.nowMs);
+        const plantLayer = this.updatePlantLayer(
+            renderedEntities,
+            elapsedTime,
+            frame.options?.showEffects ?? true,
+            rc.nowMs
+        );
 
         // Calculate scale to fit world in canvas
         // This logic matches Canvas.tsx
         const scaleX = canvas.width / this.WORLD_WIDTH;
         const scaleY = canvas.height / this.WORLD_HEIGHT;
 
-        // Collect active poker effect IDs for cleanup
-        // Matches Canvas.tsx logic
-        const pokerActiveIds = new Set<number>();
-        entities.forEach((e: EntityData) => {
-            if (e.poker_effect_state && (e.poker_effect_state.status === 'lost' || e.poker_effect_state.status === 'won')) {
-                pokerActiveIds.add(e.id);
-            }
-        });
+        // Cache maintenance only needs to run when a new entity snapshot arrives,
+        // not on every requestAnimationFrame that redraws the same snapshot.
+        if (entities !== this.lastPrunedEntities) {
+            const activeEntityIds = new Set<number>();
+            const activePlantIds = new Set<number>();
+            const pokerActiveIds = new Set<number>();
 
-        // Prune caches
-        r.pruneEntityFacingCache(entities.map((e: EntityData) => e.id), pokerActiveIds);
-        r.prunePlantCaches(
-            entities
-                .filter((e: EntityData) => e.type === 'plant')
-                .map((e: EntityData) => e.id)
-        );
+            entities.forEach((e: EntityData) => {
+                activeEntityIds.add(e.id);
+                if (e.type === 'plant') {
+                    activePlantIds.add(e.id);
+                }
+                if (e.poker_effect_state && (e.poker_effect_state.status === 'lost' || e.poker_effect_state.status === 'won')) {
+                    pokerActiveIds.add(e.id);
+                }
+            });
+
+            r.pruneEntityFacingCache(activeEntityIds, pokerActiveIds);
+            r.prunePlantCaches(activePlantIds);
+            this.lastPrunedEntities = entities;
+        }
 
         ctx.save();
         try {
@@ -77,14 +111,63 @@ export class TankSideRenderer implements Renderer {
             r.clear(this.WORLD_WIDTH, this.WORLD_HEIGHT, stats?.time, showEffects);
 
             // Render entities
-            entities.forEach((entity: EntityData) => {
-                r.renderEntity(entity, elapsedTime, entities, showEffects);
+            let plantLayerDrawn = false;
+            renderedEntities.forEach((entity: EntityData) => {
+                if (entity.type === 'plant' && plantLayer) {
+                    if (!plantLayerDrawn) {
+                        ctx.drawImage(plantLayer, 0, 0, this.WORLD_WIDTH, this.WORLD_HEIGHT);
+                        plantLayerDrawn = true;
+                    }
+                    return;
+                }
+                r.renderEntity(entity, elapsedTime, renderedEntities, showEffects);
                 this.drawSoccerEffect(ctx, entity);
             });
 
         } finally {
             ctx.restore();
         }
+    }
+
+    private updatePlantLayer(
+        entities: EntityData[],
+        elapsedTime: number,
+        showEffects: boolean,
+        nowMs: number
+    ): HTMLCanvasElement | null {
+        if (typeof document === 'undefined') return null;
+
+        if (!this.plantLayerCanvas) {
+            const canvas = document.createElement('canvas');
+            canvas.width = this.WORLD_WIDTH;
+            canvas.height = this.WORLD_HEIGHT;
+            const ctx = canvas.getContext('2d');
+            if (!ctx) return null;
+            this.plantLayerCanvas = canvas;
+            this.plantLayerCtx = ctx;
+            this.plantLayerRenderer = new TankRenderer(ctx);
+        }
+
+        if (
+            this.plantLayerCtx
+            && this.plantLayerRenderer
+            && nowMs - this.lastPlantLayerRenderMs >= PLANT_LAYER_FRAME_MS
+        ) {
+            this.plantLayerCtx.clearRect(0, 0, this.WORLD_WIDTH, this.WORLD_HEIGHT);
+            for (const entity of entities) {
+                if (entity.type === 'plant') {
+                    this.plantLayerRenderer.renderEntity(
+                        entity,
+                        elapsedTime,
+                        entities,
+                        showEffects
+                    );
+                }
+            }
+            this.lastPlantLayerRenderMs = nowMs;
+        }
+
+        return this.plantLayerCanvas;
     }
 
     private drawSoccerEffect(ctx: CanvasRenderingContext2D, entity: EntityData) {

--- a/frontend/src/rendering/entityPositionInterpolator.test.ts
+++ b/frontend/src/rendering/entityPositionInterpolator.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { EntityData } from '../types/simulation';
+import { EntityPositionInterpolator } from './entityPositionInterpolator';
+
+function fish(id: number, x: number, y: number, velX = 0, velY = 0): EntityData {
+    return {
+        id,
+        type: 'fish',
+        x,
+        y,
+        width: 20,
+        height: 10,
+        vel_x: velX,
+        vel_y: velY,
+    };
+}
+
+describe('EntityPositionInterpolator', () => {
+    it('continues movement from velocity between server snapshots without mutating source entities', () => {
+        const interpolator = new EntityPositionInterpolator();
+        const snapshot = [fish(1, 10, 20, 2, -1)];
+
+        expect(interpolator.interpolate(snapshot, 0)[0]).toBe(snapshot[0]);
+        const predicted = interpolator.interpolate(snapshot, 50)[0];
+        expect(predicted.x).toBe(13);
+        expect(predicted.y).toBe(18.5);
+        expect(snapshot[0].x).toBe(10);
+        expect(snapshot[0].y).toBe(20);
+    });
+
+    it('blends small snapshot corrections without jumping', () => {
+        const interpolator = new EntityPositionInterpolator();
+        const first = [fish(1, 0, 0, 1, 0)];
+        const corrected = [fish(1, 1, 0, 1, 0)];
+
+        interpolator.interpolate(first, 0);
+        expect(interpolator.interpolate(first, 50)[0].x).toBe(1.5);
+
+        expect(interpolator.interpolate(corrected, 50)[0].x).toBe(1.5);
+        expect(interpolator.interpolate(corrected, 100)[0].x).toBeCloseTo(2.75);
+    });
+
+    it('snaps new entities and teleports immediately before resuming movement', () => {
+        const interpolator = new EntityPositionInterpolator();
+        const first = [fish(1, 0, 0, 1, 0)];
+        const teleported = [fish(1, 200, 0, 1, 0), fish(2, 20, 20)];
+
+        interpolator.interpolate(first, 0);
+        const rendered = interpolator.interpolate(teleported, 60);
+
+        expect(rendered).toBe(teleported);
+        expect(interpolator.interpolate(teleported, 110)[0].x).toBe(201.5);
+    });
+
+    it('drops tracks for removed entities', () => {
+        const interpolator = new EntityPositionInterpolator();
+        interpolator.interpolate([fish(1, 0, 0), fish(2, 10, 0)], 0);
+        interpolator.interpolate([fish(1, 10, 0)], 60);
+
+        const readded = [fish(1, 20, 0), fish(2, 100, 0)];
+        const rendered = interpolator.interpolate(readded, 120);
+
+        expect(rendered[1]).toBe(readded[1]);
+    });
+});

--- a/frontend/src/rendering/entityPositionInterpolator.ts
+++ b/frontend/src/rendering/entityPositionInterpolator.ts
@@ -1,0 +1,98 @@
+import type { EntityData } from '../types/simulation';
+
+const SIMULATION_FRAME_MS = 1000 / 30;
+const CORRECTION_DURATION_MS = 100;
+const MAX_EXTRAPOLATION_MS = 200;
+const MAX_INTERPOLATION_DISTANCE = 96;
+
+interface PositionTrack {
+    x: number;
+    y: number;
+    velX: number;
+    velY: number;
+    acceptedAtMs: number;
+    correctionX: number;
+    correctionY: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(max, value));
+}
+
+function sampleTrack(track: PositionTrack, nowMs: number): { x: number; y: number } {
+    const elapsedMs = clamp(nowMs - track.acceptedAtMs, 0, MAX_EXTRAPOLATION_MS);
+    const elapsedFrames = elapsedMs / SIMULATION_FRAME_MS;
+    const correctionScale = 1 - clamp(elapsedMs / CORRECTION_DURATION_MS, 0, 1);
+    return {
+        x: track.x + track.velX * elapsedFrames + track.correctionX * correctionScale,
+        y: track.y + track.velY * elapsedFrames + track.correctionY * correctionScale,
+    };
+}
+
+/**
+ * Smooths display positions between lower-frequency server snapshots using
+ * short-horizon dead reckoning and correction blending.
+ * Source entities remain untouched and authoritative.
+ */
+export class EntityPositionInterpolator {
+    private tracks = new Map<number, PositionTrack>();
+    private lastEntities: EntityData[] | null = null;
+
+    reset(): void {
+        this.tracks.clear();
+        this.lastEntities = null;
+    }
+
+    interpolate(entities: EntityData[], nowMs: number): EntityData[] {
+        if (entities !== this.lastEntities) {
+            this.acceptSnapshot(entities, nowMs);
+        }
+
+        let hasInterpolatedPosition = false;
+        const renderedEntities = entities.map((entity) => {
+            const track = this.tracks.get(entity.id);
+            if (!track) return entity;
+
+            const position = sampleTrack(track, nowMs);
+            if (position.x === entity.x && position.y === entity.y) {
+                return entity;
+            }
+
+            hasInterpolatedPosition = true;
+            return { ...entity, x: position.x, y: position.y };
+        });
+
+        return hasInterpolatedPosition ? renderedEntities : entities;
+    }
+
+    private acceptSnapshot(entities: EntityData[], nowMs: number): void {
+        const nextTracks = new Map<number, PositionTrack>();
+
+        for (const entity of entities) {
+            const previousTrack = this.tracks.get(entity.id);
+            const previousPosition = previousTrack
+                ? sampleTrack(previousTrack, nowMs)
+                : { x: entity.x, y: entity.y };
+            const correctionX = previousPosition.x - entity.x;
+            const correctionY = previousPosition.y - entity.y;
+            const shouldSnap = (
+                !previousTrack
+                || (correctionX * correctionX + correctionY * correctionY)
+                    > MAX_INTERPOLATION_DISTANCE * MAX_INTERPOLATION_DISTANCE
+            );
+
+            nextTracks.set(entity.id, {
+                x: entity.x,
+                y: entity.y,
+                velX: entity.vel_x ?? 0,
+                velY: entity.vel_y ?? 0,
+                acceptedAtMs: nowMs,
+                correctionX: shouldSnap ? 0 : correctionX,
+                correctionY: shouldSnap ? 0 : correctionY,
+            });
+        }
+
+        this.tracks = nextTracks;
+        this.lastEntities = entities;
+    }
+}

--- a/frontend/src/utils/cleanup.test.ts
+++ b/frontend/src/utils/cleanup.test.ts
@@ -1,7 +1,13 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { clearAvatarPathCache, getAvatarPathCacheSize, drawAvatar } from '../renderers/avatar_renderer';
-import { clearAllPlantCaches, getPlantCacheSizes, renderPlant, type PlantGenomeData } from './plant';
+import {
+    clearAllPlantCaches,
+    getPlantCacheSizes,
+    renderPlant,
+    renderPlantNectar,
+    type PlantGenomeData,
+} from './plant';
 
 // Mock browser APIs
 const mockContext = {
@@ -54,6 +60,9 @@ class MockCanvas {
 class MockPath2D {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     constructor(_path?: string | Path2D) { }
+    moveTo() { }
+    lineTo() { }
+    ellipse() { }
 }
 
 describe('Memory Cleanup Utilities', () => {
@@ -153,6 +162,26 @@ describe('Memory Cleanup Utilities', () => {
 
             const finalSizes = getPlantCacheSizes();
             expect(finalSizes.plantCache).toBe(0);
+        });
+
+        it('should batch cached plant geometry into a small number of draw calls', () => {
+            renderPlant(mockContext, 123, mockGenome, 0, 0, 1, 2, 0);
+            vi.clearAllMocks();
+
+            renderPlant(mockContext, 123, mockGenome, 0, 0, 1, 2, 16);
+
+            expect(mockContext.stroke).toHaveBeenCalledTimes(10);
+            expect(mockContext.fill).toHaveBeenCalledTimes(1);
+        });
+
+        it('should reuse cached spiral nectar paths', () => {
+            renderPlantNectar(mockContext, 20, 20, 10, 10, 0);
+            vi.clearAllMocks();
+
+            renderPlantNectar(mockContext, 20, 20, 10, 10, 16);
+
+            expect(mockContext.lineTo).not.toHaveBeenCalled();
+            expect(getPlantCacheSizes().spiralFlowerPathCache).toBe(1);
         });
     });
 });

--- a/frontend/src/utils/plant.ts
+++ b/frontend/src/utils/plant.ts
@@ -74,6 +74,9 @@ interface PlantRenderCache {
     segments: FractalSegment[];
     leaves: FractalLeaf[];
     sortedSegments: FractalSegment[];
+    segmentGroups?: Array<{ thickness: number; segments: FractalSegment[]; path?: Path2D }>;
+    leafPath?: Path2D;
+    veinPath?: Path2D;
 }
 
 // Module-level cache keyed by plant id to avoid flickering when plants drift
@@ -84,6 +87,7 @@ const antigravityCache = new Map<number, MandelbrotCacheEntry>();
 const gptCache = new Map<number, MandelbrotCacheEntry>();
 const sonnetCache = new Map<number, PlantRenderCache>();
 const gptCodexCache = new Map<number, PlantRenderCache>();
+const spiralFlowerPathCache = new Map<string, Path2D[]>();
 
 /**
  * Remove cached plant geometry/texture entries for plants that no longer exist.
@@ -143,6 +147,7 @@ export function getPlantCacheSizes(): Record<string, number> {
         gptCache: gptCache.size,
         sonnetCache: sonnetCache.size,
         gptCodexCache: gptCodexCache.size,
+        spiralFlowerPathCache: spiralFlowerPathCache.size,
     };
 }
 
@@ -183,6 +188,7 @@ export function clearAllPlantCaches(): void {
         }
         cache.clear();
     }
+    spiralFlowerPathCache.clear();
 }
 
 /**
@@ -208,6 +214,67 @@ function getGenomeSignature(genome: PlantGenomeData): string {
         genome.leaf_density,
         ruleSignature,
     ].join(';');
+}
+
+function groupSegmentsByThickness(
+    segments: FractalSegment[]
+): Array<{ thickness: number; segments: FractalSegment[]; path?: Path2D }> {
+    const groups = new Map<number, FractalSegment[]>();
+    for (const segment of segments) {
+        const group = groups.get(segment.thickness);
+        if (group) {
+            group.push(segment);
+        } else {
+            groups.set(segment.thickness, [segment]);
+        }
+    }
+    return Array.from(groups, ([thickness, groupedSegments]) => {
+        const path = createSegmentPath(groupedSegments);
+        return { thickness, segments: groupedSegments, ...(path ? { path } : {}) };
+    });
+}
+
+function appendSegments(ctx: CanvasRenderingContext2D, segments: FractalSegment[]): void {
+    for (const segment of segments) {
+        ctx.moveTo(segment.x1, segment.y1);
+        ctx.lineTo(segment.x2, segment.y2);
+    }
+}
+
+function createSegmentPath(segments: FractalSegment[]): Path2D | undefined {
+    if (typeof Path2D === 'undefined') return undefined;
+    const path = new Path2D();
+    for (const segment of segments) {
+        path.moveTo(segment.x1, segment.y1);
+        path.lineTo(segment.x2, segment.y2);
+    }
+    return path;
+}
+
+function createLeafPaths(leaves: FractalLeaf[]): { leafPath?: Path2D; veinPath?: Path2D } {
+    if (typeof Path2D === 'undefined') return {};
+    const leafPath = new Path2D();
+    const veinPath = new Path2D();
+    for (const leaf of leaves) {
+        const rotation = (leaf.angle * Math.PI) / 180 + Math.PI / 2;
+        const centerX = leaf.x + Math.sin(rotation) * leaf.size / 2;
+        const centerY = leaf.y - Math.cos(rotation) * leaf.size / 2;
+        leafPath.ellipse(
+            centerX,
+            centerY,
+            leaf.size * 0.4,
+            leaf.size,
+            rotation,
+            0,
+            Math.PI * 2
+        );
+        veinPath.moveTo(leaf.x, leaf.y);
+        veinPath.lineTo(
+            leaf.x + Math.sin(rotation) * leaf.size,
+            leaf.y - Math.cos(rotation) * leaf.size
+        );
+    }
+    return { leafPath, veinPath };
 }
 
 /**
@@ -1032,6 +1099,9 @@ export function renderPlant(
     let segments: FractalSegment[];
     let leaves: FractalLeaf[];
     let sortedSegments: FractalSegment[];
+    let segmentGroups: Array<{ thickness: number; segments: FractalSegment[]; path?: Path2D }>;
+    let leafPath: Path2D | undefined;
+    let veinPath: Path2D | undefined;
 
     // Only regenerate geometry when iterations change (size is handled by scaling)
     const needsRegeneration = !cached || cached.signature !== genomeSignature;
@@ -1066,6 +1136,8 @@ export function renderPlant(
         segments = result.segments;
         leaves = result.leaves;
         sortedSegments = [...segments].sort((a, b) => a.depth - b.depth);
+        segmentGroups = groupSegmentsByThickness(sortedSegments);
+        ({ leafPath, veinPath } = createLeafPaths(leaves));
 
         plantCache.set(cacheKey, {
             iterations,
@@ -1073,11 +1145,17 @@ export function renderPlant(
             segments,
             leaves,
             sortedSegments,
+            segmentGroups,
+            leafPath,
+            veinPath,
         });
     } else {
         segments = cached!.segments;
         leaves = cached!.leaves;
         sortedSegments = cached!.sortedSegments;
+        segmentGroups = cached!.segmentGroups ?? groupSegmentsByThickness(sortedSegments);
+        leafPath = cached!.leafPath;
+        veinPath = cached!.veinPath;
     }
 
     // Apply organic multi-frequency swaying similar to raster plant sprites
@@ -1137,59 +1215,84 @@ export function renderPlant(
     ctx.globalAlpha = 0.15;
     ctx.translate(3, 3);
 
-    for (const seg of segments) {
-        ctx.beginPath();
-        ctx.moveTo(seg.x1, seg.y1);
-        ctx.lineTo(seg.x2, seg.y2);
+    for (const group of segmentGroups) {
         ctx.strokeStyle = '#000';
-        ctx.lineWidth = seg.thickness + 1;
+        ctx.lineWidth = group.thickness + 1;
         ctx.lineCap = 'round';
-        ctx.stroke();
+        if (group.path) {
+            ctx.stroke(group.path);
+        } else {
+            ctx.beginPath();
+            appendSegments(ctx, group.segments);
+            ctx.stroke();
+        }
     }
     ctx.restore();
 
     // Draw stem segments (back to front by depth)
-    for (const seg of sortedSegments) {
+    for (const group of segmentGroups) {
         // Main stem stroke
-        ctx.beginPath();
-        ctx.moveTo(seg.x1, seg.y1);
-        ctx.lineTo(seg.x2, seg.y2);
         ctx.strokeStyle = stemColor;
-        ctx.lineWidth = seg.thickness;
+        ctx.lineWidth = group.thickness;
         ctx.lineCap = 'round';
-        ctx.stroke();
+        if (group.path) {
+            ctx.stroke(group.path);
+        } else {
+            ctx.beginPath();
+            appendSegments(ctx, group.segments);
+            ctx.stroke();
+        }
 
         // Highlight stroke
-        ctx.beginPath();
-        ctx.moveTo(seg.x1, seg.y1);
-        ctx.lineTo(seg.x2, seg.y2);
         ctx.strokeStyle = highlightColor;
-        ctx.lineWidth = seg.thickness * 0.4;
+        ctx.lineWidth = group.thickness * 0.4;
         ctx.lineCap = 'round';
-        ctx.stroke();
+        if (group.path) {
+            ctx.stroke(group.path);
+        } else {
+            ctx.beginPath();
+            appendSegments(ctx, group.segments);
+            ctx.stroke();
+        }
     }
 
-    // Draw leaves
-    for (const leaf of leaves) {
-        ctx.save();
-        ctx.translate(leaf.x, leaf.y);
-        ctx.rotate((leaf.angle * Math.PI) / 180 + Math.PI / 2);
-
-        // Leaf shape (ellipse)
+    // Draw leaves and veins in consolidated paths.
+    ctx.fillStyle = leafColor;
+    if (leafPath) {
+        ctx.fill(leafPath);
+    } else {
         ctx.beginPath();
-        ctx.ellipse(0, -leaf.size / 2, leaf.size * 0.4, leaf.size, 0, 0, Math.PI * 2);
-        ctx.fillStyle = leafColor;
+        for (const leaf of leaves) {
+            const rotation = (leaf.angle * Math.PI) / 180 + Math.PI / 2;
+            const centerX = leaf.x + Math.sin(rotation) * leaf.size / 2;
+            const centerY = leaf.y - Math.cos(rotation) * leaf.size / 2;
+            ctx.ellipse(
+                centerX,
+                centerY,
+                leaf.size * 0.4,
+                leaf.size,
+                rotation,
+                0,
+                Math.PI * 2
+            );
+        }
         ctx.fill();
-
-        // Leaf vein
+    }
+    ctx.strokeStyle = highlightColor;
+    ctx.lineWidth = 0.5;
+    if (veinPath) {
+        ctx.stroke(veinPath);
+    } else {
         ctx.beginPath();
-        ctx.moveTo(0, 0);
-        ctx.lineTo(0, -leaf.size);
-        ctx.strokeStyle = highlightColor;
-        ctx.lineWidth = 0.5;
+        for (const leaf of leaves) {
+            const rotation = (leaf.angle * Math.PI) / 180 + Math.PI / 2;
+            ctx.moveTo(leaf.x, leaf.y);
+            ctx.lineTo(
+                leaf.x + Math.sin(rotation) * leaf.size,
+                leaf.y - Math.cos(rotation) * leaf.size
+            );
+        }
         ctx.stroke();
-
-        ctx.restore();
     }
 
     // Draw nectar glow if ready
@@ -2619,30 +2722,64 @@ function drawSpiralFractal(
 ): void {
     const rotation = elapsedTime * 0.001 * spin;
     const numArms = Math.max(2, arms);
+    const pathKey = `${numArms}:${layers}`;
+    let armPaths = spiralFlowerPathCache.get(pathKey);
+
+    if (!armPaths && typeof Path2D !== 'undefined') {
+        armPaths = [];
+        for (let arm = 0; arm < numArms; arm++) {
+            const armAngle = (arm / numArms) * Math.PI * 2;
+            const path = new Path2D();
+            for (let t = 0; t < layers * 2; t += 0.05) {
+                const angle = armAngle + t * 1.5;
+                const r = 0.1 * t;
+                const px = Math.cos(angle) * r;
+                const py = Math.sin(angle) * r;
+                if (t === 0) path.moveTo(px, py);
+                else path.lineTo(px, py);
+            }
+            armPaths.push(path);
+        }
+        if (spiralFlowerPathCache.size >= 100) {
+            spiralFlowerPathCache.clear();
+        }
+        spiralFlowerPathCache.set(pathKey, armPaths);
+    }
 
     // Draw spiral arms
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate(rotation);
+    ctx.scale(size, size);
     for (let arm = 0; arm < numArms; arm++) {
         const armAngle = (arm / numArms) * Math.PI * 2;
 
-        ctx.beginPath();
-        for (let t = 0; t < layers * 2; t += 0.05) {
-            const angle = armAngle + t * 1.5 + rotation;
-            const r = size * 0.1 * t;
-            const px = x + Math.cos(angle) * r;
-            const py = y + Math.sin(angle) * r;
+        if (!armPaths) {
+            ctx.beginPath();
+            for (let t = 0; t < layers * 2; t += 0.05) {
+                const angle = armAngle + t * 1.5;
+                const r = 0.1 * t;
+                const px = Math.cos(angle) * r;
+                const py = Math.sin(angle) * r;
 
-            if (t === 0) ctx.moveTo(px, py);
-            else ctx.lineTo(px, py);
+                if (t === 0) ctx.moveTo(px, py);
+                else ctx.lineTo(px, py);
+            }
         }
 
         // Rainbow shift along each arm
         const armHue = (hue + arm * 0.1) % 1;
         ctx.strokeStyle = hslToRgb(armHue, saturation, 0.5);
-        ctx.lineWidth = size * 0.06;
+        ctx.lineWidth = 0.06;
         ctx.lineCap = 'round';
         ctx.globalAlpha = 0.8;
-        ctx.stroke();
+        if (armPaths) {
+            ctx.stroke(armPaths[arm]);
+        } else {
+            ctx.stroke();
+        }
     }
+    ctx.restore();
 
     // Glowing center
     const centerGrad = ctx.createRadialGradient(x, y, 0, x, y, size * 0.15);

--- a/tests/test_simulation_runner_world_agnostic.py
+++ b/tests/test_simulation_runner_world_agnostic.py
@@ -49,6 +49,36 @@ class TestTankBackwardCompatibility:
         assert hasattr(state, "poker_events")
         assert hasattr(state, "poker_leaderboard")
 
+    def test_running_tank_publishes_each_requested_new_frame(self):
+        """The broadcaster already controls cadence, so publisher polls must not be halved."""
+        runner = SimulationRunner(world_type="tank", seed=42)
+        runner.running = True
+        try:
+            runner.world.step()
+            first = runner.get_state(force_full=True)
+
+            runner.world.step()
+            second = runner.get_state()
+
+            assert second.frame == first.frame + 1
+        finally:
+            runner.running = False
+
+    def test_periodic_full_state_omits_already_streamed_metrics_history(self):
+        """Recovery snapshots should not repeatedly resend the complete history."""
+        runner = SimulationRunner(world_type="tank", seed=42)
+        runner.metrics_history.sample_interval_frames = 1
+        runner.state_publisher.delta_sync_interval = 1
+
+        runner.world.step()
+        initial = runner.get_state(force_full=True)
+        assert initial.metrics_history is not None
+
+        runner.world.step()
+        periodic = runner.get_state(force_full=False, allow_delta=True)
+        assert periodic.type == "update"
+        assert periodic.metrics_history is None
+
     def test_tank_command_handling_backward_compatible(self):
         """Tank should still handle tank-specific commands."""
         runner = SimulationRunner(world_type="tank", seed=42)


### PR DESCRIPTION
## Summary

Improves tank simulation rendering smoothness by reducing transport spikes and steady-frame canvas work.

- fixes a React Strict Mode connection race that could leave duplicate WebSockets active
- publishes every requested new simulation frame instead of halving broadcaster cadence
- omits already-streamed metrics history from periodic recovery snapshots while preserving it client-side
- adds short-horizon entity position interpolation between server snapshots
- batches and caches expensive plant paths
- renders slow-swaying plants on a transparent 15 Hz layer while fish and moving entities remain full-rate
- removes periodic render-cache purges that caused cache rebuild spikes

## Root cause

Live profiling showed two main sources of visible freeze/resume behavior:

1. Duplicate WebSocket connections caused paired updates and paired ~1.1 MB full snapshots in React development mode.
2. Periodic full snapshots repeatedly included the entire 2,000-sample metrics history, causing main-thread parse/update spikes.

After fixing transport spikes, plant rendering was the largest steady canvas cost.

## Measured impact

Live browser profiling:

- WebSocket traffic: approximately 25 messages/sec to 13 messages/sec after removing the duplicate connection
- periodic full updates: approximately 1.1 MB to 125-148 KB with metrics history omitted
- plant render calls over 15 seconds: 22,050 to 4,800
- plant render time over 15 seconds: 806 ms to 108 ms, approximately 87% lower
- frame gaps over 25 ms in comparable trace: 10 to 2

An in-process payload check with only 200 history samples showed periodic snapshot size reduced by 55%; the live world retains 2,000 samples, so its reduction is larger.

## Validation

- `.venv\Scripts\python.exe tools\fast_gate.py` - 1,782 passed, 4 skipped
- `npm test -- --run` - 31 passed
- `npm run lint` - passed
- `npm run build` - passed, existing chunk-size warning only
- `git diff --check` - passed

No champion files or benchmark scoring behavior changed.