### PR TITLE
[codex] Harden engine pipeline boundary

### DIFF
--- a/core/simulation/pipeline.py
+++ b/core/simulation/pipeline.py
@@ -46,7 +46,7 @@ class FrameContext:
     entities_to_remove: list[Any] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(frozen=True)
 class PipelineStep:
     """A single step in the engine update pipeline.
 
@@ -72,12 +72,16 @@ class EnginePipeline:
         Args:
             steps: List of PipelineStep instances in execution order
         """
-        self._steps = steps
+        self._steps = steps.copy()
 
     @property
     def steps(self) -> list[PipelineStep]:
-        """Get the list of pipeline steps."""
-        return self._steps
+        """Get the pipeline steps in execution order.
+
+        Returns a copy so callers can inspect or wrap steps without mutating the
+        live pipeline accidentally.
+        """
+        return self._steps.copy()
 
     @property
     def step_names(self) -> list[str]:

--- a/core/simulation/system_registry.py
+++ b/core/simulation/system_registry.py
@@ -5,8 +5,9 @@ and debugging. Extracted from SimulationEngine to follow SRP.
 
 Design Decisions:
 -----------------
-1. Systems are registered in a specific order which determines execution order.
-   The order is controlled by the caller at registration time.
+1. Systems are registered in a stable order for introspection/debug output.
+   Execution order is owned by the EnginePipeline, PhaseExecutor, and
+   SystemCoordinator.
 
 2. Systems can be enabled/disabled at runtime without removal.
 
@@ -46,21 +47,19 @@ class SystemRegistry:
 
     Systems are the workhorses of the simulation - they contain the logic
     that operates on entities each frame. This registry:
-    - Maintains systems in execution order
+    - Maintains systems in registration order for inspection
     - Provides runtime enable/disable
     - Aggregates debug information
 
     Attributes:
-        systems: List of registered systems in execution order
+        systems: List of registered systems in inspection order
 
     Example:
         registry = SystemRegistry()
         registry.register(collision_system)
         registry.register(reproduction_system)
 
-        for system in registry.get_all():
-            system.update(frame)
-
+        debug_info = registry.get_debug_info()
         registry.set_enabled("Collision", False)  # Disable collisions
     """
 
@@ -69,9 +68,7 @@ class SystemRegistry:
         self._systems: list[BaseSystem] = []
 
     def register(self, system: "BaseSystem") -> None:
-        """Register a system for execution.
-
-        Systems are executed in registration order.
+        """Register a system for introspection and runtime control.
 
         Args:
             system: The system to register
@@ -109,7 +106,7 @@ class SystemRegistry:
         return None
 
     def get_all(self) -> list["BaseSystem"]:
-        """Get all registered systems in execution order.
+        """Get all registered systems in inspection order.
 
         Returns:
             List of registered systems (copy to prevent mutation)
@@ -146,7 +143,7 @@ class SystemRegistry:
         return len(self._systems)
 
     def __iter__(self):
-        """Iterate over systems in execution order."""
+        """Iterate over systems in inspection order."""
         return iter(self._systems)
 
     def __repr__(self) -> str:

--- a/core/systems/base.py
+++ b/core/systems/base.py
@@ -21,8 +21,9 @@ diagnostics and validation:
     class CollisionSystem(BaseSystem):
         ...
 
-The simulation engine can then orchestrate systems by phase, ensuring
-predictable execution order regardless of registration order.
+The simulation engine's explicit phase loop owns execution order; phase
+metadata lets diagnostics validate that each system is wired into the phase it
+declares.
 """
 
 from abc import ABC, abstractmethod

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -38,10 +38,10 @@ flowchart LR
 A single step in the update loop:
 
 ```python
-@dataclass
+@dataclass(frozen=True)
 class PipelineStep:
     name: str  # Human-readable identifier (e.g., "frame_start")
-    fn: Callable[[SimulationEngine], None]  # Step execution function
+    fn: Callable[[SimulationEngine, FrameContext], None]  # Step execution function
 ```
 
 ### EnginePipeline
@@ -53,12 +53,20 @@ class EnginePipeline:
     def __init__(self, steps: list[PipelineStep]): ...
 
     @property
+    def steps(self) -> list[PipelineStep]: ...
+
+    @property
     def step_names(self) -> list[str]: ...
 
     def run(self, engine: SimulationEngine) -> None:
-        for step in self.steps:
-            step.fn(engine)
+        ctx = FrameContext()
+        for step in self._steps:
+            step.fn(engine, ctx)
 ```
+
+`PipelineStep` is frozen, and `EnginePipeline` copies its step list on
+construction and returns a copy from `steps`. To customize phase order,
+construct a new pipeline instead of mutating an existing one.
 
 ### default_pipeline()
 
@@ -73,9 +81,10 @@ The canonical Tank pipeline that reproduces the exact phase order originally har
 | 5 | lifecycle | Process deaths, add/remove entities |
 | 6 | spawn | Auto-spawn food |
 | 7 | collision | Handle physical collisions |
-| 8 | interaction | Handle social interactions (poker) |
-| 9 | reproduction | Handle mating and emergency spawns |
-| 10 | frame_end | Update stats, rebuild caches |
+| 8 | soccer | Update optional ball physics and agent-ball interactions |
+| 9 | interaction | Handle social interactions (poker) |
+| 10 | reproduction | Handle mating and emergency spawns |
+| 11 | frame_end | Update stats, rebuild caches |
 
 ## How ModePack Selects a Pipeline
 
@@ -128,18 +137,23 @@ def create_my_mode_pack() -> ModePackDefinition:
 
 ## Data Flow Between Steps
 
-Some steps need to pass data to subsequent steps. This is handled via temporary engine attributes:
+Some steps need to pass data to subsequent steps. This is handled with a
+per-frame `FrameContext` created by `EnginePipeline.run()` and passed to every
+step:
 
 ```python
-def _step_time_update(engine):
+def _step_time_update(engine, ctx):
     time_modifier, time_of_day = engine._phase_time_update()
-    engine._pipeline_time_modifier = time_modifier
-    engine._pipeline_time_of_day = time_of_day
+    ctx.time_modifier = time_modifier
+    ctx.time_of_day = time_of_day
 
-def _step_entity_act(engine):
-    time_modifier = getattr(engine, "_pipeline_time_modifier", 1.0)
-    time_of_day = getattr(engine, "_pipeline_time_of_day", 0.5)
-    # ... use values ...
+def _step_entity_act(engine, ctx):
+    new_entities, entities_to_remove = engine._phase_entity_act(
+        ctx.time_modifier,
+        ctx.time_of_day,
+    )
+    ctx.new_entities = new_entities
+    ctx.entities_to_remove = entities_to_remove
 ```
 
 ## Related Files

--- a/tests/test_engine_pipeline.py
+++ b/tests/test_engine_pipeline.py
@@ -77,6 +77,31 @@ def test_custom_pipeline_can_be_created() -> None:
     assert len(custom_pipeline.steps) == 2
 
 
+def test_pipeline_steps_are_not_mutated_through_external_lists() -> None:
+    """Pipeline ordering should change only by constructing a new pipeline."""
+    from dataclasses import FrozenInstanceError
+
+    import pytest
+
+    from core.simulation.pipeline import EnginePipeline, PipelineStep
+
+    def noop_step(engine, ctx) -> None:
+        pass
+
+    source_steps = [PipelineStep("step_a", noop_step)]
+    pipeline = EnginePipeline(source_steps)
+
+    source_steps.append(PipelineStep("outside_append", noop_step))
+    assert pipeline.step_names == ["step_a"]
+
+    exposed_steps = pipeline.steps
+    exposed_steps.append(PipelineStep("property_append", noop_step))
+    assert pipeline.step_names == ["step_a"]
+
+    with pytest.raises(FrozenInstanceError):
+        exposed_steps[0].name = "renamed"
+
+
 def test_pipeline_step_execution_order() -> None:
     """Assert that pipeline steps are executed in order."""
     from core.simulation.pipeline import EnginePipeline, PipelineStep


### PR DESCRIPTION
## What changed
Hardened the engine pipeline boundary so phase order is owned by `EnginePipeline` construction rather than mutable caller-owned lists or mutable step objects.

## Layer
- [x] Layer 2 (docs / tests / tooling - does not affect simulation results)

## Why
The pipeline is the execution-order abstraction for the simulation. Previously, callers could mutate the source step list, the exposed `steps` list, or a `PipelineStep` object after construction. That made an important architecture invariant easier to break accidentally while debugging or extending modes.

This PR also corrects adjacent architecture wording so `SystemRegistry` is described as inspection/runtime-control infrastructure, while the pipeline/phase coordinator owns execution.

## Proof
Validation run locally:

```bash
py -3 -m pytest tests\test_engine_pipeline.py -v
py -3 tools\smoke_gate.py
py -3 tools\fast_gate.py
git diff --check
```

Results:
- `tests\test_engine_pipeline.py`: 6 passed
- smoke gate: passed, 31 tests
- fast gate: passed, 1737 passed, 3 skipped, 156 deselected
- `git diff --check`: passed

## No regressions
This is a Layer 2 architecture/test/docs hardening change. No behavior algorithms, config, benchmark scoring, or champion files were changed.