### PR TITLE
Fix frozen fish poker game counter (total_fish_poker_games stuck at 0)

### DIFF
--- a/core/ecosystem.py
+++ b/core/ecosystem.py
@@ -240,6 +240,10 @@ class EcosystemManager:
     def total_fish_poker_games(self, value: int) -> None:
         self.poker_manager.total_fish_poker_games = value
 
+    def record_fish_poker_game(self) -> None:
+        """Count one completed fish-vs-fish poker game (see PokerStatsManager)."""
+        self.poker_manager.record_fish_poker_game()
+
     @property
     def total_plant_poker_games(self) -> int:
         return self.poker_manager.total_plant_poker_games

--- a/core/poker_stats_manager.py
+++ b/core/poker_stats_manager.py
@@ -341,6 +341,20 @@ class PokerStatsManager:
 
         self._log_poker_event(winner_id, loser_id, amount, winner_hand, loser_hand)
 
+    def record_fish_poker_game(self) -> None:
+        """Count one completed fish-vs-fish poker game (UI ``total_fish_games``).
+
+        Per-fish ``FishPokerStats`` are recorded inside the multiplayer poker
+        interaction; only this aggregate counter was left unincremented after
+        ``record_poker_outcome`` (the legacy 2-player recorder) was orphaned, so
+        the UI's fish poker game count sat frozen at 0.
+        """
+        self.total_fish_poker_games += 1
+        try:
+            self._save_poker_totals()
+        except Exception as error:  # pragma: no cover - defensive logging
+            logger.error(f"Failed to save poker totals: {error}", exc_info=True)
+
     def record_plant_poker_game(
         self,
         fish_id: int,

--- a/core/poker_system.py
+++ b/core/poker_system.py
@@ -90,6 +90,14 @@ class PokerSystem(BaseSystem):
         """
         self.add_poker_event(poker)
 
+        # Count the completed fish-vs-fish game so the UI's total_fish_games and
+        # poker-rate stats advance. Per-fish FishPokerStats are recorded inside
+        # the poker interaction; this aggregate counter was previously never
+        # incremented (its recorder, record_poker_outcome, was orphaned).
+        ecosystem = getattr(self._engine, "ecosystem", None)
+        if ecosystem is not None and poker.result is not None:
+            ecosystem.record_fish_poker_game()
+
         # Delegate post-poker reproduction to the ReproductionService
         reproduction_service = getattr(self._engine, "reproduction_service", None)
         if reproduction_service is not None:

--- a/tests/test_ecosystem_poker_records.py
+++ b/tests/test_ecosystem_poker_records.py
@@ -27,3 +27,31 @@ def test_mixed_poker_outcome_record_tracks_house_cut():
         rel_tol=0,
         abs_tol=1e-9,
     )
+
+
+def test_record_fish_poker_game_increments_total():
+    ecosystem = EcosystemManager()
+    start = ecosystem.total_fish_poker_games
+    ecosystem.record_fish_poker_game()
+    ecosystem.record_fish_poker_game()
+    assert ecosystem.total_fish_poker_games == start + 2
+
+
+def test_fish_poker_game_counter_advances_in_sim():
+    """Regression: fish-vs-fish poker games played but the global counter stayed
+    at 0 because handle_poker_result never counted the completed game (its
+    recorder, record_poker_outcome, was orphaned when poker moved to the
+    multiplayer interaction). It must advance during a real seeded sim.
+    """
+    from core.worlds.registry import WorldRegistry
+
+    world = WorldRegistry.create_world("tank", seed=42, config={})
+    world.reset(seed=42, config={})
+    eco = world._engine.ecosystem
+    start = eco.total_fish_poker_games
+
+    for _ in range(3000):
+        world.step()
+
+    # Delta (not absolute) so a persisted logs/poker_totals.json can't mask it.
+    assert eco.total_fish_poker_games > start


### PR DESCRIPTION
## Summary

Fish-vs-fish poker games play and settle, and **per-fish** `FishPokerStats` are recorded correctly — but the **global** `total_fish_poker_games` counter (surfaced to the UI as `total_fish_games`) stayed frozen at **0**, so the poker panel looked stalled even though games were happening every few frames.

## Root cause

The global counter (and the legacy per-algorithm poker aggregate) lived in `PokerStatsManager.record_poker_outcome` — a **2-player** recorder that became **orphaned** when poker moved to the 2–6-player `MixedPokerInteraction`. Per-fish recording moved *into* the interaction, but the aggregate counter call was lost. `handle_poker_result` (the sole fish-poker entry point, called once per game by `PokerProximitySystem`) only logged the display event and ran reproduction — it never counted the completed game.

I verified this is **pre-existing on `master`**, not from any recent branch: an A/B headless run shows hundreds of `handle_poker_result` calls on both `master` and elsewhere, with `total_fish_poker_games == 0` on both.

## Fix

- Add `PokerStatsManager.record_fish_poker_game()` (increment + the existing throttled totals save) and a thin `EcosystemManager.record_fish_poker_game()` delegate.
- Call it from `handle_poker_result` once per completed game.

Multiplayer-safe (one increment per game regardless of player count) and **trajectory-neutral** — it's a counter bump plus the already-throttled totals write; no RNG draw and no entity-state change.

## Verification

- `mypy core/` clean; **141 poker tests pass**.
- End-to-end: a seed-42 tank sim now advances `total_fish_poker_games` **0 → 694** over 4000 frames (regression test added in `tests/test_ecosystem_poker_records.py`, asserting a delta so a persisted `logs/poker_totals.json` can't mask it).
- The `ecosystem_health_10k` champion still reproduces (`validate_reproduction` SUCCESS), confirming the sim trajectory and score are unchanged.

## Out of scope

The per-algorithm poker aggregate (`poker_manager.poker_stats`, also surfaced to the UI) is likewise empty for fish games. Restoring it cleanly is entangled with the algorithm-id keying determinism work (separate effort) and the legacy 2-player `record_poker_outcome` shape, so it's left as a follow-up rather than half-wired here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxBYU9VnwMiNzCBbguPzdh

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxBYU9VnwMiNzCBbguPzdh)_