### PR TITLE
Architecture hardening (ADR-009…015): reconcile agent model, de-leak minigames, fix determinism, trust typed surfaces

### DIFF
--- a/core/collision_system.py
+++ b/core/collision_system.py
@@ -394,7 +394,7 @@ class CollisionSystem(BaseSystem):
             cause: Optional death cause override
         """
         self._frame_fish_deaths += 1
-        lifecycle_system = getattr(self._engine, "lifecycle_system", None)
+        lifecycle_system = self._engine.lifecycle_system
         if lifecycle_system is not None:
             lifecycle_system.record_fish_death(fish, cause)
 

--- a/core/poker/integration/poker_system.py
+++ b/core/poker/integration/poker_system.py
@@ -94,12 +94,12 @@ class PokerSystem(BaseSystem):
         # poker-rate stats advance. Per-fish FishPokerStats are recorded inside
         # the poker interaction; this aggregate counter was previously never
         # incremented (its recorder, record_poker_outcome, was orphaned).
-        ecosystem = getattr(self._engine, "ecosystem", None)
+        ecosystem = self._engine.ecosystem
         if ecosystem is not None and poker.result is not None:
             ecosystem.record_fish_poker_game()
 
         # Delegate post-poker reproduction to the ReproductionService
-        reproduction_service = getattr(self._engine, "reproduction_service", None)
+        reproduction_service = self._engine.reproduction_service
         if reproduction_service is not None:
             baby = reproduction_service.handle_post_poker_reproduction(poker)
             if baby is not None:
@@ -389,7 +389,7 @@ class PokerSystem(BaseSystem):
                 for player in table.players:
                     if isinstance(player, Fish) and player.is_dead():
                         if player in all_entities_set:
-                            lifecycle_system = getattr(self._engine, "lifecycle_system", None)
+                            lifecycle_system = self._engine.lifecycle_system
                             if lifecycle_system is not None:
                                 lifecycle_system.record_fish_death(player)
                             all_entities_set.discard(player)
@@ -522,9 +522,12 @@ class PokerSystem(BaseSystem):
                     winner_fish = player
                     break
 
-            if winner_fish is not None:
-                # Delegate to ReproductionService
-                reproduction_service = getattr(self._engine, "reproduction_service", None)
+            # winner_type == "fish" guarantees a Fish won; isinstance narrows
+            # fish_players' (Fish | Plant) element type and guards the Fish-only
+            # reproduction path. (Surfaced by mypy once the engine accessor above
+            # stopped being a getattr-typed Any.)
+            if isinstance(winner_fish, Fish):
+                reproduction_service = self._engine.reproduction_service
                 if reproduction_service is not None:
                     reproduction_service.handle_plant_poker_asexual_reproduction(winner_fish)
 

--- a/core/poker/integration/poker_system.py
+++ b/core/poker/integration/poker_system.py
@@ -522,10 +522,7 @@ class PokerSystem(BaseSystem):
                     winner_fish = player
                     break
 
-            # winner_type == "fish" guarantees a Fish won; isinstance narrows
-            # fish_players' (Fish | Plant) element type and guards the Fish-only
-            # reproduction path. (Surfaced by mypy once the engine accessor above
-            # stopped being a getattr-typed Any.)
+            # winner_type=="fish" guarantees a Fish; isinstance also narrows fish_players' Fish|Plant.
             if isinstance(winner_fish, Fish):
                 reproduction_service = self._engine.reproduction_service
                 if reproduction_service is not None:

--- a/core/reproduction/reproduction_service.py
+++ b/core/reproduction/reproduction_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from core.energy.energy_utils import apply_energy_delta
 from core.util.stable_hash import stable_algorithm_id
@@ -193,14 +193,10 @@ class ReproductionService:
         }
 
     def _get_fish_entities(self) -> list[Fish]:
-        entity_manager = getattr(self._engine, "entity_manager", None)
-        get_fish = getattr(entity_manager, "get_fish", None)
-        if callable(get_fish):
-            return cast("list[Fish]", get_fish())
-
-        from core.entities import Fish
-
-        return [e for e in self._engine.get_all_entities() if isinstance(e, Fish)]
+        # engine.entity_manager is a typed property and get_fish() is the canonical
+        # typed fish view; the prior getattr/callable/cast dance guarded a fallback
+        # branch that could never run (get_fish always exists).
+        return self._engine.entity_manager.get_fish()
 
     def _update_cooldowns(self, fish_list: list[Fish]) -> None:
         for fish in fish_list:
@@ -638,9 +634,7 @@ class ReproductionService:
         if composable is not None and composable.value is not None:
             behavior_id = composable.value.behavior_id
             algorithm_id = stable_algorithm_id(behavior_id)
-            emit_event = getattr(fish, "_emit_event", None)
-            if callable(emit_event):
-                emit_event(ReproductionEvent(algorithm_id, is_asexual=True))
+            fish._emit_event(ReproductionEvent(algorithm_id, is_asexual=True))
 
         # Set visual birth effect timer
         fish.visual_state.set_birth_effect(60)

--- a/core/reproduction/reproduction_service.py
+++ b/core/reproduction/reproduction_service.py
@@ -147,7 +147,7 @@ class ReproductionService:
         if required_credits > 0:
             winner._reproduction_component.consume_repro_credits(required_credits)
         baby.register_birth()
-        lifecycle_system = getattr(self._engine, "lifecycle_system", None)
+        lifecycle_system = self._engine.lifecycle_system
         if lifecycle_system is not None:
             lifecycle_system.record_birth()
 
@@ -228,7 +228,7 @@ class ReproductionService:
 
             if self._engine.request_spawn(baby, reason="banked_asexual_reproduction"):
                 baby.register_birth()
-                lifecycle_system = getattr(self._engine, "lifecycle_system", None)
+                lifecycle_system = self._engine.lifecycle_system
                 if lifecycle_system is not None:
                     lifecycle_system.record_birth()
                 if required_credits > 0:
@@ -383,7 +383,7 @@ class ReproductionService:
         )
         new_fish.register_birth()
 
-        lifecycle_system = getattr(self._engine, "lifecycle_system", None)
+        lifecycle_system = self._engine.lifecycle_system
         if lifecycle_system is not None:
             lifecycle_system.record_emergency_spawn()
 
@@ -427,14 +427,12 @@ class ReproductionService:
         return best_fish
 
     def _get_repro_credit_required(self) -> float:
-        config = getattr(self._engine, "config", None)
-        soccer_cfg = getattr(config, "soccer", None) if config is not None else None
-        if soccer_cfg is None or not getattr(soccer_cfg, "enabled", False):
+        # config and config.soccer are always present (typed dataclass fields with
+        # defaults), so read them directly and let mypy guard the field names.
+        soccer_cfg = self._engine.config.soccer
+        if not soccer_cfg.enabled or soccer_cfg.repro_reward_mode != "credits":
             return 0.0
-        if getattr(soccer_cfg, "repro_reward_mode", "") != "credits":
-            return 0.0
-        required = float(getattr(soccer_cfg, "repro_credit_required", 0.0))
-        return max(0.0, required)
+        return max(0.0, soccer_cfg.repro_credit_required)
 
     @staticmethod
     def maybe_create_banked_offspring(fish: Fish) -> Fish | None:

--- a/core/simulation/pipeline.py
+++ b/core/simulation/pipeline.py
@@ -160,7 +160,7 @@ def _step_reproduction(engine: SimulationEngine, ctx: FrameContext) -> None:
 
 def _step_soccer(engine: SimulationEngine, ctx: FrameContext) -> None:
     """SOCCER: Update ball physics and agent-ball interactions."""
-    soccer_system = getattr(engine, "soccer_system", None)
+    soccer_system = engine.soccer_system
     if soccer_system and soccer_system.enabled:
         soccer_system.update(engine.frame_count)
 

--- a/core/systems/poker_proximity.py
+++ b/core/systems/poker_proximity.py
@@ -285,7 +285,7 @@ class PokerProximitySystem(BaseSystem):
                         # Handle deaths from poker
                         for f in sub_group:
                             if f.is_dead():
-                                lifecycle_system = getattr(self._engine, "lifecycle_system", None)
+                                lifecycle_system = self._engine.lifecycle_system
                                 if lifecycle_system is not None:
                                     lifecycle_system.record_fish_death(f)
 

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -45,6 +45,7 @@ the code, 2026-06):
 
 | Item | Evidence |
 |------|----------|
+| Gratuitous distrust of typed engine collaborators removed (Open-item-5 category **b**) | 11 sites across 5 files read declared, typed engine attributes through `getattr(engine, "lifecycle_system"/"reproduction_service"/"ecosystem"/"soccer_system"/"config", None)` — i.e. `getattr`-with-default against attributes the engine *always* has (`engine.py` declares them `… \| None`). Because `getattr` returns `Any`, every downstream call on the result was silently **unchecked**. Replaced with direct typed access in `reproduction/reproduction_service.py` (incl. collapsing the all-defensive `_get_repro_credit_required`: `getattr(config,"soccer")…getattr(cfg,"enabled",False)` → `self._engine.config.soccer.enabled`, all guaranteed typed dataclass fields), `collision_system.py`, `systems/poker_proximity.py`, `poker/integration/poker_system.py`, `simulation/pipeline.py`. **Proof the `Any` was hiding bugs:** restoring the type immediately surfaced a real latent hole — `poker_system` passed `fish_players`' `Fish \| Plant` element into a `Fish`-only reproduction method; fixed with an explicit `isinstance(winner_fish, Fish)` narrow (the `winner_type=="fish"` invariant already guaranteed it). Behavior-neutral: `getattr`-default never fired (attrs always present), the `isinstance` is equivalent to the prior `is not None` under that invariant, zero RNG touched — seed-42 golden-replay byte-identical, `agent_gate` 575 passed, mypy green (323 files, now type-checking these calls). |
 | Dead skill-game framework removed (~2,900 LOC; principle #6) | The generic `SkillGame` framework was a parallel abstraction to the real poker path: `core/poker`/`core/mixed_poker` never imported `core.skills`, no `SystemPack` wired `SkillGameSystem`, and only scripts/tests constructed it. Removed `core/skills/` (RPS, number-guessing, poker_adapter, base, config), `core/skill_game_system.py`, `core/fish/skill_game_component.py`, the `SkillfulAgent` protocol, and the dead `Fish.get_strategy/set_strategy/learn_from_game` surface. The genuinely-live bit — the poker-eligibility gate, misnamed `can_play_skill_games` — was kept and renamed `Fish.can_play_poker`, and `movement_observations` now reads it directly (dropping a `getattr`-lie per Open-item #5). **Determinism note:** byte-identical (seed-42, 30k frames; golden-replay guard green). The post-poker reproduction path had drawn `engine.rng.random()` only to pick whose (always-empty) skill strategies the offspring inherited; dropping that draw would have reshuffled the shared stream for every poker-on config and tripped `test_replay_golden`, so it is **retained as an explicit determinism anchor** in `_create_post_poker_offspring` (documented inline; remove via a coordinated re-record when that path next changes). A clean example of *cosmetic minigame state coupled to the core RNG stream* — the motivation for `docs/POKER_SEAM_PROPOSAL.md`. |
 | Unused `ParameterRegistry` removed (137 LOC; principle #6) | `core/parameters/` was a read-only facade over three bounds tables that its own docstring said was "intended for tooling … mutation engines" — but the mutation engine reads the source tables directly and nothing but one test imported it. Deleted the package and `tests/core/test_parameter_registry.py`. |
 | God-class ratchet now actually ratchets | `tests/test_god_class_limits.py` skipped legacy files entirely (so they could regrow unbounded), tracked only a count, and carried 6 stale/deleted entries with comments that lied (`fish.py # 1201` — was 810). Rewrote it: `LEGACY_MAX_LINES` is now a **path-keyed dict pinned to each file's current size** (resolving the 4-way `engine.py` basename collision), `test_no_new_god_classes` enforces the per-file ceiling against regrowth, and `test_legacy_list_is_current` fails when a listed file drops under 500 or disappears — forcing harvest. Net: 45→33 honest, enforced pins; 7 already-refactored files (e.g. `environment.py` 433, `behavioral.py` 270) harvested. |
@@ -142,27 +143,62 @@ type-only `Fish`. Determinism was reconfirmed by a seed-42 headless before/after
 diff (identical simulation state). ~199 cycle-safe in-function imports remain
 across the rest of `core/`. Still incremental, still test-backed.
 
-### 5. Defensive access erodes the protocol layer (new, systemic, opportunistic)
-`core/` (excl. tests) carries ~354 `getattr`, ~193 `hasattr`, and ~60 bare
-`except`. The protocol layer (`core/interfaces.py`) exists precisely so callers
-*don't* probe for attributes — yet much code routes around it with
-`getattr(x, "field", default)`, which converts a loud `AttributeError` (fixed in
-minutes) into a silent wrong value (found, if ever, after a 30k-frame
-archaeology dig). The `getattr(fish, "max_speed", 2.0)` bug (Open-item-4 sibling,
-now fixed) is the archetype: the attribute never existed, the default was
-load-bearing, and a downstream clamp hid the consequence — invisible until two
-layers change.
+### 5. Defensive access erodes the protocol layer (systemic; **three distinct root causes**)
+`core/` (excl. tests) carries ~347 `getattr` and ~192 `hasattr` (bare `except` is
+now 0). The protocol layer (`core/interfaces.py`) exists precisely so callers
+*don't* probe for attributes — yet much code routes around it, converting a loud
+`AttributeError` (fixed in minutes) into a silent wrong value (found, if ever,
+after a 30k-frame archaeology dig). `getattr` returning `Any` also **disables
+mypy on everything downstream of the call** (see the Recently-completed entry:
+restoring one type immediately exposed a `Fish | Plant` passed to a `Fish`-only
+method).
 
-Treat this exactly like the in-function import debt (item 4): **opportunistic,
-test-backed, no big-bang.** When you touch a module, replace
-protocol-guaranteed `getattr`/`hasattr` with direct access and let it fail loud;
-keep `getattr` only for *genuinely optional/foreign* attributes (e.g.
-`environment.ball`, which may not exist). A good first sweep is the rest of
-`core/movement_strategy.py` and the `Fish.__init__` config-defaulting chain
-(`getattr(environment, "simulation_config", None)` → `…soccer` → `…enabled`),
-which also mixes construction with save-migration self-healing — extract that to
-a `Genome.normalize()` invoked at load time (SRP: a constructor should
-construct).
+The key insight for *this* sweep: these are **not one debt** — they are three,
+with different costs and different correct fixes. Lumping them as "opportunistic"
+hides that two are cheap, mypy-enforceable wins and only the third is a real
+modeling decision. Triage by root cause:
+
+- **(a) Untyped service-locator on `environment`.** `Environment` accreted
+  `simulation_config: Any | None`, `genome_code_pool`, `event_bus`, `ball`, … —
+  none on the `World` protocol (`core/world.py`), which is *deliberately* minimal
+  (spatial queries only). So core code typed against `World` literally cannot see
+  them and must `getattr` the concrete shape: e.g. `Fish.__init__`'s
+  `getattr(environment, "simulation_config", None)` → `…soccer` → `…enabled`.
+  This is the **deepest** cause and a genuine design fork to decide, not sweep:
+  either (i) declare the truly-core ones on a richer `SimulationWorld(World)`
+  protocol so callers type against it and trust it, or (ii) inject them as
+  explicit typed dependencies where needed. Until then `environment` is a bag
+  every consumer reaches into blindly.
+- **(b) Gratuitous distrust of typed attributes.** `getattr(engine, "lifecycle_
+  system", None)` where the engine *declares* `lifecycle_system: … | None`. The
+  default never fires; the only effect is to silence mypy. Fix = direct access;
+  pure win, mypy-verified. **Largely done** — see Recently completed (11 sites).
+  The same pattern likely remains on `*.engine`/world handles in
+  `transfer/entity_transfer.py` and `worlds/*/backend.py`; verify the holder is
+  typed, then convert.
+- **(c) Genuine cross-mode optionality.** `getattr(fish.environment, "ball",
+  None)`, `getattr(kicker, "team", None)` — state that legitimately may be absent
+  because it belongs to a *mode* (soccer), not the generic core. `getattr` here
+  is defensible **only** as the read of last resort; the better form is the
+  ADR-011 direction (model the capability with a protocol / register it with the
+  pack) so "is this a soccer world?" is a typed question, not an attribute probe.
+  This is the unfinished half of ADR-011, not cleanup.
+
+Treat (b) like the in-function import debt (item 4): opportunistic, test-backed,
+no big-bang. Treat (a) and (c) as **decisions to make**, not sweeps to do.
+
+**Related smell — invariant placement (`Fish.__init__`).** The constructor
+*repairs* its genome at construction time (back-fills a missing
+`poker_strategy`; defaults a `soccer_policy_id` from the code pool when soccer is
+on) and reads mode config via the (a)-chain above. That places the invariant
+"a genome is complete/valid" in a *consumer's constructor* rather than in the
+genome itself — so every other site that builds or loads a genome must
+re-remember to repair it, or silently won't have the guarantee. Extract to a
+`Genome.normalize()` invoked once at load/construction (SRP: a constructor
+should construct; an invariant should live with the type it constrains).
+**Determinism caveat:** the back-fill draws from the RNG, so the extraction must
+preserve draw order exactly or be re-recorded against the golden replay — do it
+as a deliberate, verified change, not a drive-by.
 
 ### 6. Movement-consideration IoC (deferred, enables full ADR-011 compliance)
 `default_considerations()` (generic `core/movement`) still *names* the ball

--- a/tests/test_poker_system_unit.py
+++ b/tests/test_poker_system_unit.py
@@ -13,6 +13,11 @@ class DummyEngine:
     def __init__(self) -> None:
         self.frame_count = 5
         self.added_entities: list[Any] = []
+        # Collaborators handle_poker_result reads. A faithful SimulationEngine
+        # stand-in declares them (production code now trusts these typed attrs
+        # instead of getattr-defaulting, so the double must honor the contract).
+        self.ecosystem = None
+        self.reproduction_service = None
 
     def add_entity(self, entity):
         self.added_entities.append(entity)


### PR DESCRIPTION
## Scope

This is the full long-lived architecture-hardening branch — **42 commits, 185 files, net −4,994 lines** (3,718 added / 8,712 removed). It is biased toward *removing and finishing* abstractions rather than adding them, per the "finish or delete" principle in `docs/ARCHITECTURE_REVIEW.md`. Most of it is recorded in ADRs 009–015; the most recent commits are this session's defensive-access cleanup.

The big net deletion is the headline: most of the value here is **subtraction** — dead parallel abstractions, shadowed duplicate logic, and defensive scaffolding.

## Workstreams

**Agent model reconciliation** (ADR-009, ADR-013) — collapsed a duplicated `GenericAgent` behavior+state layer whose shadowed `modify_energy` had silently diverged (it dropped overflow energy instead of banking it for reproduction); the correct path was winning only by MRO ordering. One live implementation per concept now.

**Minigames out of core** (ADR-011) — moved soccer/poker event ownership off the generic engine; removed engine-level minigame facades and the dead ~2,900-LOC `SkillGame` framework that was a parallel path the real poker code never used.

**Movement arbitration** (ADR-010) — extracted movement drives into a priority arbiter; lifted soccer ball-pursuit out of the generic strategy into a self-contained consideration.

**Determinism** (ADR-012, ADR-014) — fixed cross-process hash-seed-dependent RNG order; made benchmark diversity/algorithm IDs deterministic via a stable CRC32 hash. Re-baselined tank champions under the fix.

**Stats correctness** (ADR-015) — re-keyed per-algorithm stats to the composable `behavior_id` (they previously recorded ~0 events under "Unknown"); fixed a poker-benchmark fish selection that was a silent no-op.

**Dead-code / consolidation** — removed `ParameterRegistry`, the unused mode-rulesets abstraction, the `soccer_evolution` experiment, and the inert `Perception/Locomotion/Feeding` components; consolidated loose `poker_*` / `reproduction_*` modules into packages; made the god-class ratchet actually enforce per-file ceilings.

**Trust the typed surface (this session)** — diagnosed the codebase's `getattr`/`hasattr` sprawl as **three distinct root causes**, not one (untyped service-locator on `environment`; gratuitous distrust of typed attributes; genuine cross-mode optionality / ADR-011), and fixed the second category: ~13 sites that read declared, typed engine collaborators (`lifecycle_system`, `reproduction_service`, `ecosystem`, `soccer_system`, `config`) through `getattr(..., None)`. Because `getattr` returns `Any`, those calls were silently unchecked — restoring the type immediately surfaced a real latent hole (a `Fish | Plant` passed into a `Fish`-only method, fixed with an explicit `isinstance` narrow) and an incomplete test double that had only passed because production code was defaulting its missing attributes. `docs/ARCHITECTURE_REVIEW.md` open-item-5 is upgraded to this three-category framing; the remaining two categories are scoped as deliberate follow-ups.

## Verification

- `tools/fast_gate.py` green — **1707 passed**, 3 skipped
- `python -m mypy core/` green — no issues in 323 source files
- seed-42 golden replay **byte-identical** (`tests/test_replay_golden.py`); determinism suite green
- god-class ratchet enforced (`poker_system.py` held at its 540-line pin)

## Review note

This branch is linear and fast-forwardable (0 commits behind master). Reviewing **by commit** is recommended — each is independently scoped, validated, and (where behavior could move) confirmed determinism-neutral against the golden replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsKZr3ZYKcnWJFKdrP1kB9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsKZr3ZYKcnWJFKdrP1kB9)_