### PR TITLE
Decouple soccer ball drive from generic movement; drop action-translation ceremony

### DIFF
--- a/core/movement/ball_pursuit.py
+++ b/core/movement/ball_pursuit.py
@@ -1,0 +1,117 @@
+"""Soccer-ball pursuit movement drive.
+
+This is the one place that knows fish *want* the ball. It is a self-contained
+:class:`MovementConsideration` (ADR-010): it owns its own activation condition
+(energy gate + survival yield) and desired velocity, so the generic movement
+strategy no longer carries any ball/soccer concept. The arbiter in
+``core.movement.considerations`` lists it; it does not implement it.
+
+Note on placement: ball pursuit is a *tank-world default* drive (the practice
+ball exists whenever ``tank_practice_enabled`` is set, which is the default even
+when ``soccer_enabled`` is False), not a soccer-only minigame plugin. It lives
+in ``core.movement`` rather than ``core.minigames.soccer`` so a plain tank run
+does not pull in the heavy soccer package ``__init__``. See ADR-010 / ADR-011.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from core.entities.ball import Ball
+
+if TYPE_CHECKING:
+    from core.entities import Fish
+    from core.movement_strategy import AlgorithmicMovement
+
+Velocity = tuple[float, float]
+
+# Ball play is only worthwhile once a fish is genuinely topped up. Reproduction
+# is funded by energy banked *above* max_energy (overflow), so a fish anywhere
+# below max is still climbing toward its next birth - diverting it to the ball
+# burns the very energy that would fund offspring. Gate on near-max energy so
+# only fish at the overflow boundary spend genuine surplus on play.
+PLAY_ENERGY_THRESHOLD_RATIO = 0.90
+
+# Target magnitude for the pursuit velocity. The arbiter's velocity tail in
+# AlgorithmicMovement.move() re-scales by the fish's speed and clamps the
+# magnitude, so this is a "head straight at the ball at full tilt" signal, not a
+# literal pixels/frame speed. (Historically this read a non-existent
+# ``fish.max_speed`` attribute via getattr and silently fell back to 2.0; the
+# constant makes the real, always-used value explicit.)
+BALL_PURSUIT_TARGET_SPEED = 2.0
+
+
+def ball_pursuit_velocity(fish: Fish) -> Velocity | None:
+    """Desired velocity toward the soccer ball, or None if not pursuing.
+
+    Only fish with an energy surplus play ball, and even a topped-up fish yields
+    to a live survival drive (threat/food) so leisure never pre-empts survival.
+
+    The survival yield is checked *after* the RNG draw so the random stream is
+    identical to when ball pursuit had unconditional top priority - only the
+    *outcome* changes, and only for the few fish that both rolled "play" and
+    have a survival drive (ADR-010 step 2).
+    """
+    # The ball is genuinely optional on the environment, so getattr-with-default
+    # is the right tool here (unlike energy/max_energy, which every fish has).
+    ball = getattr(fish.environment, "ball", None)
+    if ball is None:
+        agents = getattr(fish.environment, "agents", None)
+        if agents:
+            for entity in agents:
+                if isinstance(entity, Ball):
+                    ball = entity
+                    break
+
+    if ball is None:
+        return None  # No ball = no soccer
+
+    max_energy = fish.max_energy
+    current_energy = fish.energy
+    energy_ratio = current_energy / max_energy if max_energy > 0 else 1.0
+
+    if energy_ratio <= PLAY_ENERGY_THRESHOLD_RATIO:
+        return None  # Still building toward reproduction: forage, don't play
+
+    # Cap kept low: surplus energy banked via overflow funds reproduction, so
+    # heavy ball play by full-energy fish directly suppresses births.
+    surplus = (energy_ratio - PLAY_ENERGY_THRESHOLD_RATIO) / (1.0 - PLAY_ENERGY_THRESHOLD_RATIO)
+    pursuit_prob = 0.25 * surplus  # 0% at play threshold -> 25% at full energy
+
+    rng = fish.environment.rng
+    if rng.random() > pursuit_prob:
+        return None
+
+    # Survival outranks leisure (checked after the RNG draw above; see docstring).
+    behavior = fish.genome.behavioral.behavior.value if fish.genome.behavioral.behavior else None
+    if behavior is not None and behavior.has_survival_priority(fish):
+        return None
+
+    # Calculate direction to ball
+    dx = ball.pos.x - fish.pos.x
+    dy = ball.pos.y - fish.pos.y
+    dist = math.sqrt(dx * dx + dy * dy)
+
+    if dist < 10:  # Already at ball
+        return None
+
+    # Normalize and scale to the pursuit target magnitude (re-scaled downstream).
+    vx = (dx / dist) * BALL_PURSUIT_TARGET_SPEED
+    vy = (dy / dist) * BALL_PURSUIT_TARGET_SPEED
+
+    return (vx, vy)
+
+
+class BallPursuitConsideration:
+    """Soccer-ball pursuit drive for fish with surplus energy.
+
+    Implements the :class:`~core.movement.considerations.MovementConsideration`
+    protocol structurally; the ``strategy`` argument is unused because this
+    drive depends only on the fish and its environment.
+    """
+
+    name = "ball_pursuit"
+
+    def desired_velocity(self, strategy: AlgorithmicMovement, fish: Fish) -> Velocity | None:
+        return ball_pursuit_velocity(fish)

--- a/core/movement/considerations.py
+++ b/core/movement/considerations.py
@@ -18,18 +18,32 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
+from core.movement.ball_pursuit import BallPursuitConsideration
+
 if TYPE_CHECKING:
     from core.entities import Fish
     from core.movement_strategy import AlgorithmicMovement
 
 Velocity = tuple[float, float]
 
+__all__ = [
+    "MovementConsideration",
+    "PolicyOverrideConsideration",
+    "BallPursuitConsideration",
+    "CodePolicyConsideration",
+    "ComposableBehaviorConsideration",
+    "MovementArbiter",
+    "default_considerations",
+]
+
 
 class MovementConsideration(Protocol):
     """One competing movement drive.
 
-    Implementations are stateless and delegate to the owning strategy, so the
-    priority *order* lives in exactly one place (the arbiter's list).
+    Implementations are stateless; some delegate to the owning strategy (e.g.
+    the policy/code/composable drives below) while others are self-contained
+    (e.g. ``BallPursuitConsideration``). Either way the priority *order* lives in
+    exactly one place — the arbiter's list — not in control flow.
     """
 
     name: str
@@ -46,15 +60,6 @@ class PolicyOverrideConsideration:
 
     def desired_velocity(self, strategy: AlgorithmicMovement, fish: Fish) -> Velocity | None:
         return strategy._get_policy_override_velocity(fish)
-
-
-class BallPursuitConsideration:
-    """Soccer-ball pursuit for fish with surplus energy."""
-
-    name = "ball_pursuit"
-
-    def desired_velocity(self, strategy: AlgorithmicMovement, fish: Fish) -> Velocity | None:
-        return strategy._get_ball_pursuit_velocity(fish)
 
 
 class CodePolicyConsideration:

--- a/core/movement_strategy.py
+++ b/core/movement_strategy.py
@@ -19,7 +19,6 @@ from core.policies.interfaces import build_movement_observation
 if TYPE_CHECKING:
     from core.entities import Fish
 
-from core.actions.action_registry import translate_action
 from core.movement.considerations import MovementArbiter, default_considerations
 
 logger = logging.getLogger(__name__)
@@ -33,6 +32,21 @@ ALGORITHMIC_MAX_SPEED_MULTIPLIER = 1.0  # Cap at base speed (was 0.6)
 ALGORITHMIC_MAX_SPEED_MULTIPLIER_SQ = (
     ALGORITHMIC_MAX_SPEED_MULTIPLIER * ALGORITHMIC_MAX_SPEED_MULTIPLIER
 )
+
+# Kinematic action bound for tank-like worlds, mirroring
+# TankLikeActionTranslator(max_velocity=5.0). The internal movement path clamps
+# inline rather than round-tripping every fish every frame through the
+# external-brain action-translation registry, which only re-applied this same
+# clamp while allocating an Action object. The translation layer is still the
+# correct seam for *external* brains; it is just not needed on the internal
+# composable-behavior path. See ADR-007 (silent-fallback removal).
+MAX_ACTION_VELOCITY = 5.0
+
+
+def _clamp_action_velocity(value: float) -> float:
+    """Clamp one velocity component to the kinematic action bound."""
+    return max(-MAX_ACTION_VELOCITY, min(MAX_ACTION_VELOCITY, value))
+
 
 VelocityComponents = tuple[float, float]
 
@@ -126,26 +140,13 @@ class AlgorithmicMovement(MovementStrategy):
             super().move(sprite_entity)
             return
 
-        # =========================================================================
-        # CONTRACT ENFORCEMENT
-        # =========================================================================
-        # Convert raw decision (velocity) to canonical Action via Registry
-        # This ensures all behaviors go through the standard translation layer.
-
-        world_type = getattr(sprite_entity.environment, "world_type", None) or "tank"
-
-        # Translate to standardized Action
-        # Note: desired_velocity is a tuple (vx, vy); the world's registered
-        # translator (e.g. TankActionTranslator) converts it to a canonical Action.
-        try:
-            action = translate_action(
-                world_type, str(getattr(sprite_entity, "fish_id", "unknown")), desired_velocity
-            )
-            # Use the translated velocity from the Action object
-            desired_vx, desired_vy = action.target_velocity
-        except Exception:
-            # Fallback if translation fails (should not happen with defaults)
-            desired_vx, desired_vy = desired_velocity
+        # Clamp the desired velocity to the kinematic action bound, then scale by
+        # speed below. This is the internal fast path: on the composable-behavior
+        # path the external-brain action-translation registry only re-applied this
+        # same clamp (allocating an Action per fish per frame), so it is bypassed
+        # here. External brains still translate through core.actions.
+        desired_vx = _clamp_action_velocity(float(desired_velocity[0]))
+        desired_vy = _clamp_action_velocity(float(desired_velocity[1]))
 
         # Apply algorithm decision - scale by speed to get actual velocity
         speed = sprite_entity.speed
@@ -273,84 +274,3 @@ class AlgorithmicMovement(MovementStrategy):
             dt=env_dt,
             frame=fish_frame,
         )
-
-    def _get_ball_pursuit_velocity(self, fish: Fish) -> VelocityComponents | None:
-        """Check if fish should pursue the soccer ball.
-
-        Only fish with an energy surplus play ball. Hungry fish skip the
-        ball entirely so the composable behavior's food pursuit can run.
-
-        The previous version *increased* ball interest with hunger (up to
-        80% per frame for starving fish). Because ball pursuit pre-empts
-        food seeking, the whole population converged on the ball at tank
-        center and starved next to uneaten food (98% starvation deaths).
-
-        Returns:
-            Velocity toward ball if pursuing, None otherwise
-        """
-        import math
-
-        from core.entities.ball import Ball
-
-        # Prefer the primary ball reference provided by the environment
-        ball = getattr(fish.environment, "ball", None)
-        if ball is None:
-            agents = getattr(fish.environment, "agents", None)
-            if agents:
-                for entity in agents:
-                    if isinstance(entity, Ball):
-                        ball = entity
-                        break
-
-        if ball is None:
-            return None  # No ball = no soccer
-
-        # Ball play is only worthwhile once a fish is genuinely topped up.
-        # Reproduction is funded by energy banked *above* max_energy (overflow),
-        # so a fish anywhere below max is still climbing toward its next birth -
-        # diverting it to the ball burns the very energy that would fund offspring.
-        # The previous gate let merely-"safe" fish (>40% energy) play, taxing the
-        # exact population that should be breeding. Gate on near-max energy so only
-        # fish at the overflow boundary spend the genuine surplus on play.
-        PLAY_ENERGY_THRESHOLD_RATIO = 0.90
-        max_energy = getattr(fish, "max_energy", 100.0)
-        current_energy = getattr(fish, "energy", max_energy)
-        energy_ratio = current_energy / max_energy if max_energy > 0 else 1.0
-
-        if energy_ratio <= PLAY_ENERGY_THRESHOLD_RATIO:
-            return None  # Still building toward reproduction: forage, don't play
-
-        # Cap kept low: surplus energy banked via overflow funds reproduction,
-        # so heavy ball play by full-energy fish directly suppresses births.
-        surplus = (energy_ratio - PLAY_ENERGY_THRESHOLD_RATIO) / (1.0 - PLAY_ENERGY_THRESHOLD_RATIO)
-        pursuit_prob = 0.25 * surplus  # 0% at play threshold -> 25% at full energy
-
-        rng = fish.environment.rng
-        if rng.random() > pursuit_prob:
-            return None
-
-        # Survival outranks leisure: even a topped-up fish that rolled "play"
-        # yields the ball to flee a predator or chase nearby food (ADR-010).
-        # Checked AFTER the RNG draw above so the random stream is identical to
-        # when ball pursuit had top priority - only the *outcome* changes, and
-        # only for the few fish that both rolled play and have a survival drive.
-        behavior = (
-            fish.genome.behavioral.behavior.value if fish.genome.behavioral.behavior else None
-        )
-        if behavior is not None and behavior.has_survival_priority(fish):
-            return None
-
-        # Calculate direction to ball
-        dx = ball.pos.x - fish.pos.x
-        dy = ball.pos.y - fish.pos.y
-        dist = math.sqrt(dx * dx + dy * dy)
-
-        if dist < 10:  # Already at ball
-            return None
-
-        # Normalize and scale to fish's max speed
-        max_speed = getattr(fish, "max_speed", 2.0)
-        vx = (dx / dist) * max_speed
-        vy = (dy / dist) * max_speed
-
-        return (vx, vy)

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -69,6 +69,9 @@ the code, 2026-06):
 | Benchmark diversity metric made cross-process deterministic (was: process-randomized `hash(str)`) | `core/util/stable_hash.py` adds `stable_algorithm_id` (CRC32); `genetic_diversity_tracker` now counts `behavior_id` strings directly (deterministic + collision-free), and `enhanced_statistics`/`poker_adapter` use the stable id. `ecosystem_health_10k` now scores identically across separate processes; both tank champions still reproduce (`validate_reproduction` passes), so no re-baseline was needed. `tests/test_stable_hash.py` (incl. a subprocess cross-process check) guards it. ADR-014. The four telemetry `algorithm_id` sites were deliberately left for the separate keying fix — now done in ADR-015 |
 | Per-algorithm stats re-keyed to the composable `behavior_id` (was: registration by legacy `ALL_ALGORITHMS` enumerate-index vs telemetry by `behavior_id` hash → counters never recorded, names always "Unknown") | Registration (`population_tracker._init_algorithm_stats`) and the 5 telemetry sites now both derive the key from `behavior_id` via `stable_algorithm_id`; `ComposableBehavior.all_behavior_ids()` enumerates the 384-combo key space. End-to-end: a seed-42 run now records births/deaths/reproductions across ~91 behaviors with real names (was ~0 / "Unknown"). Telemetry-only — champions still reproduce. `tests/test_algorithm_tracking.py` rewritten to cover the shared id space. ADR-015 |
 | Poker-benchmark fish selection fixed (was: silent no-op) | `periodic_benchmark` and `comprehensive_benchmark` ranked fish by `f.components.poker_stats.total_winnings` — a field that exists on neither `AgentComponents` nor `FishPokerStats` — so the sort key was always 0 and "top fish" = input order. Now rank by `fish.poker_stats.get_net_energy()` (won − lost − house cuts; `None` until the fish plays). `tests/test_poker_benchmark_selection.py` proves the ordering. Item 5 |
+| Ball drive lifted out of generic movement (ADR-010 follow-through) | `_get_ball_pursuit_velocity` removed from `core/movement_strategy.py` (the generic strategy no longer imports `core.entities.ball.Ball` or carries any soccer concept). The drive is now the self-contained `BallPursuitConsideration` + `ball_pursuit_velocity()` in `core/movement/ball_pursuit.py`, owning its own energy gate and survival-yield (the "self-contained Consideration" ADR-010 designed). Byte-identical seed-42 30k. Residual (full relocation to `core/minigames/soccer` via IoC registration) tracked in Open item 5 |
+| Internal movement path no longer round-trips the external-brain action layer | `AlgorithmicMovement.move()` clamped each fish's desired velocity inline (`MAX_ACTION_VELOCITY`) instead of allocating an `Action` per fish per frame via `translate_action` wrapped in a bare `except Exception`. The translation registry (`core/actions`) remains the seam for *external* brains; it was never needed on the internal composable-behavior path, where it only re-applied the same ±5.0 clamp. Removes the silent-fallback ADR-007 flagged at `movement_strategy.py`. Byte-identical seed-42 30k; `tests/core/test_movement_actions.py` rewritten to assert the inline-clamp contract |
+| `getattr` lies removed from ball pursuit | `getattr(fish, "max_speed", 2.0)` (Fish has **no** `max_speed`; only `Food`/`Ball` do — the default always fired) → explicit `BALL_PURSUIT_TARGET_SPEED`; `getattr(fish, "energy"/"max_energy", …)` (Fish is an `EnergyHolder`, always has them) → direct access. Genuinely-optional `environment.ball` access *kept* as `getattr` — the point is to distinguish optional from guaranteed, not to ban the tool |
 
 ## Open items
 
@@ -134,6 +137,40 @@ Aliased imports (`Fish as FishClass`) stay as runtime aliases alongside the
 type-only `Fish`. Determinism was reconfirmed by a seed-42 headless before/after
 diff (identical simulation state). ~199 cycle-safe in-function imports remain
 across the rest of `core/`. Still incremental, still test-backed.
+
+### 5. Defensive access erodes the protocol layer (new, systemic, opportunistic)
+`core/` (excl. tests) carries ~354 `getattr`, ~193 `hasattr`, and ~60 bare
+`except`. The protocol layer (`core/interfaces.py`) exists precisely so callers
+*don't* probe for attributes — yet much code routes around it with
+`getattr(x, "field", default)`, which converts a loud `AttributeError` (fixed in
+minutes) into a silent wrong value (found, if ever, after a 30k-frame
+archaeology dig). The `getattr(fish, "max_speed", 2.0)` bug (Open-item-4 sibling,
+now fixed) is the archetype: the attribute never existed, the default was
+load-bearing, and a downstream clamp hid the consequence — invisible until two
+layers change.
+
+Treat this exactly like the in-function import debt (item 4): **opportunistic,
+test-backed, no big-bang.** When you touch a module, replace
+protocol-guaranteed `getattr`/`hasattr` with direct access and let it fail loud;
+keep `getattr` only for *genuinely optional/foreign* attributes (e.g.
+`environment.ball`, which may not exist). A good first sweep is the rest of
+`core/movement_strategy.py` and the `Fish.__init__` config-defaulting chain
+(`getattr(environment, "simulation_config", None)` → `…soccer` → `…enabled`),
+which also mixes construction with save-migration self-healing — extract that to
+a `Genome.normalize()` invoked at load time (SRP: a constructor should
+construct).
+
+### 6. Movement-consideration IoC (deferred, enables full ADR-011 compliance)
+`default_considerations()` (generic `core/movement`) still *names* the ball
+drive. The clean form is registration: the tank/soccer pack inserts its
+considerations into the arbiter, so the generic factory lists only generic
+drives and a new minigame touches zero generic code. Blocked on a small seam —
+`AlgorithmicMovement` is constructed arg-less in 4 sites (`entity_factory`,
+`reproduction_service`, `entity_transfer`, `backend/runner/commands/fish`), so
+the arbiter has no pack/config access today. Determinism note: ball pursuit is a
+no-op (returns `None` *before* any RNG draw) when no ball is present, so adding
+it conditionally is RNG-neutral — the migration can be byte-identical. See
+ADR-010 follow-up and ADR-011.
 
 ## Design principles to maintain
 

--- a/docs/adr/010-movement-arbitration.md
+++ b/docs/adr/010-movement-arbitration.md
@@ -243,6 +243,35 @@ perturbation (yield-after-draw) over the "cleaner-looking" one that reshuffles
 evaluation order. Correctness of intent is necessary but not sufficient; the
 seed-stability of the measurement is part of the design.
 
+## Follow-up: ball drive made a self-contained consideration (shipped)
+
+The Decision called for "each drive a self-contained `Consideration` that knows
+its own activation condition and desired velocity," but step 1 left the ball
+logic as `AlgorithmicMovement._get_ball_pursuit_velocity` — a private method on
+the *generic* movement strategy that imported `core.entities.ball.Ball`. The
+`BallPursuitConsideration` was a hollow shim delegating back into it, so the
+generic strategy still named a minigame entity (the ADR-011 leak).
+
+That logic now lives in `core/movement/ball_pursuit.py` as the consideration
+itself: `ball_pursuit_velocity(fish)` plus a `BallPursuitConsideration` that
+owns the energy gate and survival-yield. `core/movement_strategy.py` no longer
+imports `Ball` or carries any soccer concept; the arbiter's list *names* the
+drive but does not *implement* it. The same pass removed two `getattr` lies in
+the moved code — `getattr(fish, "max_speed", 2.0)` (Fish has no `max_speed`, so
+it always returned the default) became the explicit `BALL_PURSUIT_TARGET_SPEED`,
+and `getattr(fish, "energy"/"max_energy", …)` became direct attribute access
+(Fish is an `EnergyHolder`). Verified byte-identical: seed-42 30k-frame headless
+run, all behavioral/stat fields match.
+
+**Honest residual:** the module lives in `core/movement` (generic), not
+`core/minigames/soccer`. Ball pursuit is a *tank-world default* drive
+(`tank_practice_enabled` defaults True even with soccer off), not a soccer-only
+plugin, and the soccer package `__init__` eagerly imports the whole subsystem —
+so importing it from generic movement would pull soccer into every tank run. A
+full relocation needs inversion of control (the world/pack *registers* its
+considerations into the arbiter instead of the generic factory naming them);
+deferred until that seam exists. Tracked in `docs/ARCHITECTURE_REVIEW.md`.
+
 ## Related
 - [ADR-003: Phase-Based Execution](003-phase-based-execution.md)
 - [ADR-007: Error-Handling Strategy](007-error-handling-strategy.md)

--- a/tests/core/test_movement_actions.py
+++ b/tests/core/test_movement_actions.py
@@ -1,10 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from core.brains.contracts import BrainAction
 from core.math_utils import Vector2
-
-Action = BrainAction
 
 
 class TestMovementActions(unittest.TestCase):
@@ -29,57 +26,33 @@ class TestMovementActions(unittest.TestCase):
         self.strategy = AlgorithmicMovement()
 
     @patch("core.movement_strategy.build_movement_observation")
-    @patch("core.movement_strategy.translate_action")
-    def test_move_uses_action_registry(self, mock_translate, mock_build_obs):
-        # Mock observation builder to return empty dict
+    def test_move_applies_desired_velocity(self, mock_build_obs):
+        # The internal movement path uses the arbiter's desired velocity directly
+        # (scaled by speed, then smoothed) - no external-brain action round-trip.
         mock_build_obs.return_value = {}
 
-        # Setup: Force a specific raw decision via movement_policy override
-        desired_raw = (1.0, 0.5)
-        self.fish.movement_policy = MagicMock(return_value=desired_raw)
+        # Force a specific desired decision via the movement_policy override drive.
+        self.fish.movement_policy = MagicMock(return_value=(1.0, 0.5))
 
-        # Setup: Mock translate_action to return a DIFFERENT action
-        # This proves the system is using the translated action, not the raw one
-        translated_velocity = (0.0, 1.0)  # Different from raw
-        mock_action = Action(entity_id="123", target_velocity=translated_velocity)
-        mock_translate.return_value = mock_action
-
-        # Act
         self.strategy.move(self.fish)
 
-        # Assert: Registry was called correctly
-        mock_translate.assert_called_once()
-        args, _ = mock_translate.call_args
-        self.assertEqual(args[0], "tank")  # World type
-        self.assertEqual(args[1], "123")  # Fish ID string
-        self.assertEqual(args[2], desired_raw)  # Raw decision passed through
-
-        # Assert: Fish velocity reflects the TRANSLATED action
-        # Note: AlgorithmicMovement applies smoothing, but target should push velocity towards (0, 1)
-        # Initial vel is (0,0), target is (0, 2.0) [0.0*speed, 1.0*speed]
-        # Smoothing is 0.1. So new vel should be approx (0, 0.2)
-        # vel.y += (2.0 - 0) * 0.1 = 0.2
-
-        self.assertAlmostEqual(self.fish.vel.x, 0.0)
-        self.assertAlmostEqual(self.fish.vel.y, 0.2)
+        # target = (1.0*speed, 0.5*speed) = (2.0, 1.0); smoothing 0.1 from vel (0,0):
+        # vel.x += (2.0 - 0) * 0.1 = 0.2; vel.y += (1.0 - 0) * 0.1 = 0.1
+        self.assertAlmostEqual(self.fish.vel.x, 0.2)
+        self.assertAlmostEqual(self.fish.vel.y, 0.1)
 
     @patch("core.movement_strategy.build_movement_observation")
-    @patch("core.movement_strategy.translate_action")
-    def test_fallback_on_translation_failure(self, mock_translate, mock_build_obs):
-        # Mock observation
+    def test_move_clamps_desired_velocity_to_action_bound(self, mock_build_obs):
+        # A desired component beyond MAX_ACTION_VELOCITY (5.0) is clamped inline
+        # before being scaled by speed - the clamp the action translator used to
+        # apply, now applied directly without allocating an Action per frame.
         mock_build_obs.return_value = {}
 
-        # Setup: Force raw decision
-        desired_raw = (1.0, 0.0)
-        self.fish.movement_policy = MagicMock(return_value=desired_raw)
+        self.fish.movement_policy = MagicMock(return_value=(10.0, 0.0))
 
-        # Setup: Make translation fail
-        mock_translate.side_effect = Exception("Registry error")
-
-        # Act
         self.strategy.move(self.fish)
 
-        # Assert: Should fall back to raw decision
-        # target_vx = 1.0 * 2.0 = 2.0
-        # vel.x += (2.0 - 0) * 0.1 = 0.2
-        self.assertAlmostEqual(self.fish.vel.x, 0.2)
+        # Clamp 10.0 -> 5.0; target_vx = 5.0 * 2.0 = 10.0; vel.x += 10.0 * 0.1 = 1.0
+        # (Unclamped this would be 2.0, so the assertion distinguishes the clamp.)
+        self.assertAlmostEqual(self.fish.vel.x, 1.0)
+        self.assertAlmostEqual(self.fish.vel.y, 0.0)

--- a/tests/test_movement_strategy.py
+++ b/tests/test_movement_strategy.py
@@ -4,6 +4,7 @@ from core.entities import Fish, Food
 from core.entities.ball import Ball
 from core.genetics import Genome
 from core.math_utils import Vector2
+from core.movement.ball_pursuit import ball_pursuit_velocity
 from core.movement_strategy import AlgorithmicMovement, MovementStrategy
 
 
@@ -130,7 +131,7 @@ class TestAlgorithmicMovement:
 
         env._rng = FixedRng()
 
-        velocity = strategy._get_ball_pursuit_velocity(fish)
+        velocity = ball_pursuit_velocity(fish)
 
         assert velocity is not None
 
@@ -155,11 +156,11 @@ class TestAlgorithmicMovement:
 
         # No survival drive -> fish pursues the ball.
         behavior.has_survival_priority = lambda f: False
-        assert strategy._get_ball_pursuit_velocity(fish) is not None
+        assert ball_pursuit_velocity(fish) is not None
 
         # Survival drive active -> fish yields the ball even though it rolled play.
         behavior.has_survival_priority = lambda f: True
-        assert strategy._get_ball_pursuit_velocity(fish) is None
+        assert ball_pursuit_velocity(fish) is None
 
     def test_isolated_full_fish_has_no_survival_priority(self, simulation_env):
         """A full fish with no predator or reachable food has no survival drive,


### PR DESCRIPTION
## Summary

Three **behavior-neutral** structural fixes that came out of an architecture review focused on *correct abstractions* and *fewer bugs as we extend*. Each is verified **byte-identical** on a seed-42 30k-frame headless run (all behavioral/stat fields match to full float precision; only wall-clock fields differ).

### 1. Ball drive lifted out of generic movement (finishes ADR-010 / ADR-011)
`_get_ball_pursuit_velocity` is removed from `core/movement_strategy.py`, which no longer imports `core.entities.ball.Ball` or carries any soccer concept. The drive is now the self-contained `BallPursuitConsideration` + `ball_pursuit_velocity()` in `core/movement/ball_pursuit.py`, owning its own energy gate and survival-yield — the "self-contained Consideration" ADR-010 designed. The previous `BallPursuitConsideration` was a hollow shim delegating right back into the generic strategy, so the generic core still *named* a minigame entity (the ADR-011 leak).

### 2. Internal movement path no longer round-trips the external-brain action layer
`AlgorithmicMovement.move()` clamps each fish's desired velocity inline (`MAX_ACTION_VELOCITY`) instead of allocating an `Action` per fish per frame via `translate_action` wrapped in a bare `except Exception`. The `core.actions` registry stays the correct seam for *external* brains; on the internal composable-behavior path it only re-applied the same ±5.0 clamp. Removes the silent fallback ADR-007 flagged at this site.

### 3. `getattr` lies removed from the ball drive
- `getattr(fish, "max_speed", 2.0)` read a **non-existent** attribute (Fish has no `max_speed`; only `Food`/`Ball` do), so the default always fired → now the explicit `BALL_PURSUIT_TARGET_SPEED`.
- `getattr(fish, "energy"/"max_energy", …)` → direct access (Fish is an `EnergyHolder`).
- Genuinely-optional `environment.ball` access **kept** as `getattr` — the goal is to distinguish optional from guaranteed, not to ban the tool.

## Verification
- **Determinism:** seed-42 30k-frame headless run byte-identical (e.g. `total_births=2497`, `max_generation=60`, `total_energy` to full precision). Reproduce: `python main.py --headless --max-frames 30000 --export-stats out.json --seed 42`
- **Tests:** agent gate green (577 tests, incl. architecture / import-boundary / protocol-conformance suites). `tests/core/test_movement_actions.py` rewritten to assert the inline-clamp contract; `tests/test_movement_strategy.py` calls `ball_pursuit_velocity()` directly.
- Net **−37 LOC** (`movement_strategy.py` shed ~124 lines of churn).

## Honest residual (tracked, not hidden)
The ball module lives in `core/movement/` (generic), **not** `core/minigames/soccer/`, because (a) the soccer package `__init__` eagerly imports the whole subsystem — importing it from generic movement would pull soccer into every tank run (verified: a plain tank run loads zero soccer modules today), and (b) ball pursuit is actually a *tank-world default* drive (`tank_practice_enabled` defaults True even with soccer off), not a soccer-only plugin. The complete fix is inversion of control (the world/pack *registers* its considerations into the arbiter); deferred until that seam exists. Captured in `docs/ARCHITECTURE_REVIEW.md` Open item 6 and the ADR-010 follow-up.

## Docs
ADR-010 follow-up section; `docs/ARCHITECTURE_REVIEW.md` updated with 3 completed items and 2 new open items (5: defensive-access cleanup; 6: movement-consideration IoC) — closing the doc-vs-code drift the review flagged rather than adding to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsi5KmhgX7TfAoXXozPXsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hsi5KmhgX7TfAoXXozPXsn)_