### PR TITLE
Make fast gate exclude expensive simulation tests

### DIFF
--- a/tests/test_ecosystem_poker_records.py
+++ b/tests/test_ecosystem_poker_records.py
@@ -1,4 +1,5 @@
 import math
+import pytest
 
 from core.ecosystem import EcosystemManager
 from core.ecosystem_stats import MixedPokerOutcomeRecord
@@ -50,6 +51,58 @@ def test_poker_win_energy_delta_feeds_reported_fish_poker_source():
     assert math.isclose(ecosystem.get_summary_stats([])["energy_from_poker"], 12.5)
 
 
+def test_fish_poker_game_counter_advances_unit():
+    """Verify that calling handle_poker_result on PokerSystem increments the ecosystem's
+    total_fish_poker_games counter without needing a full 3000-frame simulation.
+    """
+    from core.worlds.registry import WorldRegistry
+    from types import SimpleNamespace
+
+    world = WorldRegistry.create_world("tank", seed=42, config={})
+    world.reset(seed=42, config={})
+    engine = world._engine
+    eco = engine.ecosystem
+    start = eco.total_fish_poker_games
+
+    # Create a minimal PokerInteraction between two fish
+    # Let's get two fish from the engine
+    fish_list = list(engine._entity_manager.get_fish())
+    assert len(fish_list) >= 2, "Need at least two fish to play poker"
+    fish1, fish2 = fish_list[0], fish_list[1]
+
+    # Mock the result of the PokerInteraction
+    mock_result = SimpleNamespace(
+        winner_id=fish1.get_poker_id(),
+        loser_ids=[fish2.get_poker_id()],
+        loser_id=fish2.get_poker_id(),
+        is_tie=False,
+        winner_hand=SimpleNamespace(description="Pair of Aces"),
+        loser_hands=[SimpleNamespace(description="Two Pair")],
+        energy_transferred=5.0,
+        plant_count=0,
+        fish_count=2,
+        winner_type="fish",
+        loser_types=["fish"],
+        reproduction_occurred=False,
+        offspring=None,
+    )
+
+    mock_poker = SimpleNamespace(
+        result=mock_result,
+        players=[fish1, fish2],
+        fish1=fish1,
+        fish2=fish2,
+        hand1=mock_result.winner_hand,
+        hand2=mock_result.loser_hands[0],
+    )
+
+    # Invoke handle_poker_result directly on poker_system
+    engine.poker_system.handle_poker_result(mock_poker)
+
+    assert eco.total_fish_poker_games == start + 1
+
+
+@pytest.mark.slow
 def test_fish_poker_game_counter_advances_in_sim():
     """Regression: fish-vs-fish poker games played but the global counter stayed
     at 0 because handle_poker_result never counted the completed game (its

--- a/tests/test_tank_action_pipeline.py
+++ b/tests/test_tank_action_pipeline.py
@@ -11,8 +11,8 @@ from core.worlds.tank import TankWorldBackendAdapter
 class TestActionPipeline:
     """Integration tests for the action pipeline."""
 
-    def test_200_tick_sanity(self):
-        """Run 200 ticks with seed, verify no crashes and entity count evolves."""
+    def test_50_tick_sanity(self):
+        """Run 50 ticks with seed, verify no crashes and entity count evolves."""
         adapter = TankWorldBackendAdapter(seed=12345)
         result = adapter.reset(seed=12345)
 
@@ -22,14 +22,14 @@ class TestActionPipeline:
         initial_entities = len(adapter.entities_list)
         assert initial_entities > 0, "Should have initial entities"
 
-        # Run 200 ticks
-        for i in range(200):
+        # Run 50 ticks
+        for i in range(50):
             result = adapter.step()
             assert result is not None
             assert result.info["frame"] == i + 1
 
         final_entities = len(adapter.entities_list)
-        assert final_entities > 0, "Should still have entities after 200 ticks"
+        assert final_entities > 0, "Should still have entities after 50 ticks"
 
         # Entity count should change (births/deaths occur)
         # This is a sanity check, not a strict assertion

--- a/tests/test_validation_tiers.py
+++ b/tests/test_validation_tiers.py
@@ -38,3 +38,126 @@ def test_agent_gate_composes_smoke_gate_and_uses_curated_tests():
     assert "_AGENT_CURATED_TESTS" in source
     assert "tests/test_determinism.py" in source
     assert "not slow and not integration and not manual" in source
+
+
+def test_no_unmarked_expensive_simulation_loops():
+    """Ensure that no test function contains a large simulation loop (e.g. range > 100
+    with world.step() or equivalent) unless marked as slow, integration, or manual.
+    """
+    import ast
+
+    tests_dir = ROOT / "tests"
+
+    def get_range_limit(call_node):
+        if not isinstance(call_node, ast.Call):
+            return None
+        if not (isinstance(call_node.func, ast.Name) and call_node.func.id == "range"):
+            return None
+        args = call_node.args
+        stop_node = None
+        if len(args) == 1:
+            stop_node = args[0]
+        elif len(args) in (2, 3):
+            stop_node = args[1]
+
+        if stop_node is not None:
+            if isinstance(stop_node, ast.Constant) and isinstance(stop_node.value, int):
+                return stop_node.value
+        return None
+
+    def has_step_call(body_nodes):
+        for node in body_nodes:
+            for child in ast.walk(node):
+                if isinstance(child, ast.Call):
+                    func = child.func
+                    if (isinstance(func, ast.Attribute) and func.attr == "step") or (
+                        isinstance(func, ast.Name) and func.id == "step"
+                    ):
+                        return True
+        return False
+
+    def has_exclusion_decorator(node):
+        if not hasattr(node, "decorator_list"):
+            return False
+        for dec in node.decorator_list:
+            curr = dec
+            if isinstance(curr, ast.Call):
+                curr = curr.func
+
+            parts = []
+            while isinstance(curr, ast.Attribute):
+                parts.append(curr.attr)
+                curr = curr.value
+            if isinstance(curr, ast.Name):
+                parts.append(curr.id)
+            parts.reverse()
+
+            # Match pytest.mark.slow, pytest.mark.integration, pytest.mark.manual
+            if (
+                len(parts) >= 3
+                and parts[0] == "pytest"
+                and parts[1] == "mark"
+                and parts[2] in ("slow", "integration", "manual")
+            ):
+                return True
+        return False
+
+    def has_module_level_exclusion(tree):
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "pytestmark":
+                        value_str = ast.dump(node.value)
+                        if any(marker in value_str for marker in ("slow", "integration", "manual")):
+                            return True
+        return False
+
+    violations = []
+
+    for path in tests_dir.rglob("test_*.py"):
+        try:
+            content = path.read_text(encoding="utf-8")
+            tree = ast.parse(content)
+        except Exception:
+            continue
+
+        if has_module_level_exclusion(tree):
+            continue
+
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                class_excluded = has_exclusion_decorator(node)
+                for subnode in node.body:
+                    if isinstance(subnode, ast.FunctionDef) and subnode.name.startswith("test_"):
+                        if class_excluded or has_exclusion_decorator(subnode):
+                            continue
+                        for child in ast.walk(subnode):
+                            if isinstance(child, ast.For):
+                                limit = get_range_limit(child.iter)
+                                if limit is not None and limit > 100:
+                                    if has_step_call(child.body):
+                                        violations.append(
+                                            f"File: {path.relative_to(ROOT)}\n"
+                                            f"Test: {node.name}.{subnode.name}\n"
+                                            f"Range limit: {limit} with step() call."
+                                        )
+            elif isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+                if has_exclusion_decorator(node):
+                    continue
+                for child in ast.walk(node):
+                    if isinstance(child, ast.For):
+                        limit = get_range_limit(child.iter)
+                        if limit is not None and limit > 100:
+                            if has_step_call(child.body):
+                                violations.append(
+                                    f"File: {path.relative_to(ROOT)}\n"
+                                    f"Test: {node.name}\n"
+                                    f"Range limit: {limit} with step() call."
+                                )
+
+    if violations:
+        msg = "\n\n".join(violations)
+        raise AssertionError(
+            f"Found unmarked expensive simulation loops in ordinary tests:\n\n{msg}\n\n"
+            f"Please mark these tests with @pytest.mark.slow, @pytest.mark.integration, or @pytest.mark.manual."
+        )


### PR DESCRIPTION
### Description

#### Which test was slow and why:
- `tests/test_ecosystem_poker_records.py::test_fish_poker_game_counter_advances_in_sim` ran a full 3000-frame tank simulation to verify that the global poker counter correctly advances. This resulted in an enormous, unnecessary CPU bottleneck in the fast gate.
- `tests/test_tank_action_pipeline.py::test_200_tick_sanity` ran an unmarked 200-frame loop.

#### Changes Made:
- **Marked Slow**: Decorated `test_fish_poker_game_counter_advances_in_sim` with `@pytest.mark.slow` to correctly move it to the slow/full gate tier.
- **Fast Replacement Added**: Introduced `test_fish_poker_game_counter_advances_unit`. It mocks the completed `PokerInteraction` result and invokes `poker_system.handle_poker_result` directly, testing the integration and increment logic in under 50ms.
- **Reduced Loop Size**: Decreased the range in `test_200_tick_sanity` to 50 frames (renamed to `test_50_tick_sanity`) to stay under validation loop thresholds.
- **Tier Invariant Enforcement**: Added `test_no_unmarked_expensive_simulation_loops` to `tests/test_validation_tiers.py` to statically verify all test files. It flags any ordinary/fast test containing a `range()` loop greater than 100 iterations calling `step()`.

#### Runtime Metrics:
- **`fast_gate.py` (Before)**: 100.86 seconds
- **`fast_gate.py` (After)**: 40.72 seconds (~60s faster, a 60% speedup!)

#### Exact Commands Run and Results:
```powershell
# 1. Run the smoke gate
py tools/smoke_gate.py
# Result: PASS

# 2. Run local agent gate
py tools/agent_gate.py
# Result: PASS

# 3. Run fast gate
py tools/fast_gate.py
# Result: PASS (40.72s)

# 4. Run targeted tests
py -m pytest tests/test_ecosystem_poker_records.py tests/test_validation_tiers.py -q
# Result: 8 passed, 1 deselected in 0.49s

# 5. Verify type correctness
py -m mypy core
py -m mypy tools backend
# Result: Success (no issues found)
```

#### Why this helps ordinary coding agents contribute safely:
Fast feedback loops are crucial for developer and agent velocity. By enforcing clear boundaries between fast unit tests and slow simulation tests, contributors can run `fast_gate.py` locally and in CI with highly reliable, sub-minute execution times. The AST-based enforcement check ensures that the codebase remains fast over time by warning authors immediately if they accidentally introduce an expensive simulation loop without the proper `@pytest.mark.slow` decorator.