### PR TITLE
[codex] Fix tank connection server ids

### DIFF
--- a/frontend/src/components/TankNetworkMap.test.tsx
+++ b/frontend/src/components/TankNetworkMap.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildConnectionPayload, type TankNode } from './tankNetworkConnections';
+
+const tank = (overrides: Partial<TankNode>): TankNode => ({
+    id: 'tank-a',
+    name: 'Tank A',
+    serverId: 'server-a',
+    serverName: 'Server A',
+    allowTransfers: true,
+    x: 100,
+    y: 200,
+    ...overrides,
+});
+
+describe('buildConnectionPayload', () => {
+    it('includes server ids when creating a cross-server tank connection', () => {
+        const nodes = new Map<string, TankNode>([
+            ['tank-a', tank({ id: 'tank-a', serverId: 'local-server', x: 100 })],
+            ['tank-b', tank({ id: 'tank-b', serverId: 'remote-server', x: 300 })],
+        ]);
+
+        const payload = buildConnectionPayload('tank-a', 'tank-b', 25, nodes);
+
+        expect(payload).toEqual({
+            id: 'tank-a->tank-b',
+            sourceId: 'tank-a',
+            destinationId: 'tank-b',
+            probability: 25,
+            direction: 'right',
+            sourceServerId: 'local-server',
+            destinationServerId: 'remote-server',
+        });
+    });
+
+    it('sets direction from node positions', () => {
+        const nodes = new Map<string, TankNode>([
+            ['tank-a', tank({ id: 'tank-a', x: 300 })],
+            ['tank-b', tank({ id: 'tank-b', x: 100 })],
+        ]);
+
+        expect(buildConnectionPayload('tank-a', 'tank-b', 50, nodes).direction).toBe('left');
+    });
+});

--- a/frontend/src/components/TankNetworkMap.tsx
+++ b/frontend/src/components/TankNetworkMap.tsx
@@ -2,23 +2,7 @@ import { useCallback, useEffect, useMemo, useState, useRef, memo } from 'react';
 import { config, type ServerWithWorlds } from '../config';
 import { useErrorNotification } from '../hooks/useErrorNotification';
 import { ErrorNotification } from './ErrorNotification';
-
-interface TankNode {
-    id: string;
-    name: string;
-    serverName: string;
-    allowTransfers: boolean;
-    x: number;
-    y: number;
-}
-
-export interface TankConnection {
-    id: string;
-    sourceId: string;
-    destinationId: string;
-    probability: number; // 0-100
-    direction: 'left' | 'right';
-}
+import { buildConnectionPayload, type TankConnection, type TankNode } from './tankNetworkConnections';
 
 interface TankNetworkMapProps {
     servers: ServerWithWorlds[];
@@ -46,6 +30,7 @@ const TankNetworkMapInternal = function TankNetworkMap({ servers }: TankNetworkM
                 id: tankStatus.world_id,
                 name: tankStatus.name,
                 allowTransfers: true,
+                serverId: server.server.server_id,
                 serverName: server.server.hostname,
             })),
         );
@@ -173,18 +158,7 @@ const TankNetworkMapInternal = function TankNetworkMap({ servers }: TankNetworkM
         e.preventDefault();
         if (!sourceId || !destinationId || sourceId === destinationId) return;
 
-        const sourceNode = nodeLookup.get(sourceId);
-        const destNode = nodeLookup.get(destinationId);
-
-        const direction = (sourceNode && destNode && destNode.x > sourceNode.x) ? 'right' : 'left';
-
-        const newConnection = {
-            id: `${sourceId}->${destinationId}`,
-            sourceId,
-            destinationId,
-            probability,
-            direction
-        };
+        const newConnection = buildConnectionPayload(sourceId, destinationId, probability, nodeLookup);
 
         try {
             const res = await fetch(`${config.apiBaseUrl}/api/connections`, {

--- a/frontend/src/components/tankNetworkConnections.ts
+++ b/frontend/src/components/tankNetworkConnections.ts
@@ -1,0 +1,40 @@
+export interface TankNode {
+    id: string;
+    name: string;
+    serverId: string;
+    serverName: string;
+    allowTransfers: boolean;
+    x: number;
+    y: number;
+}
+
+export interface TankConnection {
+    id: string;
+    sourceId: string;
+    destinationId: string;
+    probability: number;
+    direction: 'left' | 'right';
+    sourceServerId?: string;
+    destinationServerId?: string;
+}
+
+export function buildConnectionPayload(
+    sourceId: string,
+    destinationId: string,
+    probability: number,
+    nodeLookup: Map<string, TankNode>,
+): TankConnection {
+    const sourceNode = nodeLookup.get(sourceId);
+    const destNode = nodeLookup.get(destinationId);
+    const direction = sourceNode && destNode && destNode.x > sourceNode.x ? 'right' : 'left';
+
+    return {
+        id: `${sourceId}->${destinationId}`,
+        sourceId,
+        destinationId,
+        probability,
+        direction,
+        ...(sourceNode?.serverId ? { sourceServerId: sourceNode.serverId } : {}),
+        ...(destNode?.serverId ? { destinationServerId: destNode.serverId } : {}),
+    };
+}


### PR DESCRIPTION
## Summary

Fixes tank migration tube creation for tanks that live on different servers.

The network map was flattening worlds from all discovered servers but only POSTing `sourceId` and `destinationId` to `/api/connections`. For cross-server connections, the backend needs `sourceServerId` and `destinationServerId`; without them it treats remote tank IDs as local worlds and can reject creation with `Destination world not found`.

## Changes

- Preserve each tank node's `server_id` in `TankNetworkMap`.
- Move connection payload construction into `tankNetworkConnections.ts`.
- Include `sourceServerId` and `destinationServerId` in created connection payloads.
- Add regression tests for cross-server payloads and direction calculation.

## Validation

- `./.venv/Scripts/python.exe tools/smoke_gate.py` passed
- `npm test -- TankNetworkMap.test.tsx --run` passed
- `npm test -- cleanup.test.ts --run` passed
- `npm run lint` passed
- `npm run build` passed, with existing Vite large-chunk warning
- `npm test -- --run` passed: 37 tests
- `./.venv/Scripts/python.exe tools/agent_gate.py` passed: 575 selected tests

Note: `python tools/smoke_gate.py` failed in this shell because the `python` launcher is not on PATH, so validation used the repo virtualenv interpreter.