### PR TITLE
[codex] Fix poker autopilot response routing

### DIFF
--- a/backend/routers/websocket.py
+++ b/backend/routers/websocket.py
@@ -84,10 +84,13 @@ async def _handle_websocket_for_adapter(
                         data = orjson.loads(text)
                         command = data.get("command")
                         command_data = data.get("data")
+                        request_id = data.get("request_id")
 
                         if command and hasattr(adapter, "handle_command_async"):
                             result = await adapter.handle_command_async(command, command_data)
                             if result is not None:
+                                if request_id is not None and isinstance(result, dict):
+                                    result = {**result, "request_id": request_id}
                                 response = orjson.dumps(result)
                                 await websocket.send_bytes(response)
                     except Exception as e:

--- a/frontend/src/components/poker/PokerPlayer.module.css
+++ b/frontend/src/components/poker/PokerPlayer.module.css
@@ -128,13 +128,15 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 8px 12px;
+    padding: 8px 82px 8px 12px;
     background: transparent;
     border-radius: 8px;
     border: 1px solid rgba(255, 255, 255, 0.15);
     transition: all 0.3s ease;
     width: 320px;
     flex-shrink: 0;
+    position: relative;
+    box-sizing: border-box;
 }
 
 .humanPlayer.humanActive {
@@ -154,7 +156,7 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    width: 140px;
+    width: auto;
     flex-shrink: 0;
 }
 
@@ -173,6 +175,9 @@
 }
 
 .currentBet {
+    position: absolute;
+    right: 12px;
+    bottom: 12px;
     color: #fbbf24;
     font-weight: bold;
     font-size: 11px;
@@ -182,6 +187,12 @@
     padding: 2px 6px;
     border-radius: 4px;
     border: 1px solid rgba(251, 191, 36, 0.3);
+}
+
+.humanPlayer .betHidden {
+    position: absolute;
+    right: 12px;
+    bottom: 12px;
 }
 
 .yourCards {

--- a/frontend/src/components/tank_tabs/TankPokerTab.tsx
+++ b/frontend/src/components/tank_tabs/TankPokerTab.tsx
@@ -45,13 +45,31 @@ export function TankPokerTab({
     const [pokerLoading, setPokerLoading] = useState(false);
     const [pokerError, setPokerError] = useState<string | null>(null);
     const [restartCountdown, setRestartCountdown] = useState<number | null>(null);
+    const hasStartedRef = useRef(false);
 
-    const handlePokerError = (message: string, error?: unknown) => {
+    const handlePokerError = useCallback((message: string, error?: unknown) => {
         const errorDetail = error instanceof Error ? error.message : String(error ?? '');
         const fullMessage = errorDetail ? `${message}: ${errorDetail}` : message;
         setPokerError(fullMessage);
         setTimeout(() => setPokerError(null), 5000);
-    };
+    }, []);
+
+    const clearInactivePokerGame = useCallback(() => {
+        setPokerGameState(null);
+        setShowPokerGame(false);
+        hasStartedRef.current = false;
+    }, []);
+
+    const handleInactivePokerResponse = useCallback((response: PokerCommandResponse): boolean => {
+        if (response.success !== false) {
+            return false;
+        }
+        if (!response.error?.toLowerCase().includes('no poker game active')) {
+            return false;
+        }
+        clearInactivePokerGame();
+        return true;
+    }, [clearInactivePokerGame]);
 
     // Process AI turns one at a time with delay for visual feedback
     const processAiTurnsWithDelay = useCallback(async () => {
@@ -66,6 +84,10 @@ export function TankPokerTab({
                     data: {},
                 });
 
+                if (handleInactivePokerResponse(response)) {
+                    return;
+                }
+
                 if (response.state) {
                     setPokerGameState(response.state);
                 }
@@ -79,7 +101,7 @@ export function TankPokerTab({
         };
 
         await processNextAiTurn();
-    }, [sendCommandWithResponse]);
+    }, [sendCommandWithResponse, handleInactivePokerResponse, handlePokerError]);
 
     const handleStartPoker = useCallback(async () => {
         try {
@@ -92,8 +114,7 @@ export function TankPokerTab({
             if (response.success === false) {
                 console.warn("Failed to auto-start poker:", response.error);
                 handlePokerError('Failed to start poker game', response.error);
-                setPokerGameState(null);
-                setShowPokerGame(false);
+                clearInactivePokerGame();
             } else if (response.state) {
                 setPokerGameState(response.state);
                 if (!response.state.is_your_turn && !response.state.game_over) {
@@ -101,8 +122,7 @@ export function TankPokerTab({
                 }
             } else {
                 handlePokerError('Failed to start poker game', 'No game state returned');
-                setPokerGameState(null);
-                setShowPokerGame(false);
+                clearInactivePokerGame();
             }
         } catch (error) {
             // Suppress ghost-mount errors in StrictMode and allow retry
@@ -111,12 +131,12 @@ export function TankPokerTab({
                 setShowPokerGame(false);
             } else {
                 handlePokerError('Failed to start poker game', error);
-                setShowPokerGame(false);
+                clearInactivePokerGame();
             }
         } finally {
             setPokerLoading(false);
         }
-    }, [sendCommandWithResponse, processAiTurnsWithDelay]);
+    }, [sendCommandWithResponse, processAiTurnsWithDelay, clearInactivePokerGame, handlePokerError]);
 
     // Auto-restart game when session ends
     useEffect(() => {
@@ -152,7 +172,6 @@ export function TankPokerTab({
     }, [showPokerGame, pokerGameState?.session_over, handleStartPoker]);
 
     // Effect to start game once connected
-    const hasStartedRef = useRef(false);
     useEffect(() => {
         if (isConnected && !hasStartedRef.current && !pokerGameState && !pokerLoading) {
             hasStartedRef.current = true;
@@ -160,7 +179,7 @@ export function TankPokerTab({
         }
     }, [isConnected, pokerGameState, pokerLoading, handleStartPoker]);
 
-    const handlePokerAction = async (action: string, amount?: number) => {
+    const handlePokerAction = useCallback(async (action: string, amount?: number) => {
         try {
             setPokerLoading(true);
             const response = await sendCommandWithResponse({
@@ -168,6 +187,9 @@ export function TankPokerTab({
                 data: { action, amount: amount || 0 },
             });
             if (response.success === false) {
+                if (handleInactivePokerResponse(response)) {
+                    return;
+                }
                 handlePokerError(response.error || 'Invalid action');
             } else if (response.state) {
                 setPokerGameState(response.state);
@@ -178,14 +200,14 @@ export function TankPokerTab({
         } finally {
             setPokerLoading(false);
         }
-    };
+    }, [sendCommandWithResponse, processAiTurnsWithDelay, handleInactivePokerResponse, handlePokerError]);
 
-    const handleClosePoker = () => {
+    const handleClosePoker = useCallback(() => {
         setShowPokerGame(false);
         setPokerGameState(null);
-    };
+    }, []);
 
-    const handleNewRound = async () => {
+    const handleNewRound = useCallback(async () => {
         try {
             setPokerLoading(true);
             const response = await sendCommandWithResponse({
@@ -193,6 +215,9 @@ export function TankPokerTab({
                 data: {},
             });
             if (response.success === false) {
+                if (handleInactivePokerResponse(response)) {
+                    return;
+                }
                 handlePokerError(response.error || 'Failed to start new round');
             } else if (response.state) {
                 setPokerGameState(response.state);
@@ -205,19 +230,20 @@ export function TankPokerTab({
         } finally {
             setPokerLoading(false);
         }
-    };
+    }, [sendCommandWithResponse, processAiTurnsWithDelay, handleInactivePokerResponse, handlePokerError]);
 
-    const handleGetAutopilotAction = async () => {
+    const handleGetAutopilotAction = useCallback(async () => {
         const response = await sendCommandWithResponse({
             command: 'poker_autopilot_action',
             data: {},
         });
+        handleInactivePokerResponse(response);
         return {
             success: response.success,
             action: response.action ?? 'wait',
             amount: response.amount ?? 0,
         };
-    };
+    }, [sendCommandWithResponse, handleInactivePokerResponse]);
 
     return (
         <div className={styles.pokerTab}>

--- a/frontend/src/hooks/useWebSocket.test.ts
+++ b/frontend/src/hooks/useWebSocket.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { SimulationUpdate, StatsData } from '../types/simulation';
-import { applyFullUpdate } from './useWebSocket';
+import { applyFullUpdate, routeCommandResponse } from './useWebSocket';
 
 /**
  * Pure function to normalize a WorldUpdatePayload into SimulationUpdate format.
@@ -184,4 +184,33 @@ describe('WebSocket Update Normalization', () => {
         expect(result.metrics_history).toBe(history);
     });
 
+});
+
+describe('Command response routing', () => {
+    it('routes request-id responses only to the matching pending command', () => {
+        const calls: string[] = [];
+        const callbacks = new Map<string, (data: { success: boolean; request_id?: string }) => void>([
+            ['start', () => calls.push('start')],
+            ['autopilot', () => calls.push('autopilot')],
+        ]);
+
+        routeCommandResponse(callbacks, { success: false, request_id: 'autopilot' });
+
+        expect(calls).toEqual(['autopilot']);
+        expect(callbacks.has('start')).toBe(true);
+        expect(callbacks.has('autopilot')).toBe(false);
+    });
+
+    it('keeps legacy uncorrelated responses working as a fallback', () => {
+        const calls: string[] = [];
+        const callbacks = new Map<string, (data: { success: boolean; request_id?: string }) => void>([
+            ['first', () => calls.push('first')],
+            ['second', () => calls.push('second')],
+        ]);
+
+        routeCommandResponse(callbacks, { success: true });
+
+        expect(calls).toEqual(['first', 'second']);
+        expect(callbacks.size).toBe(0);
+    });
 });

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -131,10 +131,8 @@ export function useWebSocket(worldId?: string) {
                     } else if (data.type === 'delta') {
                         setState((current) => (current ? applyDelta(current, data as DeltaUpdate) : current));
                     } else if (data.success !== undefined || data.state !== undefined || data.error !== undefined) {
-                        // This is a command response (e.g., poker game state)
-                        // Call any pending callbacks
-                        responseCallbacksRef.current.forEach((callback) => callback(data));
-                        responseCallbacksRef.current.clear();
+                        // This is a command response (e.g., poker game state).
+                        routeCommandResponse(responseCallbacksRef.current, data);
                     }
                 } catch (error) {
                     console.error('WebSocket message parse error:', error, 'Data:', event.data);
@@ -222,7 +220,8 @@ export function useWebSocket(worldId?: string) {
                     }
                 }, 10000); // 10 second timeout
 
-                wsRef.current.send(JSON.stringify(command));
+                const requestId = callbackId;
+                wsRef.current.send(JSON.stringify({ ...command, request_id: requestId }));
             } else {
                 reject(new Error('WebSocket not connected'));
             }
@@ -242,6 +241,25 @@ export function useWebSocket(worldId?: string) {
         /** Connected world ID (available immediately after connection, before first update) */
         connectedWorldId,
     };
+}
+
+export function routeCommandResponse(
+    callbacks: Map<string, (data: CommandResponse) => void>,
+    data: CommandResponse
+): void {
+    if (data.request_id) {
+        const callback = callbacks.get(data.request_id);
+        if (callback) {
+            callbacks.delete(data.request_id);
+            callback(data);
+        }
+        return;
+    }
+
+    // Backward-compatible fallback for legacy command responses that do not
+    // include request IDs.
+    callbacks.forEach((callback) => callback(data));
+    callbacks.clear();
 }
 
 export function applyFullUpdate(

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -562,6 +562,7 @@ export interface DeltaUpdate {
 }
 
 export interface Command {
+    request_id?: string;
     command:
     | 'add_food'
     | 'spawn_fish'
@@ -695,6 +696,7 @@ export interface AutoEvaluateStats {
 // Command Response Types
 export interface CommandResponse {
     success: boolean;
+    request_id?: string;
     error?: string;
     state?: PokerGameState;
     stats?: AutoEvaluateStats;


### PR DESCRIPTION
## Summary

Fixes the interactive poker stall where the UI could show an active hand while autopilot reports that no poker game is active on the server.

## What Changed

- Added request IDs to WebSocket commands and echoes them from the backend command response path.
- Routes frontend command responses only to the matching pending promise, with a fallback for legacy uncorrelated responses.
- Clears stale poker UI state when the server explicitly reports `No poker game active`.
- Lowers and anchors the human player's bet amount inside the player rectangle so it no longer spills outside the box.
- Adds regression coverage for command response routing.

## Root Cause

Poker can issue overlapping WebSocket commands for AI turn processing, autopilot decisions, player actions, and new rounds. The frontend previously resolved every pending command promise with the first command response received, so one response could be consumed by the wrong poker flow and leave the browser/server game state out of sync.

## Validation

- `npm test -- --run src/components/tank_tabs/TankPokerTab.test.tsx` passed.
- `npm test -- --run` passed, 34 frontend tests.
- `npm run lint` passed.
- `npm run build` passed with the existing Vite chunk-size warning.
- `.\.venv\Scripts\python.exe tools\smoke_gate.py` passed, 33 tests.