### PR TITLE
[codex] Add poker benchmark certainty UI

### DIFF
--- a/core/poker/evaluation/benchmark_eval.py
+++ b/core/poker/evaluation/benchmark_eval.py
@@ -102,21 +102,36 @@ class BenchmarkSuiteResult:
     weighted_bb_per_100_ci_95: tuple[float, float]
 
 
-def _compute_ci_95(values: list[float]) -> tuple[float, float]:
-    """Basic t-approximation CI. Good enough for our use;
-    if you want bootstrap later, you can swap this out.
+def compute_standard_error(values: list[float]) -> float:
+    """Standard error of a mean for benchmark sample values."""
+    if len(values) < 2:
+        return 0.0
+
+    stdev = statistics.stdev(values)
+    return stdev / math.sqrt(len(values))
+
+
+def compute_mean_ci_95(values: list[float]) -> tuple[tuple[float, float], float]:
+    """Basic t-approximation CI plus standard error for a sample mean.
+
+    Good enough for live observability; a later plateau analyzer can swap in a
+    bootstrap model without changing the persisted snapshot shape.
     """
     if len(values) < 2:
         mean = values[0] if values else 0.0
-        return (mean, mean)
+        return (mean, mean), 0.0
 
     mean = statistics.mean(values)
-    stdev = statistics.stdev(values)
-    n = len(values)
-
+    se = compute_standard_error(values)
     t_crit = 1.96  # ~95% for large n
-    margin = t_crit * (stdev / math.sqrt(n))
-    return (mean - margin, mean + margin)
+    margin = t_crit * se
+    return (mean - margin, mean + margin), se
+
+
+def _compute_ci_95(values: list[float]) -> tuple[float, float]:
+    """Basic t-approximation CI. Kept for existing per-opponent callers."""
+    ci, _ = compute_mean_ci_95(values)
+    return ci
 
 
 def create_standard_strategy(

--- a/core/poker/evaluation/benchmark_snapshot.py
+++ b/core/poker/evaluation/benchmark_snapshot.py
@@ -1,0 +1,92 @@
+"""Snapshot model and payload helpers for poker evolution benchmarks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.poker.evaluation.benchmark_eval import compute_mean_ci_95
+
+
+def _round_ci(ci: tuple[float, float], digits: int = 2) -> list[float]:
+    """Round a confidence interval for JSON/API payloads."""
+    return [round(ci[0], digits), round(ci[1], digits)]
+
+
+@dataclass
+class BenchmarkSnapshot:
+    """Single point-in-time benchmark snapshot."""
+
+    frame: int
+    timestamp: str
+    generation_estimate: int
+
+    # Population-level bb/100 metrics
+    pop_bb_per_100: float
+    pop_weighted_bb: float
+    pop_bb_vs_trivial: float
+    pop_bb_vs_weak: float
+    pop_bb_vs_moderate: float
+    pop_bb_per_100_ci_95: tuple[float, float] = (0.0, 0.0)
+    pop_bb_per_100_se: float = 0.0
+    pop_weighted_bb_ci_95: tuple[float, float] = (0.0, 0.0)
+    pop_weighted_bb_se: float = 0.0
+    pop_bb_vs_strong: float = 0.0
+    pop_bb_vs_expert: float = 0.0
+
+    # Elo rating metrics
+    pop_mean_elo: float = 1200.0
+    pop_median_elo: float = 1200.0
+    elo_tier_distribution: dict[str, int] = field(default_factory=dict)
+
+    # Confidence-based skill assessments
+    confidence_vs_weak: float = 0.5
+    confidence_vs_moderate: float = 0.5
+    confidence_vs_strong: float = 0.5
+    confidence_vs_expert: float = 0.5
+
+    # Strategy distribution
+    strategy_distribution: dict[str, int] = field(default_factory=dict)
+    dominant_strategy: str = ""
+
+    # Best performer
+    best_fish_id: int | None = None
+    best_bb_per_100: float = 0.0
+    best_elo: float = 1200.0
+    best_strategy: str = ""
+
+    # Per-baseline breakdown
+    per_baseline_bb_per_100: dict[str, float] = field(default_factory=dict)
+
+    # Evaluation metadata
+    fish_evaluated: int = 0
+    total_hands: int = 0
+
+
+def snapshot_uncertainty_payload(snapshot: BenchmarkSnapshot) -> dict[str, Any]:
+    """Uncertainty fields shared by export and API benchmark payloads."""
+    return {
+        "pop_bb_per_100_ci_95": _round_ci(snapshot.pop_bb_per_100_ci_95),
+        "pop_bb_per_100_se": round(snapshot.pop_bb_per_100_se, 4),
+        "pop_weighted_bb_ci_95": _round_ci(snapshot.pop_weighted_bb_ci_95),
+        "pop_weighted_bb_se": round(snapshot.pop_weighted_bb_se, 4),
+    }
+
+
+def benchmark_result_uncertainty(result: Any) -> dict[str, Any]:
+    """Build BenchmarkSnapshot uncertainty fields from a population result."""
+    individual_results = getattr(result, "individual_results", [])
+    all_bb = [r.overall_bb_per_100 for r in individual_results]
+    all_weighted = [r.weighted_bb_per_100 for r in individual_results]
+
+    pop_ci, pop_se = compute_mean_ci_95(all_bb)
+    weighted_ci, weighted_se = compute_mean_ci_95(all_weighted)
+
+    if not all_bb:
+        pop_ci = getattr(result, "pop_avg_bb_per_100_ci_95", (0.0, 0.0))
+    return {
+        "pop_bb_per_100_ci_95": pop_ci,
+        "pop_bb_per_100_se": pop_se,
+        "pop_weighted_bb_ci_95": weighted_ci,
+        "pop_weighted_bb_se": weighted_se,
+    }

--- a/core/poker/evaluation/comprehensive_benchmark.py
+++ b/core/poker/evaluation/comprehensive_benchmark.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 from core.poker.evaluation.benchmark_eval import (
     BenchmarkEvalConfig,
     SingleBenchmarkResult,
+    compute_mean_ci_95,
     evaluate_vs_single_benchmark_duplicate,
 )
 from core.poker.evaluation.benchmark_suite import BASELINE_OPPONENTS, ComprehensiveBenchmarkConfig
@@ -189,7 +190,10 @@ class PopulationBenchmarkResult:
     # Population averages
     pop_avg_bb_per_100: float = 0.0
     pop_avg_bb_per_100_ci_95: tuple[float, float] = (0.0, 0.0)
+    pop_avg_bb_per_100_se: float = 0.0
     pop_weighted_bb_per_100: float = 0.0
+    pop_weighted_bb_per_100_ci_95: tuple[float, float] = (0.0, 0.0)
+    pop_weighted_bb_per_100_se: float = 0.0
 
     # Per-difficulty tier population averages
     pop_bb_vs_trivial: float = 0.0
@@ -473,7 +477,11 @@ def run_comprehensive_benchmark(
         all_bb = [r.overall_bb_per_100 for r in fish_results]
         all_weighted = [r.weighted_bb_per_100 for r in fish_results]
         result.pop_avg_bb_per_100 = sum(all_bb) / len(all_bb)
+        result.pop_avg_bb_per_100_ci_95, result.pop_avg_bb_per_100_se = compute_mean_ci_95(all_bb)
         result.pop_weighted_bb_per_100 = sum(all_weighted) / len(all_weighted)
+        result.pop_weighted_bb_per_100_ci_95, result.pop_weighted_bb_per_100_se = (
+            compute_mean_ci_95(all_weighted)
+        )
 
         # Per-tier averages
         result.pop_bb_vs_trivial = sum(r.avg_bb_per_100_vs_trivial for r in fish_results) / len(

--- a/core/poker/evaluation/comprehensive_benchmark.py
+++ b/core/poker/evaluation/comprehensive_benchmark.py
@@ -190,10 +190,7 @@ class PopulationBenchmarkResult:
     # Population averages
     pop_avg_bb_per_100: float = 0.0
     pop_avg_bb_per_100_ci_95: tuple[float, float] = (0.0, 0.0)
-    pop_avg_bb_per_100_se: float = 0.0
     pop_weighted_bb_per_100: float = 0.0
-    pop_weighted_bb_per_100_ci_95: tuple[float, float] = (0.0, 0.0)
-    pop_weighted_bb_per_100_se: float = 0.0
 
     # Per-difficulty tier population averages
     pop_bb_vs_trivial: float = 0.0
@@ -469,19 +466,14 @@ def run_comprehensive_benchmark(
             except Exception as e:
                 logger.error(f"Benchmark failed for fish {fish.fish_id}: {e}")
 
-    # Compute population aggregates
     if fish_results:
         result.individual_results = fish_results
 
-        # Overall population averages
         all_bb = [r.overall_bb_per_100 for r in fish_results]
         all_weighted = [r.weighted_bb_per_100 for r in fish_results]
         result.pop_avg_bb_per_100 = sum(all_bb) / len(all_bb)
-        result.pop_avg_bb_per_100_ci_95, result.pop_avg_bb_per_100_se = compute_mean_ci_95(all_bb)
+        result.pop_avg_bb_per_100_ci_95, _ = compute_mean_ci_95(all_bb)
         result.pop_weighted_bb_per_100 = sum(all_weighted) / len(all_weighted)
-        result.pop_weighted_bb_per_100_ci_95, result.pop_weighted_bb_per_100_se = (
-            compute_mean_ci_95(all_weighted)
-        )
 
         # Per-tier averages
         result.pop_bb_vs_trivial = sum(r.avg_bb_per_100_vs_trivial for r in fish_results) / len(

--- a/core/poker/evaluation/evolution_benchmark_tracker.py
+++ b/core/poker/evaluation/evolution_benchmark_tracker.py
@@ -22,64 +22,17 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from core.poker.evaluation.benchmark_snapshot import (
+    BenchmarkSnapshot,
+    benchmark_result_uncertainty,
+    snapshot_uncertainty_payload,
+)
+
 if TYPE_CHECKING:
     from core.entities import Fish
     from core.poker.evaluation.comprehensive_benchmark import PopulationBenchmarkResult
 
 logger = logging.getLogger(__name__)
-
-
-def _round_ci(ci: tuple[float, float], digits: int = 2) -> list[float]:
-    """Round a confidence interval for JSON/API payloads."""
-    return [round(ci[0], digits), round(ci[1], digits)]
-
-
-@dataclass
-class BenchmarkSnapshot:
-    """Single point-in-time benchmark snapshot."""
-
-    frame: int
-    timestamp: str
-    generation_estimate: int  # Average generation of evaluated fish
-
-    # Population-level bb/100 metrics
-    pop_bb_per_100: float
-    pop_weighted_bb: float
-    pop_bb_vs_trivial: float
-    pop_bb_vs_weak: float
-    pop_bb_vs_moderate: float
-    pop_bb_per_100_ci_95: tuple[float, float] = (0.0, 0.0)
-    pop_bb_per_100_se: float = 0.0
-    pop_weighted_bb_ci_95: tuple[float, float] = (0.0, 0.0)
-    pop_weighted_bb_se: float = 0.0
-    pop_bb_vs_strong: float = 0.0
-    pop_bb_vs_expert: float = 0.0  # Elo rating metrics (more stable than raw bb/100)
-    pop_mean_elo: float = 1200.0
-    pop_median_elo: float = 1200.0
-    elo_tier_distribution: dict[str, int] = field(default_factory=dict)
-
-    # Confidence-based skill assessments
-    confidence_vs_weak: float = 0.5
-    confidence_vs_moderate: float = 0.5
-    confidence_vs_strong: float = 0.5
-    confidence_vs_expert: float = 0.5
-
-    # Strategy distribution
-    strategy_distribution: dict[str, int] = field(default_factory=dict)
-    dominant_strategy: str = ""
-
-    # Best performer
-    best_fish_id: int | None = None
-    best_bb_per_100: float = 0.0
-    best_elo: float = 1200.0
-    best_strategy: str = ""
-
-    # Per-baseline breakdown
-    per_baseline_bb_per_100: dict[str, float] = field(default_factory=dict)
-
-    # Evaluation metadata
-    fish_evaluated: int = 0
-    total_hands: int = 0
 
 
 @dataclass
@@ -411,10 +364,7 @@ class EvolutionBenchmarkTracker:
             pop_bb_vs_trivial=result.pop_bb_vs_trivial,
             pop_bb_vs_weak=result.pop_bb_vs_weak,
             pop_bb_vs_moderate=result.pop_bb_vs_moderate,
-            pop_bb_per_100_ci_95=result.pop_avg_bb_per_100_ci_95,
-            pop_bb_per_100_se=result.pop_avg_bb_per_100_se,
-            pop_weighted_bb_ci_95=result.pop_weighted_bb_per_100_ci_95,
-            pop_weighted_bb_se=result.pop_weighted_bb_per_100_se,
+            **benchmark_result_uncertainty(result),
             pop_bb_vs_strong=result.pop_bb_vs_strong,
             pop_bb_vs_expert=result.pop_bb_vs_expert,
             # Elo rating metrics (more stable than raw bb/100)
@@ -484,11 +434,8 @@ class EvolutionBenchmarkTracker:
                         "confidence_vs_strong": round(s.confidence_vs_strong, 3),
                         # Raw bb/100 metrics (for reference)
                         "pop_bb_per_100": round(s.pop_bb_per_100, 2),
-                        "pop_bb_per_100_ci_95": _round_ci(s.pop_bb_per_100_ci_95),
-                        "pop_bb_per_100_se": round(s.pop_bb_per_100_se, 4),
                         "pop_weighted_bb": round(s.pop_weighted_bb, 2),
-                        "pop_weighted_bb_ci_95": _round_ci(s.pop_weighted_bb_ci_95),
-                        "pop_weighted_bb_se": round(s.pop_weighted_bb_se, 4),
+                        **snapshot_uncertainty_payload(s),
                         "pop_bb_vs_trivial": round(s.pop_bb_vs_trivial, 2),
                         "pop_bb_vs_weak": round(s.pop_bb_vs_weak, 2),
                         "pop_bb_vs_moderate": round(s.pop_bb_vs_moderate, 2),
@@ -565,11 +512,8 @@ class EvolutionBenchmarkTracker:
                     "conf_expert": round(s.confidence_vs_expert, 3),
                     # Raw bb/100 metrics (for reference)
                     "pop_bb_per_100": round(s.pop_bb_per_100, 2),
-                    "pop_bb_per_100_ci_95": _round_ci(s.pop_bb_per_100_ci_95),
-                    "pop_bb_per_100_se": round(s.pop_bb_per_100_se, 4),
                     "pop_weighted_bb": round(s.pop_weighted_bb, 2),
-                    "pop_weighted_bb_ci_95": _round_ci(s.pop_weighted_bb_ci_95),
-                    "pop_weighted_bb_se": round(s.pop_weighted_bb_se, 4),
+                    **snapshot_uncertainty_payload(s),
                     "vs_trivial": round(s.pop_bb_vs_trivial, 2),
                     "vs_weak": round(s.pop_bb_vs_weak, 2),
                     "vs_moderate": round(s.pop_bb_vs_moderate, 2),
@@ -617,15 +561,8 @@ class EvolutionBenchmarkTracker:
                     ),
                     # Raw bb/100 metrics (for reference)
                     "pop_bb_per_100": round(self.history.snapshots[-1].pop_bb_per_100, 2),
-                    "pop_bb_per_100_ci_95": _round_ci(
-                        self.history.snapshots[-1].pop_bb_per_100_ci_95
-                    ),
-                    "pop_bb_per_100_se": round(self.history.snapshots[-1].pop_bb_per_100_se, 4),
                     "pop_weighted_bb": round(self.history.snapshots[-1].pop_weighted_bb, 2),
-                    "pop_weighted_bb_ci_95": _round_ci(
-                        self.history.snapshots[-1].pop_weighted_bb_ci_95
-                    ),
-                    "pop_weighted_bb_se": round(self.history.snapshots[-1].pop_weighted_bb_se, 4),
+                    **snapshot_uncertainty_payload(self.history.snapshots[-1]),
                     "vs_trivial": round(self.history.snapshots[-1].pop_bb_vs_trivial, 2),
                     "vs_weak": round(self.history.snapshots[-1].pop_bb_vs_weak, 2),
                     "vs_moderate": round(self.history.snapshots[-1].pop_bb_vs_moderate, 2),

--- a/core/poker/evaluation/evolution_benchmark_tracker.py
+++ b/core/poker/evaluation/evolution_benchmark_tracker.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _round_ci(ci: tuple[float, float], digits: int = 2) -> list[float]:
+    """Round a confidence interval for JSON/API payloads."""
+    return [round(ci[0], digits), round(ci[1], digits)]
+
+
 @dataclass
 class BenchmarkSnapshot:
     """Single point-in-time benchmark snapshot."""
@@ -43,6 +48,10 @@ class BenchmarkSnapshot:
     pop_bb_vs_trivial: float
     pop_bb_vs_weak: float
     pop_bb_vs_moderate: float
+    pop_bb_per_100_ci_95: tuple[float, float] = (0.0, 0.0)
+    pop_bb_per_100_se: float = 0.0
+    pop_weighted_bb_ci_95: tuple[float, float] = (0.0, 0.0)
+    pop_weighted_bb_se: float = 0.0
     pop_bb_vs_strong: float = 0.0
     pop_bb_vs_expert: float = 0.0  # Elo rating metrics (more stable than raw bb/100)
     pop_mean_elo: float = 1200.0
@@ -402,6 +411,10 @@ class EvolutionBenchmarkTracker:
             pop_bb_vs_trivial=result.pop_bb_vs_trivial,
             pop_bb_vs_weak=result.pop_bb_vs_weak,
             pop_bb_vs_moderate=result.pop_bb_vs_moderate,
+            pop_bb_per_100_ci_95=result.pop_avg_bb_per_100_ci_95,
+            pop_bb_per_100_se=result.pop_avg_bb_per_100_se,
+            pop_weighted_bb_ci_95=result.pop_weighted_bb_per_100_ci_95,
+            pop_weighted_bb_se=result.pop_weighted_bb_per_100_se,
             pop_bb_vs_strong=result.pop_bb_vs_strong,
             pop_bb_vs_expert=result.pop_bb_vs_expert,
             # Elo rating metrics (more stable than raw bb/100)
@@ -471,7 +484,11 @@ class EvolutionBenchmarkTracker:
                         "confidence_vs_strong": round(s.confidence_vs_strong, 3),
                         # Raw bb/100 metrics (for reference)
                         "pop_bb_per_100": round(s.pop_bb_per_100, 2),
+                        "pop_bb_per_100_ci_95": _round_ci(s.pop_bb_per_100_ci_95),
+                        "pop_bb_per_100_se": round(s.pop_bb_per_100_se, 4),
                         "pop_weighted_bb": round(s.pop_weighted_bb, 2),
+                        "pop_weighted_bb_ci_95": _round_ci(s.pop_weighted_bb_ci_95),
+                        "pop_weighted_bb_se": round(s.pop_weighted_bb_se, 4),
                         "pop_bb_vs_trivial": round(s.pop_bb_vs_trivial, 2),
                         "pop_bb_vs_weak": round(s.pop_bb_vs_weak, 2),
                         "pop_bb_vs_moderate": round(s.pop_bb_vs_moderate, 2),
@@ -548,7 +565,11 @@ class EvolutionBenchmarkTracker:
                     "conf_expert": round(s.confidence_vs_expert, 3),
                     # Raw bb/100 metrics (for reference)
                     "pop_bb_per_100": round(s.pop_bb_per_100, 2),
+                    "pop_bb_per_100_ci_95": _round_ci(s.pop_bb_per_100_ci_95),
+                    "pop_bb_per_100_se": round(s.pop_bb_per_100_se, 4),
                     "pop_weighted_bb": round(s.pop_weighted_bb, 2),
+                    "pop_weighted_bb_ci_95": _round_ci(s.pop_weighted_bb_ci_95),
+                    "pop_weighted_bb_se": round(s.pop_weighted_bb_se, 4),
                     "vs_trivial": round(s.pop_bb_vs_trivial, 2),
                     "vs_weak": round(s.pop_bb_vs_weak, 2),
                     "vs_moderate": round(s.pop_bb_vs_moderate, 2),
@@ -596,7 +617,15 @@ class EvolutionBenchmarkTracker:
                     ),
                     # Raw bb/100 metrics (for reference)
                     "pop_bb_per_100": round(self.history.snapshots[-1].pop_bb_per_100, 2),
+                    "pop_bb_per_100_ci_95": _round_ci(
+                        self.history.snapshots[-1].pop_bb_per_100_ci_95
+                    ),
+                    "pop_bb_per_100_se": round(self.history.snapshots[-1].pop_bb_per_100_se, 4),
                     "pop_weighted_bb": round(self.history.snapshots[-1].pop_weighted_bb, 2),
+                    "pop_weighted_bb_ci_95": _round_ci(
+                        self.history.snapshots[-1].pop_weighted_bb_ci_95
+                    ),
+                    "pop_weighted_bb_se": round(self.history.snapshots[-1].pop_weighted_bb_se, 4),
                     "vs_trivial": round(self.history.snapshots[-1].pop_bb_vs_trivial, 2),
                     "vs_weak": round(self.history.snapshots[-1].pop_bb_vs_weak, 2),
                     "vs_moderate": round(self.history.snapshots[-1].pop_bb_vs_moderate, 2),

--- a/frontend/src/components/EvolutionBenchmarkDisplay.tsx
+++ b/frontend/src/components/EvolutionBenchmarkDisplay.tsx
@@ -662,6 +662,56 @@ function ImprovementBanner({ improvement }: { improvement: BenchmarkImprovementM
     );
 }
 
+function formatSignedBb(value: number): string {
+    return `${value >= 0 ? '+' : ''}${value.toFixed(1)}`;
+}
+
+function formatCi(ci?: [number, number]): string {
+    if (!ci) return 'waiting for next benchmark';
+    return `[${formatSignedBb(ci[0])}, ${formatSignedBb(ci[1])}]`;
+}
+
+function BenchmarkCertainty({ latest }: { latest: BenchmarkSnapshot }) {
+    const hasUncertainty = latest.pop_bb_per_100_ci_95 || latest.pop_weighted_bb_ci_95;
+
+    return (
+        <div style={styles.certaintyPanel}>
+            <div style={styles.certaintyHeader}>
+                <span style={styles.certaintyTitle}>Benchmark Certainty</span>
+                <span style={styles.certaintyMeta}>
+                    {latest.total_hands?.toLocaleString() ?? 0} hands · {latest.fish_evaluated ?? 0} fish
+                </span>
+            </div>
+            {hasUncertainty ? (
+                <div style={styles.certaintyGrid}>
+                    <div style={styles.certaintyMetric}>
+                        <span style={styles.certaintyLabel}>Population 95% CI</span>
+                        <span style={styles.certaintyValue}>
+                            {formatCi(latest.pop_bb_per_100_ci_95)}
+                        </span>
+                        <span style={styles.certaintySub}>
+                            SE {(latest.pop_bb_per_100_se ?? 0).toFixed(2)}
+                        </span>
+                    </div>
+                    <div style={styles.certaintyMetric}>
+                        <span style={styles.certaintyLabel}>Weighted 95% CI</span>
+                        <span style={styles.certaintyValue}>
+                            {formatCi(latest.pop_weighted_bb_ci_95)}
+                        </span>
+                        <span style={styles.certaintySub}>
+                            SE {(latest.pop_weighted_bb_se ?? 0).toFixed(2)}
+                        </span>
+                    </div>
+                </div>
+            ) : (
+                <div style={styles.certaintyEmpty}>
+                    Waiting for a fresh benchmark snapshot with uncertainty fields.
+                </div>
+            )}
+        </div>
+    );
+}
+
 export function EvolutionBenchmarkDisplay({ worldId }: { worldId?: string }) {
     const [data, setData] = useState<EvolutionBenchmarkData | null>(null);
     const [viewMode, setViewMode] = useState<ViewMode>('overview');
@@ -878,6 +928,8 @@ export function EvolutionBenchmarkDisplay({ worldId }: { worldId?: string }) {
                                     <ImprovementBanner improvement={improvement} />
                                 </div>
                             </div>
+
+                            <BenchmarkCertainty latest={latest} />
                         </div>
                     )}
 
@@ -1109,6 +1161,71 @@ const styles = {
         display: 'flex',
         gap: '12px',
         fontSize: '11px',
+    },
+    certaintyPanel: {
+        backgroundColor: colors.bgLight,
+        borderRadius: '8px',
+        padding: '8px 12px',
+        border: `1px solid ${colors.border}`,
+        display: 'flex',
+        flexDirection: 'column' as const,
+        gap: '8px',
+    },
+    certaintyHeader: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: '12px',
+        flexWrap: 'wrap' as const,
+    },
+    certaintyTitle: {
+        color: colors.text,
+        fontSize: '11px',
+        fontWeight: 700,
+        textTransform: 'uppercase' as const,
+        letterSpacing: '0.04em',
+    },
+    certaintyMeta: {
+        color: colors.textSecondary,
+        fontSize: '10px',
+        fontFamily: 'var(--font-mono)',
+    },
+    certaintyGrid: {
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+        gap: '8px',
+    },
+    certaintyMetric: {
+        minHeight: '52px',
+        borderRadius: '6px',
+        backgroundColor: 'rgba(15,23,42,0.45)',
+        border: `1px solid rgba(148,163,184,0.16)`,
+        padding: '8px 10px',
+        display: 'flex',
+        flexDirection: 'column' as const,
+        justifyContent: 'center',
+        gap: '3px',
+    },
+    certaintyLabel: {
+        color: colors.textSecondary,
+        fontSize: '10px',
+        textTransform: 'uppercase' as const,
+    },
+    certaintyValue: {
+        color: colors.text,
+        fontSize: '13px',
+        fontWeight: 700,
+        fontFamily: 'var(--font-mono)',
+    },
+    certaintySub: {
+        color: colors.textSecondary,
+        fontSize: '10px',
+        fontFamily: 'var(--font-mono)',
+    },
+    certaintyEmpty: {
+        color: colors.textSecondary,
+        fontSize: '11px',
+        padding: '4px 0',
     },
     baselineGrid: {
         display: 'flex',

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -717,7 +717,11 @@ export interface BenchmarkSnapshot {
     fish_evaluated?: number;
     total_hands?: number;
     pop_bb_per_100: number;
+    pop_bb_per_100_ci_95?: [number, number];
+    pop_bb_per_100_se?: number;
     pop_weighted_bb: number;
+    pop_weighted_bb_ci_95?: [number, number];
+    pop_weighted_bb_se?: number;
     vs_trivial: number;
     vs_weak: number;
     vs_moderate: number;

--- a/tests/test_poker_benchmark_uncertainty.py
+++ b/tests/test_poker_benchmark_uncertainty.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import math
+from types import SimpleNamespace
+
+from core.poker.evaluation import comprehensive_benchmark
+from core.poker.evaluation.benchmark_suite import ComprehensiveBenchmarkConfig
+from core.poker.evaluation.comprehensive_benchmark import FishBenchmarkResult
+from core.poker.evaluation.evolution_benchmark_tracker import EvolutionBenchmarkTracker
+
+
+class _StubFish:
+    poker_stats = None
+
+
+def test_population_benchmark_populates_bb100_uncertainty(monkeypatch):
+    fish_results = [
+        FishBenchmarkResult(
+            fish_id=1,
+            fish_generation=0,
+            strategy_id="a",
+            strategy_params={},
+            overall_bb_per_100=10.0,
+            weighted_bb_per_100=5.0,
+        ),
+        FishBenchmarkResult(
+            fish_id=2,
+            fish_generation=0,
+            strategy_id="b",
+            strategy_params={},
+            overall_bb_per_100=20.0,
+            weighted_bb_per_100=15.0,
+        ),
+        FishBenchmarkResult(
+            fish_id=3,
+            fish_generation=0,
+            strategy_id="c",
+            strategy_params={},
+            overall_bb_per_100=30.0,
+            weighted_bb_per_100=25.0,
+        ),
+    ]
+
+    def fake_evaluate(fish, config, eval_config):
+        return fish_results.pop(0)
+
+    monkeypatch.setattr(comprehensive_benchmark, "_evaluate_single_fish", fake_evaluate)
+
+    result = comprehensive_benchmark.run_comprehensive_benchmark(
+        fish_population=[_StubFish(), _StubFish(), _StubFish()],
+        config=ComprehensiveBenchmarkConfig(),
+        parallel=False,
+        frame=100,
+    )
+
+    assert result.pop_avg_bb_per_100 == 20.0
+    assert math.isclose(result.pop_avg_bb_per_100_se, 10.0 / math.sqrt(3))
+    assert result.pop_avg_bb_per_100_ci_95[0] < result.pop_avg_bb_per_100
+    assert result.pop_avg_bb_per_100_ci_95[1] > result.pop_avg_bb_per_100
+
+    assert result.pop_weighted_bb_per_100 == 15.0
+    assert math.isclose(result.pop_weighted_bb_per_100_se, 10.0 / math.sqrt(3))
+    assert result.pop_weighted_bb_per_100_ci_95[0] < result.pop_weighted_bb_per_100
+    assert result.pop_weighted_bb_per_100_ci_95[1] > result.pop_weighted_bb_per_100
+
+
+def test_tracker_persists_uncertainty_fields(monkeypatch, tmp_path):
+    def fake_quick_benchmark(fish_population, frame):
+        return SimpleNamespace(
+            frame=frame,
+            timestamp="2026-06-23T00:00:00",
+            pop_avg_bb_per_100=12.345,
+            pop_avg_bb_per_100_ci_95=(7.0, 18.0),
+            pop_avg_bb_per_100_se=2.8061,
+            pop_weighted_bb_per_100=15.678,
+            pop_weighted_bb_per_100_ci_95=(9.0, 22.0),
+            pop_weighted_bb_per_100_se=3.3163,
+            pop_bb_vs_trivial=0.0,
+            pop_bb_vs_weak=0.0,
+            pop_bb_vs_moderate=0.0,
+            pop_bb_vs_strong=0.0,
+            pop_bb_vs_expert=0.0,
+            pop_mean_elo=1234.0,
+            pop_median_elo=1230.0,
+            elo_tier_distribution={},
+            pop_confidence_vs_weak=0.5,
+            pop_confidence_vs_moderate=0.5,
+            pop_confidence_vs_strong=0.5,
+            pop_confidence_vs_expert=0.5,
+            strategy_count={"tight_aggressive": 1},
+            best_fish_id=1,
+            best_bb_per_100=20.0,
+            best_elo=1300.0,
+            best_strategy="tight_aggressive",
+            pop_vs_baseline={},
+            fish_evaluated=1,
+            total_hands=100,
+            individual_results=[],
+        )
+
+    monkeypatch.setattr(comprehensive_benchmark, "run_quick_benchmark", fake_quick_benchmark)
+
+    export_path = tmp_path / "poker_evolution.json"
+    tracker = EvolutionBenchmarkTracker(export_path=export_path)
+    snapshot = tracker.run_and_record(
+        [SimpleNamespace(generation=2)], current_frame=100, force=True
+    )
+
+    assert snapshot is not None
+    assert snapshot.pop_bb_per_100_ci_95 == (7.0, 18.0)
+    assert snapshot.pop_bb_per_100_se == 2.8061
+    assert snapshot.pop_weighted_bb_ci_95 == (9.0, 22.0)
+    assert snapshot.pop_weighted_bb_se == 3.3163
+
+    api_data = tracker.get_api_data()
+    assert api_data["latest"]["pop_bb_per_100_ci_95"] == [7.0, 18.0]
+    assert api_data["latest"]["pop_bb_per_100_se"] == 2.8061
+    assert api_data["latest"]["pop_weighted_bb_ci_95"] == [9.0, 22.0]
+    assert api_data["latest"]["pop_weighted_bb_se"] == 3.3163
+    assert api_data["history"][0]["pop_bb_per_100_ci_95"] == [7.0, 18.0]
+
+    exported = json.loads(export_path.read_text())
+    assert exported["snapshots"][0]["pop_bb_per_100_ci_95"] == [7.0, 18.0]
+    assert exported["snapshots"][0]["pop_weighted_bb_ci_95"] == [9.0, 22.0]

--- a/tests/test_poker_benchmark_uncertainty.py
+++ b/tests/test_poker_benchmark_uncertainty.py
@@ -55,14 +55,10 @@ def test_population_benchmark_populates_bb100_uncertainty(monkeypatch):
     )
 
     assert result.pop_avg_bb_per_100 == 20.0
-    assert math.isclose(result.pop_avg_bb_per_100_se, 10.0 / math.sqrt(3))
     assert result.pop_avg_bb_per_100_ci_95[0] < result.pop_avg_bb_per_100
     assert result.pop_avg_bb_per_100_ci_95[1] > result.pop_avg_bb_per_100
 
     assert result.pop_weighted_bb_per_100 == 15.0
-    assert math.isclose(result.pop_weighted_bb_per_100_se, 10.0 / math.sqrt(3))
-    assert result.pop_weighted_bb_per_100_ci_95[0] < result.pop_weighted_bb_per_100
-    assert result.pop_weighted_bb_per_100_ci_95[1] > result.pop_weighted_bb_per_100
 
 
 def test_tracker_persists_uncertainty_fields(monkeypatch, tmp_path):
@@ -72,10 +68,7 @@ def test_tracker_persists_uncertainty_fields(monkeypatch, tmp_path):
             timestamp="2026-06-23T00:00:00",
             pop_avg_bb_per_100=12.345,
             pop_avg_bb_per_100_ci_95=(7.0, 18.0),
-            pop_avg_bb_per_100_se=2.8061,
             pop_weighted_bb_per_100=15.678,
-            pop_weighted_bb_per_100_ci_95=(9.0, 22.0),
-            pop_weighted_bb_per_100_se=3.3163,
             pop_bb_vs_trivial=0.0,
             pop_bb_vs_weak=0.0,
             pop_bb_vs_moderate=0.0,
@@ -96,7 +89,24 @@ def test_tracker_persists_uncertainty_fields(monkeypatch, tmp_path):
             pop_vs_baseline={},
             fish_evaluated=1,
             total_hands=100,
-            individual_results=[],
+            individual_results=[
+                FishBenchmarkResult(
+                    fish_id=1,
+                    fish_generation=2,
+                    strategy_id="tight_aggressive",
+                    strategy_params={},
+                    overall_bb_per_100=10.0,
+                    weighted_bb_per_100=12.0,
+                ),
+                FishBenchmarkResult(
+                    fish_id=2,
+                    fish_generation=2,
+                    strategy_id="tight_aggressive",
+                    strategy_params={},
+                    overall_bb_per_100=20.0,
+                    weighted_bb_per_100=24.0,
+                ),
+            ],
         )
 
     monkeypatch.setattr(comprehensive_benchmark, "run_quick_benchmark", fake_quick_benchmark)
@@ -108,18 +118,20 @@ def test_tracker_persists_uncertainty_fields(monkeypatch, tmp_path):
     )
 
     assert snapshot is not None
-    assert snapshot.pop_bb_per_100_ci_95 == (7.0, 18.0)
-    assert snapshot.pop_bb_per_100_se == 2.8061
-    assert snapshot.pop_weighted_bb_ci_95 == (9.0, 22.0)
-    assert snapshot.pop_weighted_bb_se == 3.3163
+    assert snapshot.pop_bb_per_100_ci_95[0] < 15.0
+    assert snapshot.pop_bb_per_100_ci_95[1] > 15.0
+    assert math.isclose(snapshot.pop_bb_per_100_se, 5.0)
+    assert snapshot.pop_weighted_bb_ci_95[0] < 18.0
+    assert snapshot.pop_weighted_bb_ci_95[1] > 18.0
+    assert math.isclose(snapshot.pop_weighted_bb_se, 6.0)
 
     api_data = tracker.get_api_data()
-    assert api_data["latest"]["pop_bb_per_100_ci_95"] == [7.0, 18.0]
-    assert api_data["latest"]["pop_bb_per_100_se"] == 2.8061
-    assert api_data["latest"]["pop_weighted_bb_ci_95"] == [9.0, 22.0]
-    assert api_data["latest"]["pop_weighted_bb_se"] == 3.3163
-    assert api_data["history"][0]["pop_bb_per_100_ci_95"] == [7.0, 18.0]
+    assert api_data["latest"]["pop_bb_per_100_ci_95"] == [5.2, 24.8]
+    assert api_data["latest"]["pop_bb_per_100_se"] == 5.0
+    assert api_data["latest"]["pop_weighted_bb_ci_95"] == [6.24, 29.76]
+    assert api_data["latest"]["pop_weighted_bb_se"] == 6.0
+    assert api_data["history"][0]["pop_bb_per_100_ci_95"] == [5.2, 24.8]
 
     exported = json.loads(export_path.read_text())
-    assert exported["snapshots"][0]["pop_bb_per_100_ci_95"] == [7.0, 18.0]
-    assert exported["snapshots"][0]["pop_weighted_bb_ci_95"] == [9.0, 22.0]
+    assert exported["snapshots"][0]["pop_bb_per_100_ci_95"] == [5.2, 24.8]
+    assert exported["snapshots"][0]["pop_weighted_bb_ci_95"] == [6.24, 29.76]


### PR DESCRIPTION
## Summary

Adds the missing uncertainty plumbing for poker benchmark snapshots and surfaces it in the Poker Evolution Benchmark overview.

## What changed

- Computes population and weighted bb/100 95% confidence intervals plus standard errors.
- Persists those uncertainty fields through benchmark snapshots, JSON export, and the evolution benchmark API.
- Adds frontend types for the new fields.
- Adds a Benchmark Certainty strip in the Poker tab showing CI, SE, total hands, and fish evaluated.
- Adds focused regression tests for benchmark uncertainty aggregation and tracker/API/export persistence.

## Why

The plateau-alert work needs statistically meaningful inputs. Before this change, benchmark CIs existed at lower layers but were collapsed before the long-running tracker/API could use them.

## Validation

- `npm run build`
- `py -3.14 -m pytest tests/test_poker_benchmark_uncertainty.py`
- `py -3.14 tools/smoke_gate.py`
- `git diff --check`

Note: `python tools/smoke_gate.py` was attempted first, but this Windows environment resolves `python` to the Microsoft Store alias. Validation used `py -3.14` instead.