### PR TITLE
Polish public agent validation and CI consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,17 +112,18 @@ tank/
 - `core/algorithms/composable/` - Composable behavior library (58 strategies)
 - `core/agents/components/` - Shared agent state components (lifecycle, reproduction); Fish composes these plus `EnergyComponent` and delegates behavior to `BehaviorExecutor` (see ADR-004, ADR-009)
 
-## CI Pipeline
+## Validation Pipeline
 
-CI runs named validation tiers:
+Local validation tiers:
 
-1. **smoke-gate**: `python tools/smoke_gate.py`
-2. **agent-gate**: `python tools/agent_gate.py`
-3. **fast-gate**: `python tools/fast_gate.py` plus mypy
-4. **frontend-ci**: npm install, lint, build, test
-5. **nightly-full**: `python tools/full_gate.py` (nightly or on `full-test`)
+1. **Smoke Gate**: `python tools/smoke_gate.py` before coding
+2. **Agent Gate**: `python tools/agent_gate.py` before local commit
+3. **Fast Gate**: `python tools/fast_gate.py` before PR
+4. **Full Gate**: `python tools/full_gate.py` only for maintainers/nightly/full validation
 
-Benchmark CI (`bench.yml`): Verifies champions and runs full determinism checks
+Public CI jobs are named `smoke-gate`, `fast-gate`, `frontend-ci`, and
+`nightly-full` in `ci.yml`, plus `verify-champions` and `benchmark-gate` in
+`bench.yml`. Benchmark CI verifies champions and runs full determinism checks
 nightly or when a maintainer dispatches it explicitly.
 
 ## Working on Improvements

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -27,6 +27,7 @@ import logging
 import os
 import platform
 import socket
+import sys
 import time
 from collections.abc import Callable, Coroutine
 from contextlib import asynccontextmanager
@@ -151,7 +152,7 @@ def _get_network_ip() -> str:
 
 def _configure_windows_event_loop(logger: logging.Logger) -> None:
     """Configure asyncio event loop policy on Windows."""
-    if platform.system() != "Windows":
+    if sys.platform != "win32":
         return
 
     loop_policy = os.getenv("TANK_WINDOWS_EVENT_LOOP", "selector").strip().lower()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ exclude = [
     "frontend/",
     ".venv/",
     "venv/",
+    "tools/archive/debug_poker_match.py",
 ]
 
 [tool.coverage.run]

--- a/start.py
+++ b/start.py
@@ -117,7 +117,7 @@ def wait_for_port(port, timeout=15.0):
         try:
             with socket.create_connection(("localhost", port), timeout=1.0):
                 return True
-        except (ConnectionRefusedError, socket.timeout):
+        except (ConnectionRefusedError, TimeoutError):
             time.sleep(0.5)
     return False
 

--- a/tests/test_docs_agent_onboarding.py
+++ b/tests/test_docs_agent_onboarding.py
@@ -6,6 +6,47 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _workflow_job_names() -> set[str]:
+    workflow_paths = [
+        ROOT / ".github" / "workflows" / "ci.yml",
+        ROOT / ".github" / "workflows" / "bench.yml",
+    ]
+
+    actual_jobs = set()
+    job_pattern = re.compile(r"^(?:  |\t)([a-zA-Z0-9_-]+):")
+
+    for wf_path in workflow_paths:
+        assert wf_path.exists(), f"Workflow file {wf_path} does not exist"
+        in_jobs = False
+        for line in wf_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("jobs:"):
+                in_jobs = True
+                continue
+            if in_jobs:
+                if line.strip() == "":
+                    continue
+                if not line.startswith(" ") and not line.startswith("\t"):
+                    in_jobs = False
+                    continue
+                match = job_pattern.match(line)
+                if match:
+                    actual_jobs.add(match.group(1))
+
+    assert actual_jobs, "No jobs were parsed from the workflow files"
+    return actual_jobs
+
+
+def _markdown_section(content: str, heading: str) -> str:
+    marker = f"## {heading}"
+    start = content.find(marker)
+    assert start != -1, f"Could not find section heading: {marker}"
+
+    next_heading = content.find("\n## ", start + len(marker))
+    if next_heading == -1:
+        return content[start:]
+    return content[start:next_heading]
+
+
 def test_readme_references_smoke_and_fast_gates():
     readme_path = ROOT / "README.md"
     assert readme_path.exists(), "README.md does not exist"
@@ -22,6 +63,20 @@ def test_agents_references_agent_quickstart():
     assert (
         "docs/AGENT_QUICKSTART.md" in content
     ), "AGENTS.md must reference docs/AGENT_QUICKSTART.md"
+    assert "tools/agent_gate.py" in content, "AGENTS.md must reference tools/agent_gate.py"
+
+
+def test_vague_prompt_guidance_starts_with_smoke_gate_not_fast_gate():
+    agents_path = ROOT / "AGENTS.md"
+    content = agents_path.read_text(encoding="utf-8")
+    section = _markdown_section(content, "If you were given a vague prompt")
+
+    gate_commands = re.findall(r"python tools/(?:smoke|agent|fast|full)_gate\.py", section)
+
+    assert gate_commands, "AGENTS.md vague-prompt section must name a validation gate"
+    assert (
+        gate_commands[0] == "python tools/smoke_gate.py"
+    ), "Vague-prompt guidance must make smoke_gate.py the first validation command"
 
 
 def test_agent_quickstart_exists():
@@ -64,34 +119,7 @@ def test_ci_job_names_in_readme_match_workflow_files():
     readme_path = ROOT / "README.md"
     readme_content = readme_path.read_text(encoding="utf-8")
 
-    # Extract actual job names from CI and Bench workflow files
-    workflow_paths = [
-        ROOT / ".github" / "workflows" / "ci.yml",
-        ROOT / ".github" / "workflows" / "bench.yml",
-    ]
-
-    actual_jobs = set()
-    job_pattern = re.compile(r"^(?:  |\t)([a-zA-Z0-9_-]+):")
-
-    for wf_path in workflow_paths:
-        assert wf_path.exists(), f"Workflow file {wf_path} does not exist"
-        in_jobs = False
-        for line in wf_path.read_text(encoding="utf-8").splitlines():
-            if line.startswith("jobs:"):
-                in_jobs = True
-                continue
-            if in_jobs:
-                if line.strip() == "":
-                    continue
-                if not line.startswith(" ") and not line.startswith("\t"):
-                    in_jobs = False
-                    continue
-                match = job_pattern.match(line)
-                if match:
-                    actual_jobs.add(match.group(1))
-
-    # Assert that actual jobs are found
-    assert actual_jobs, "No jobs were parsed from the workflow files"
+    actual_jobs = _workflow_job_names()
 
     # Extract the job names mentioned in the CI section of README.md
     # Look for "CI currently runs" sentence
@@ -111,3 +139,12 @@ def test_ci_job_names_in_readme_match_workflow_files():
         assert (
             job in actual_jobs
         ), f"README.md references stale/nonexistent CI job '{job}' (actual jobs: {actual_jobs})"
+
+    all_readme_job_mentions = set(
+        re.findall(
+            r"(?<!-)\b[a-zA-Z0-9_-]+-gate\b|(?<!-)\b[a-zA-Z0-9_-]+-ci\b|(?<!-)\bverify-[a-zA-Z0-9_-]+\b|(?<!-)\bnightly-[a-zA-Z0-9_-]+\b",
+            readme_content,
+        )
+    )
+    stale_mentions = sorted(all_readme_job_mentions - actual_jobs)
+    assert not stale_mentions, f"README.md mentions stale/nonexistent CI jobs: {stale_mentions}"


### PR DESCRIPTION
## Summary

Polishes the remaining public-agent readiness checks without changing simulation behavior, physics, benchmark formulas, champion scores, or frontend renderers.

## What changed

- Fixed the remaining full-repo Ruff `UP041` issue in `start.py` by replacing `socket.timeout` with builtin `TimeoutError`.
- Fixed the Windows event loop policy typing issue in `backend/app_factory.py` by using `sys.platform` narrowing.
- Cleanly excluded archived removed-code script `tools/archive/debug_poker_match.py` from mypy via `pyproject.toml` instead of refactoring stale archive code.
- Updated `CLAUDE.md` so public CI job names match the actual workflows: `smoke-gate`, `fast-gate`, `frontend-ci`, `nightly-full`, `verify-champions`, and `benchmark-gate`. It now treats `agent_gate.py` as local pre-commit validation, not a public CI job.
- Strengthened `tests/test_docs_agent_onboarding.py` to catch README CI job-name drift, missing `agent_gate.py` in `AGENTS.md`, stale benchmark paths, and vague-prompt guidance that starts with `fast_gate.py` instead of `smoke_gate.py`.

## Stale docs or CI mismatches fixed

- `CLAUDE.md` previously listed `agent-gate` beside public CI jobs even though no `agent-gate` workflow job exists. It now separates local validation tiers from public CI jobs.
- Re-scanned the requested docs/workflows for stale `integration-gate` and `test-headless` references; none remain in the public-readiness docs/workflows.

## Validation

Note: bare `python` resolves to the Windows Store shim on this machine, so these were run with `.venv\Scripts\python.exe`.

- `.venv\Scripts\python.exe -m ruff check .` -> `All checks passed!` with non-fatal Ruff cache access warnings.
- `.venv\Scripts\python.exe tools\smoke_gate.py` -> `33 passed in 2.60s`; smoke gate passed.
- `.venv\Scripts\python.exe tools\agent_gate.py` -> smoke passed; curated suite `577 passed, 100 deselected in 4.57s`; agent gate passed.
- `.venv\Scripts\python.exe -m pytest tests/test_docs_agent_onboarding.py tests/test_validation_tiers.py tests/test_champion_provenance.py tests/test_benchmark_determinism.py tests/test_run_bench.py -q` -> `27 passed in 2.12s`.
- `.venv\Scripts\python.exe tools\validate_champion_provenance.py` -> `Champion provenance validation passed for 4 files.`
- `.venv\Scripts\python.exe -m mypy core` -> `Success: no issues found in 333 source files`.
- `.venv\Scripts\python.exe -m mypy tools backend` -> before: `1 error`; after: `Success: no issues found in 96 source files`.
- Extra pre-PR check: `.venv\Scripts\python.exe tools\fast_gate.py` -> `1750 passed, 3 skipped, 156 deselected, 57 warnings in 82.96s`; fast gate passed.

Frontend validation was not run because no frontend files changed.

## Remaining known slow commands

- `python tools/full_gate.py` remains intentionally reserved for maintainers/nightly/full validation.
- Full champion reproduction remains in `verify-champions`/nightly workflows, not routine local iteration.

## Why this helps vague-prompt coding agents

This makes the public onboarding surface harder to misread: vague-prompt agents are steered to the smoke gate first, the local agent gate before commit, the fast gate before PR, and the full gate only for maintainer/nightly validation. The tests now enforce those expectations so future docs or CI drift is caught while still staying fast.