### PR TITLE
[codex] Clarify minigame event ownership

### DIFF
--- a/backend/runner/hooks/poker_mixin.py
+++ b/backend/runner/hooks/poker_mixin.py
@@ -32,8 +32,12 @@ class PokerMixin:
         if not hasattr(runner.world, "engine"):
             return None
 
+        poker_system = getattr(runner.world.engine, "poker_system", None)
+        if poker_system is None:
+            return None
+
         poker_events: list[PokerEventPayload] = []
-        recent_events = runner.world.engine.poker_events
+        recent_events = poker_system.poker_events
         for event in recent_events:
             if "Standard Algorithm" in event["message"] or "Auto-eval" in event["message"]:
                 continue

--- a/backend/runner/hooks/soccer_mixin.py
+++ b/backend/runner/hooks/soccer_mixin.py
@@ -66,18 +66,7 @@ class SoccerMixin:
         Returns:
             Soccer league live state dict, or None if not available
         """
-        # Try direct method on world (e.g. TankWorldBackendAdapter)
-        get_live = getattr(runner.world, "get_soccer_league_live_state", None)
-        if callable(get_live):
-            live = get_live()
-            return live if isinstance(live, dict) else None
-
-        # Try via engine
         engine = getattr(runner.world, "engine", None)
-        if engine is None and hasattr(runner.world, "world"):
-            # Handle adapter wrapper
-            engine = getattr(runner.world.world, "engine", None)
-
         if engine is None or not hasattr(engine, "soccer_events"):
             return None
 

--- a/core/simulation/engine.py
+++ b/core/simulation/engine.py
@@ -32,7 +32,6 @@ import os
 import random
 import time
 import uuid
-from collections import deque
 from typing import TYPE_CHECKING, Any
 
 import core.simulation.diagnostics as diagnostics
@@ -174,7 +173,6 @@ class SimulationEngine:
         self.poker_proximity_system: PokerProximitySystem | None = None
         self.food_spawning_system: FoodSpawningSystem | None = None
         self.plant_manager: PlantManager | None = None
-        self.poker_events: deque[Any] = deque(maxlen=self.config.poker.max_poker_events)
 
         # Soccer event management (extracted from engine)
         self._soccer_events_mgr = SoccerEventManager(

--- a/core/systems/base.py
+++ b/core/systems/base.py
@@ -221,10 +221,11 @@ class BaseSystem(ABC):
         result = self._do_update(frame)
         self._update_count += 1
 
-        # Defensive: _do_update is typed to return SystemResult, but normalize a
-        # stray None so a mis-implemented system can't leak None into the loop.
-        if result is None:
-            return SystemResult.empty()
+        if not isinstance(result, SystemResult):
+            raise TypeError(
+                f"{self.__class__.__name__}._do_update() must return SystemResult, "
+                f"got {type(result).__name__}"
+            )
         return result
 
     @abstractmethod

--- a/core/update_phases.py
+++ b/core/update_phases.py
@@ -128,8 +128,8 @@ def runs_in_phase(phase: UpdatePhase) -> Callable:
     Example:
         @runs_in_phase(UpdatePhase.COLLISION)
         class CollisionSystem(BaseSystem):
-            def _do_update(self, frame: int) -> None:
-                ...
+            def _do_update(self, frame: int) -> SystemResult:
+                return SystemResult.empty()
     """
 
     def decorator(cls):

--- a/core/worlds/shared/tank_like_pack_base.py
+++ b/core/worlds/shared/tank_like_pack_base.py
@@ -92,7 +92,6 @@ class TankLikePackBase(ABC):
         poker = PokerSystem(engine, max_events=self.config.poker.max_poker_events)
         poker.enabled = self.config.server.poker_activity_enabled
         systems["poker_system"] = poker
-        systems["poker_events"] = poker.poker_events
         systems["poker_proximity_system"] = PokerProximitySystem(engine)
 
         if self.config.poker.enable_periodic_benchmarks:

--- a/core/worlds/tank/backend.py
+++ b/core/worlds/tank/backend.py
@@ -670,19 +670,3 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         # Restore pause state if present
         if "paused" in state:
             self._engine.paused = state["paused"]
-
-    # ========================================================================
-    # Legacy TankWorld-compatible properties (for smooth transition)
-    # ========================================================================
-
-    def get_recent_poker_events(self, max_age_frames: int = 180) -> list[dict[str, Any]]:
-        """Get recent poker events (TankWorld API compatibility)."""
-        if self._engine is None or self._engine.poker_system is None:
-            return []
-        return self._engine.poker_system.get_recent_poker_events(max_age_frames)
-
-    def get_soccer_league_live_state(self) -> dict[str, Any] | None:
-        """Get live league match state for rendering."""
-        if self._engine is None:
-            return None
-        return self._engine.soccer_events.league_live_state

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -59,6 +59,9 @@ the code, 2026-06):
 | Unused `PhaseRunner` execution model removed (finish-or-delete) | `core/update_phases.py` keeps only the `UpdatePhase` taxonomy the engine uses |
 | `core/worlds` mode registration made lazy (was: eager at import → `core.worlds`↔`core.simulation` import-time cycle) | `core/worlds/registry.py`; de-poisons `core.worlds.*` imports; ADR-008 |
 | Persistence/versioning contract made honest (one validated snapshot version; legacy-save shims removed; finish-or-delete) | `core/contracts/version.py` keeps a single `SNAPSHOT_VERSION` (dead, unconsumed `ENTITY_TRANSFER_VERSION`/`WS_PAYLOAD_VERSION` removed; misplaced module docstring fixed); `core/transfer/entity_transfer.py` drops the unvalidated per-entity version stamp and the dead fish `movement_policy_id` shim (`genome_codec` already defaults it); `core/genetics/plant_genome.py` replaces the *random* `strategy_type`/`fractal_type` migration with a deterministic default (removes RNG from restore); `backend/world_persistence.py` `_resolve_engine()` replaces silent `except: pass` paths; `docs/persistence.md` refreshed to v3.0 with real APIs |
+| Engine-level poker event storage removed | `PokerSystem` owns `poker_events`; backend hooks and tests read `engine.poker_system.poker_events` directly, leaving the generic engine without duplicate poker-specific state. See ADR-011 |
+| SystemResult contract made fail-fast | `BaseSystem.update()` now raises `TypeError` when `_do_update()` returns anything other than `SystemResult`, instead of normalizing invalid `None` returns to an empty result |
+| Tank adapter minigame event facades removed | `TankWorldBackendAdapter` no longer exposes `get_recent_poker_events()` or `get_soccer_league_live_state()` pass-throughs; backend hooks read `PokerSystem` and `SoccerEventManager` directly |
 
 ## Open items
 

--- a/docs/adr/011-minigames-out-of-core.md
+++ b/docs/adr/011-minigames-out-of-core.md
@@ -99,19 +99,22 @@ Behavior-neutral: `ecosystem_health_10k` seed 42 is byte-identical
 (4.791812102268079); poker-system, mixed-poker-with-plants, adapter-hot-path,
 and websocket-payload tests pass, plus mypy.
 
-### Known remaining issue (needs app verification, not done)
+### Dead poker event alias removed (follow-up, shipped)
 
-`engine.poker_events` is a **dead deque** — allocated but never written (the
-real events live in `poker_system.poker_events`). Yet `poker_mixin` reads
-`engine.poker_events` to build the world-extras `poker_events` payload, which the
-frontend consumes as `snapshot.poker_events` — so that path appears to deliver an
-**empty** poker-event list. Fixing it (point `poker_mixin` at
-`poker_system.poker_events` and delete the dead deque) is a UI-affecting change:
-the poker dashboard's contents would change, and there is a parallel
-`snapshot.events` poker path that could then double up. That needs verification
-against the running frontend, which this environment can't exercise, so it is
-**intentionally left** rather than fixed blind. It is the last poker-specific
-state on the engine.
+`engine.poker_events` was removed. The constructor allocated a deque that setup
+later overwrote with `PokerSystem.poker_events`, so ownership was implicit and
+the generic engine still exposed poker-specific state. Backend world hooks and
+tests now read from the owning system directly: `engine.poker_system.poker_events`.
+The frontend payload key remains `snapshot.poker_events`; only the internal
+source of that payload changed.
+
+### Tank adapter minigame facades removed (follow-up, shipped)
+
+`TankWorldBackendAdapter.get_recent_poker_events()` and
+`TankWorldBackendAdapter.get_soccer_league_live_state()` had no production
+callers after the hook migration. They were deleted so the adapter stays focused
+on the world backend contract; feature hooks now read poker events from
+`engine.poker_system` and soccer live state from `engine.soccer_events`.
 
 ## Consequences
 

--- a/tests/test_adapter_update_hot_path.py
+++ b/tests/test_adapter_update_hot_path.py
@@ -36,10 +36,8 @@ def test_adapter_update_avoids_expensive_calls():
         # get_stats should NOT be called
         assert mock_get_stats.call_count == 0, "get_stats() was called during update()!"
 
-        # get_recent_poker_events should NOT be called
-        assert (
-            mock_get_events.call_count == 0
-        ), "get_recent_poker_events() was called during update()!"
+        # drain_frame_outputs should NOT be called
+        assert mock_get_events.call_count == 0, "drain_frame_outputs() was called during update()!"
 
         # Verify frame count advanced
         assert adapter.frame_count == 10

--- a/tests/test_architecture_patterns.py
+++ b/tests/test_architecture_patterns.py
@@ -6,6 +6,8 @@ and provide good examples of how to use them.
 
 from typing import Any, cast
 
+import pytest
+
 from core.cache_manager import CachedList, CacheManager
 from core.systems.base import BaseSystem, SystemResult
 
@@ -350,6 +352,32 @@ class TestCollisionSystemWithSystemResult:
         assert collision_system._frame_collisions_detected == 0
 
 
+class TestMinigameEventOwnership:
+    """Tests for minigame event stream ownership boundaries."""
+
+    def test_poker_events_are_owned_by_poker_system_not_engine(self):
+        """The generic engine should not expose a poker-specific event buffer."""
+        from core.simulation.engine import SimulationEngine
+
+        engine = SimulationEngine(headless=True)
+        assert not hasattr(engine, "poker_events")
+
+        engine.setup()
+
+        assert not hasattr(engine, "poker_events")
+        assert engine.poker_system is not None
+        assert hasattr(engine.poker_system, "poker_events")
+
+    def test_tank_adapter_does_not_expose_minigame_event_facades(self):
+        """Feature hooks should read minigame events from owning systems."""
+        from core.worlds.tank.backend import TankWorldBackendAdapter
+
+        adapter = TankWorldBackendAdapter(seed=42)
+
+        assert not hasattr(adapter, "get_recent_poker_events")
+        assert not hasattr(adapter, "get_soccer_league_live_state")
+
+
 class TestBaseSystemWithResult:
     """Tests for BaseSystem handling SystemResult."""
 
@@ -392,24 +420,20 @@ class TestBaseSystemWithResult:
         assert result.skipped is True
         assert result.entities_affected == 0
 
-    def test_base_system_handles_legacy_none_return(self):
-        """BaseSystem.update should handle legacy systems returning None."""
+    def test_base_system_rejects_missing_system_result(self):
+        """BaseSystem.update should fail loudly when _do_update violates the contract."""
 
-        class LegacySystem(BaseSystem):
+        class BrokenSystem(BaseSystem):
             def __init__(self):
                 self._engine = cast(Any, None)
-                self._name = "Legacy"
+                self._name = "Broken"
                 self._enabled = True
                 self._update_count = 0
 
             def _do_update(self, frame: int):
-                # Legacy systems return None
                 return None
 
-        system = LegacySystem()
-        result = system.update(frame=1)
+        system = BrokenSystem()
 
-        # Should get empty result, not None
-        assert isinstance(result, SystemResult)
-        assert result.entities_affected == 0
-        assert result.skipped is False
+        with pytest.raises(TypeError, match="must return SystemResult"):
+            system.update(frame=1)

--- a/tests/test_mixed_poker_with_plants.py
+++ b/tests/test_mixed_poker_with_plants.py
@@ -459,7 +459,7 @@ class TestMutualProximityFiltering:
         max_dist_sq = max_distance * max_distance
         violations = []
 
-        for event in engine.poker_events:
+        for event in engine.poker_system.poker_events:
             players = event.get("players", [])
             if len(players) >= 2:
                 # Check all pairs using squared distance
@@ -484,7 +484,7 @@ class TestMutualProximityFiltering:
         max_dist = max(FISH_POKER_MAX_DISTANCE, PLANT_POKER_MAX_DISTANCE)
         max_dist_sq = max_dist * max_dist
 
-        for event in engine.poker_events:
+        for event in engine.poker_system.poker_events:
             players = event.get("players", [])
             for i, p1 in enumerate(players):
                 for p2 in players[i + 1 :]:
@@ -543,7 +543,7 @@ class TestSimulationIntegration:
     def test_poker_events_recorded(self, run_simulation):
         """Verify poker events are being recorded."""
         result = run_simulation(frames=600)
-        poker_events = list(result["engine"].poker_events)
+        poker_events = list(result["engine"].poker_system.poker_events)
 
         assert len(poker_events) > 0, "Should have recorded poker events"
 
@@ -687,7 +687,7 @@ def run_manual_test():
             f"  Plant {p.plant_id}: {p.poker_wins} wins, {p.poker_losses} losses, energy={p.energy:.1f}"
         )
 
-    total_poker_events = len(list(engine.poker_events))
+    total_poker_events = len(list(engine.poker_system.poker_events))
     print(f"\nTotal poker events recorded: {total_poker_events}")
 
     print("\n" + "=" * 60)


### PR DESCRIPTION
## Summary

This PR tightens simulation architecture boundaries around minigame event streams and system update contracts.

- Removes the duplicate `SimulationEngine.poker_events` alias so poker events are owned by `PokerSystem` only.
- Removes legacy minigame event facade methods from `TankWorldBackendAdapter`.
- Updates websocket hooks and tests to read event state from the owning systems.
- Makes `BaseSystem.update()` fail fast when `_do_update()` does not return a `SystemResult`.
- Records the cleanup in the architecture review and minigames ADR.

## Why

The old compatibility aliases made ownership ambiguous: generic engine and adapter layers exposed poker/soccer-specific event access even though the minigame systems already owned that state. That increases the chance of stale aliases, hidden coupling, and harder debugging as new worlds or minigames are added.

The `BaseSystem` change also turns a silent contract violation into an immediate error, which should make future system bugs easier to find.

## Validation

- `git diff --check` passed
- `.\.venv\Scripts\python.exe tools\fast_gate.py` passed
- Fast gate result: `1736 passed, 3 skipped, 156 deselected, 57 warnings`

No champion files, benchmarks, or Layer 1 behavior algorithms were changed.