### PR TITLE
[codex] Fix plant leaf subpaths

### DIFF
--- a/frontend/src/utils/cleanup.test.ts
+++ b/frontend/src/utils/cleanup.test.ts
@@ -58,11 +58,22 @@ class MockCanvas {
 
 // Mock Path2D
 class MockPath2D {
+    static instances: MockPath2D[] = [];
+    calls: string[] = [];
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    constructor(_path?: string | Path2D) { }
-    moveTo() { }
-    lineTo() { }
-    ellipse() { }
+    constructor(_path?: string | Path2D) {
+        MockPath2D.instances.push(this);
+    }
+    moveTo() {
+        this.calls.push('moveTo');
+    }
+    lineTo() {
+        this.calls.push('lineTo');
+    }
+    ellipse() {
+        this.calls.push('ellipse');
+    }
 }
 
 describe('Memory Cleanup Utilities', () => {
@@ -78,6 +89,7 @@ describe('Memory Cleanup Utilities', () => {
         });
 
         // Clear caches before each test
+        MockPath2D.instances = [];
         clearAvatarPathCache();
         clearAllPlantCaches();
     });
@@ -172,6 +184,20 @@ describe('Memory Cleanup Utilities', () => {
 
             expect(mockContext.stroke).toHaveBeenCalledTimes(10);
             expect(mockContext.fill).toHaveBeenCalledTimes(1);
+        });
+
+        it('starts each cached leaf ellipse as a separate subpath', () => {
+            renderPlant(mockContext, 789, mockGenome, 0, 0, 1, 2, 0);
+
+            const leafPath = MockPath2D.instances.find((path) => path.calls.includes('ellipse'));
+            expect(leafPath).toBeDefined();
+
+            const calls = leafPath!.calls;
+            calls.forEach((call, index) => {
+                if (call === 'ellipse') {
+                    expect(calls[index - 1]).toBe('moveTo');
+                }
+            });
         });
 
         it('should reuse cached spiral nectar paths', () => {

--- a/frontend/src/utils/plant.ts
+++ b/frontend/src/utils/plant.ts
@@ -259,11 +259,17 @@ function createLeafPaths(leaves: FractalLeaf[]): { leafPath?: Path2D; veinPath?:
         const rotation = (leaf.angle * Math.PI) / 180 + Math.PI / 2;
         const centerX = leaf.x + Math.sin(rotation) * leaf.size / 2;
         const centerY = leaf.y - Math.cos(rotation) * leaf.size / 2;
+        const radiusX = leaf.size * 0.4;
+        const radiusY = leaf.size;
+        leafPath.moveTo(
+            centerX + Math.cos(rotation) * radiusX,
+            centerY + Math.sin(rotation) * radiusX
+        );
         leafPath.ellipse(
             centerX,
             centerY,
-            leaf.size * 0.4,
-            leaf.size,
+            radiusX,
+            radiusY,
             rotation,
             0,
             Math.PI * 2
@@ -1266,11 +1272,17 @@ export function renderPlant(
             const rotation = (leaf.angle * Math.PI) / 180 + Math.PI / 2;
             const centerX = leaf.x + Math.sin(rotation) * leaf.size / 2;
             const centerY = leaf.y - Math.cos(rotation) * leaf.size / 2;
+            const radiusX = leaf.size * 0.4;
+            const radiusY = leaf.size;
+            ctx.moveTo(
+                centerX + Math.cos(rotation) * radiusX,
+                centerY + Math.sin(rotation) * radiusX
+            );
             ctx.ellipse(
                 centerX,
                 centerY,
-                leaf.size * 0.4,
-                leaf.size,
+                radiusX,
+                radiusY,
                 rotation,
                 0,
                 Math.PI * 2


### PR DESCRIPTION
## Summary

- Start each rendered plant leaf ellipse with a `moveTo` so leaves are independent subpaths.
- Add cleanup utility coverage that verifies cached leaf ellipses are preceded by `moveTo` calls.

## Why

Canvas ellipses appended to a shared path can be connected by implicit segments when a new subpath is not started first. This keeps plant leaf rendering isolated for both cached `Path2D` rendering and the direct canvas fallback path.

## Validation

- `npm --prefix frontend test -- cleanup.test.ts --run`
- `npm --prefix frontend run lint`