### PR TITLE
[codex] Preserve lineage across snapshot restore

### DIFF
--- a/backend/world_persistence.py
+++ b/backend/world_persistence.py
@@ -248,7 +248,7 @@ def restore_world_from_snapshot(
         from core.contracts import VersionMismatchError
         from core.entities import Food
         from core.entities.plant import PlantNectar
-        from core.transfer.entity_transfer import deserialize_entity
+        from core.transfer.entity_transfer import deserialize_entity_for_persistence
 
         # Validate snapshot version (strict: no legacy compatibility)
         try:
@@ -285,6 +285,9 @@ def restore_world_from_snapshot(
         engine._entity_manager.clear()
         logger.debug("Cleared entities via EntityManager")
 
+        if getattr(engine, "ecosystem", None) is not None:
+            engine.ecosystem.lineage.clear()
+
         if engine.environment:
             engine.environment.spatial_grid.clear()
 
@@ -313,7 +316,7 @@ def restore_world_from_snapshot(
 
             if entity_type in ("fish", "plant", "crab"):
                 # Use deserialization logic from entity_transfer
-                entity = deserialize_entity(entity_data, target_world)
+                entity = deserialize_entity_for_persistence(entity_data, target_world)
                 if entity:
                     engine.add_entity(entity)
                     restored_count += 1
@@ -384,6 +387,9 @@ def restore_world_from_snapshot(
         if "paused" in snapshot and hasattr(target_world, "paused"):
             target_world.paused = snapshot["paused"]
 
+        _restore_lineage_state(snapshot, engine)
+        _advance_fish_id_counter(engine)
+
         world_id_label = snapshot.get("world_id") or "unknown"
         logger.info(
             f"Restored world {world_id_label[:8]} to frame {snapshot.get('frame', 0)} "
@@ -406,6 +412,133 @@ def restore_world_from_snapshot(
     except Exception as e:
         logger.error(f"Failed to restore world from snapshot: {e}", exc_info=True)
         return False
+
+
+def _restore_lineage_state(snapshot: dict[str, Any], engine: Any) -> None:
+    """Restore lineage tracker state from a snapshot.
+
+    Current snapshots persist the lineage log explicitly. Older snapshots only
+    have living fish entities, so we rebuild a partial tree and add placeholder
+    ancestors for missing saved parent IDs instead of flattening children to root.
+    """
+    ecosystem = getattr(engine, "ecosystem", None)
+    lineage = getattr(ecosystem, "lineage", None)
+    if lineage is None:
+        return
+
+    raw_records = snapshot.get("lineage_log")
+    if isinstance(raw_records, list):
+        records = [dict(record) for record in raw_records if isinstance(record, dict)]
+    else:
+        records = _build_lineage_from_restored_fish(engine)
+
+    lineage.lineage_log = _with_missing_parent_placeholders(records)
+    alive_fish_ids = {
+        entity.fish_id
+        for entity in getattr(engine, "entities_list", [])
+        if getattr(entity, "snapshot_type", None) == "fish"
+    }
+    lineage.update_alive_fish(alive_fish_ids)
+
+
+def _build_lineage_from_restored_fish(engine: Any) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    frame = getattr(engine, "frame_count", 0)
+
+    for entity in getattr(engine, "entities_list", []):
+        if getattr(entity, "snapshot_type", None) != "fish":
+            continue
+
+        color = "#00ff00"
+        genome = getattr(entity, "genome", None)
+        if genome is not None and hasattr(genome, "get_color_tint"):
+            try:
+                r, g, b = genome.get_color_tint()
+                color = f"#{r:02x}{g:02x}{b:02x}"
+            except Exception:
+                logger.debug("Failed to derive restored fish lineage color", exc_info=True)
+
+        records.append(
+            {
+                "id": str(entity.fish_id),
+                "parent_id": (
+                    str(entity.parent_id)
+                    if getattr(entity, "parent_id", None) is not None
+                    else "root"
+                ),
+                "generation": getattr(entity, "generation", 0),
+                "algorithm": _get_fish_algorithm_name(entity),
+                "color": color,
+                "birth_time": frame,
+                "tank_name": getattr(getattr(entity, "environment", None), "tank_name", None),
+            }
+        )
+
+    return records
+
+
+def _with_missing_parent_placeholders(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    valid_ids = {
+        str(record["id"])
+        for record in records
+        if isinstance(record, dict) and record.get("id") is not None
+    }
+    valid_ids.add("root")
+
+    placeholders: dict[str, dict[str, Any]] = {}
+    for record in records:
+        parent_id_raw = record.get("parent_id", "root")
+        parent_id = str(parent_id_raw) if parent_id_raw is not None else "root"
+        if parent_id in valid_ids or parent_id in placeholders:
+            continue
+
+        try:
+            generation = max(0, int(record.get("generation", 1)) - 1)
+        except (TypeError, ValueError):
+            generation = 0
+
+        placeholders[parent_id] = {
+            "id": parent_id,
+            "parent_id": "root",
+            "generation": generation,
+            "algorithm": "Restored ancestor",
+            "color": "#94a3b8",
+            "birth_time": record.get("birth_time", 0),
+            "tank_name": record.get("tank_name"),
+            "is_placeholder": True,
+        }
+
+    if placeholders:
+        logger.info(
+            "Lineage: Added %d restored ancestor placeholder(s) for snapshot parents",
+            len(placeholders),
+        )
+
+    return [*placeholders.values(), *records]
+
+
+def _get_fish_algorithm_name(fish: Any) -> str:
+    extractor = getattr(fish, "_extract_algorithm_name", None)
+    behavior = getattr(getattr(getattr(fish, "genome", None), "behavioral", None), "behavior", None)
+    behavior_value = getattr(behavior, "value", None)
+    behavior_id = getattr(behavior_value, "behavior_id", None)
+    if callable(extractor) and behavior_id:
+        return str(extractor(behavior_id))
+    return "Unknown"
+
+
+def _advance_fish_id_counter(engine: Any) -> None:
+    ecosystem = getattr(engine, "ecosystem", None)
+    if ecosystem is None:
+        return
+
+    fish_ids = [
+        entity.fish_id
+        for entity in getattr(engine, "entities_list", [])
+        if getattr(entity, "snapshot_type", None) == "fish"
+    ]
+    if fish_ids:
+        ecosystem.next_fish_id = max(ecosystem.next_fish_id, max(fish_ids) + 1)
 
 
 def _validate_restored_world(engine: Any) -> bool:

--- a/core/transfer/entity_transfer.py
+++ b/core/transfer/entity_transfer.py
@@ -481,11 +481,24 @@ def deserialize_entity(data: dict[str, Any], target_world: Any) -> Any | None:
     return DEFAULT_REGISTRY.deserialize_entity(data, target_world)
 
 
+def deserialize_entity_for_persistence(data: dict[str, Any], target_world: Any) -> Any | None:
+    """Deserialize entity data for same-world snapshot restoration.
+
+    Unlike migration transfer, persistence must preserve stable entity identity so
+    restored descendants keep valid lineage and telemetry references.
+    """
+    if data.get("type") == "fish":
+        return _deserialize_fish(data, target_world, preserve_identity=True)
+    return deserialize_entity(data, target_world)
+
+
 def try_deserialize_entity(data: dict[str, Any], target_world: Any) -> TransferOutcome:
     return DEFAULT_REGISTRY.try_deserialize_entity(data, target_world)
 
 
-def _deserialize_fish(data: dict[str, Any], target_world: Any) -> Any | None:
+def _deserialize_fish(
+    data: dict[str, Any], target_world: Any, *, preserve_identity: bool = False
+) -> Any | None:
     """Deserialize and create a Fish entity."""
     try:
         from core.entities.fish import Fish
@@ -510,6 +523,12 @@ def _deserialize_fish(data: dict[str, Any], target_world: Any) -> Any | None:
 
         # Create movement strategy (AlgorithmicMovement uses genome from fish directly)
         movement = AlgorithmicMovement()
+        fish_id = int(data["id"]) if preserve_identity and data.get("id") is not None else None
+        parent_id = (
+            int(data["parent_id"])
+            if preserve_identity and data.get("parent_id") is not None
+            else None
+        )
 
         # Create fish
         fish = Fish(
@@ -521,10 +540,10 @@ def _deserialize_fish(data: dict[str, Any], target_world: Any) -> Any | None:
             speed=data["speed"],
             genome=genome,
             generation=data["generation"],
-            fish_id=None,  # Will get new ID in target tank
+            fish_id=fish_id,
             ecosystem=target_world.engine.ecosystem,
             initial_energy=data["energy"],
-            parent_id=None,  # Clear parent_id: source tank parent doesn't exist here
+            parent_id=parent_id,
             skip_birth_recording=True,  # Prevent phantom "soup_spawn" stats
         )
         if "max_age" in data:

--- a/core/worlds/tank/backend.py
+++ b/core/worlds/tank/backend.py
@@ -652,6 +652,9 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             "config": {},  # Config serialization should be handled by SimulationConfig
             "seed": self._seed,
             "entities": self._build_entities_list(),
+            "lineage_log": [
+                dict(record) for record in getattr(self._engine.ecosystem, "lineage_log", [])
+            ],
         }
 
     def restore_state_from_save(self, state: dict[str, Any]) -> None:

--- a/tests/test_persistence_hardening.py
+++ b/tests/test_persistence_hardening.py
@@ -119,3 +119,117 @@ def test_persistence_round_trip():
     assert (
         abs(restored_test_fish.energy - test_fish_energy) < 0.01
     ), f"Fish energy mismatch: {restored_test_fish.energy}"
+
+
+def test_persistence_preserves_fish_identity_and_lineage():
+    config = {
+        "headless": True,
+        "screen_width": 1000,
+        "screen_height": 1000,
+        "max_population": 100,
+        "auto_food_enabled": False,
+    }
+    adapter = WorldRegistry.create_world("tank", seed=42, config=config)
+    adapter.reset(seed=42, config=config)
+    assert adapter.environment is not None
+    environment = cast(World, adapter.environment)
+
+    adapter.engine._entity_manager.clear()
+    adapter.engine.ecosystem.lineage.clear()
+    adapter.engine.ecosystem.next_fish_id = 12
+
+    parent = Fish(
+        environment=environment,
+        movement_strategy=AlgorithmicMovement(),
+        species="parent-species",
+        x=100,
+        y=100,
+        speed=5.0,
+        fish_id=10,
+        ecosystem=adapter.engine.ecosystem,
+    )
+    child = Fish(
+        environment=environment,
+        movement_strategy=AlgorithmicMovement(),
+        species="child-species",
+        x=120,
+        y=120,
+        speed=5.0,
+        fish_id=11,
+        ecosystem=adapter.engine.ecosystem,
+        parent_id=10,
+        generation=1,
+    )
+    adapter.add_entity(parent)
+    adapter.add_entity(child)
+    parent.register_birth()
+    child.register_birth()
+
+    snapshot = adapter.capture_state_for_save()
+    assert "lineage_log" in snapshot
+    assert any(
+        record["id"] == "11" and record["parent_id"] == "10" for record in snapshot["lineage_log"]
+    )
+
+    dest_adapter = WorldRegistry.create_world("tank", seed=43, config=config)
+    dest_adapter.reset(seed=43, config=config)
+
+    assert restore_world_from_snapshot(snapshot, dest_adapter) is True
+
+    restored_fish = {
+        entity.fish_id: entity for entity in dest_adapter.entities_list if isinstance(entity, Fish)
+    }
+    assert {10, 11}.issubset(restored_fish)
+    assert restored_fish[11].parent_id == 10
+    assert dest_adapter.engine.ecosystem.next_fish_id >= 12
+
+    lineage_data = dest_adapter.engine.ecosystem.get_lineage_data({10, 11})
+    child_record = next(record for record in lineage_data if record["id"] == "11")
+    assert child_record["parent_id"] == "10"
+    assert "_original_parent_id" not in child_record
+
+
+def test_legacy_snapshot_lineage_restore_adds_missing_parent_placeholder():
+    config = {
+        "headless": True,
+        "screen_width": 1000,
+        "screen_height": 1000,
+        "max_population": 100,
+        "auto_food_enabled": False,
+    }
+    adapter = WorldRegistry.create_world("tank", seed=42, config=config)
+    adapter.reset(seed=42, config=config)
+    assert adapter.environment is not None
+    environment = cast(World, adapter.environment)
+
+    adapter.engine._entity_manager.clear()
+    adapter.engine.ecosystem.lineage.clear()
+
+    child = Fish(
+        environment=environment,
+        movement_strategy=AlgorithmicMovement(),
+        species="legacy-child-species",
+        x=120,
+        y=120,
+        speed=5.0,
+        fish_id=11,
+        ecosystem=adapter.engine.ecosystem,
+        parent_id=10,
+        generation=3,
+    )
+    adapter.add_entity(child)
+
+    snapshot = adapter.capture_state_for_save()
+    snapshot.pop("lineage_log", None)
+
+    dest_adapter = WorldRegistry.create_world("tank", seed=43, config=config)
+    dest_adapter.reset(seed=43, config=config)
+
+    assert restore_world_from_snapshot(snapshot, dest_adapter) is True
+
+    lineage_data = dest_adapter.engine.ecosystem.get_lineage_data({11})
+    parent_record = next(record for record in lineage_data if record["id"] == "10")
+    child_record = next(record for record in lineage_data if record["id"] == "11")
+    assert parent_record["is_placeholder"] is True
+    assert child_record["parent_id"] == "10"
+    assert "_original_parent_id" not in child_record


### PR DESCRIPTION
## Summary

Fixes Phylogenetic Tree distortion after server restart/snapshot restore by preserving same-world fish identity and lineage state during persistence restore.

## Root cause

Snapshot restore reused the migration deserializer. Migration correctly assigns fresh fish IDs and clears `parent_id`, but same-world persistence needs stable fish IDs and parent links. Restored descendants could then reference parents that had no matching lineage records, causing `LineageTracker` to remap those records to `root` and flatten the tree.

## Changes

- Add a persistence-specific entity deserializer that preserves fish IDs and parent IDs while leaving migration behavior unchanged.
- Persist `lineage_log` in tank snapshots and restore it on load.
- Clear reset-time lineage before snapshot restore, advance `next_fish_id` after restore, and add placeholder ancestors for older snapshots that lack full lineage logs.
- Add regression tests for identity/lineage preservation and legacy snapshot fallback.

## Validation

- `./.venv/Scripts/python.exe -m pytest tests/test_entity_transfer_codecs.py tests/test_persistence_hardening.py -q` -> 6 passed
- `./.venv/Scripts/python.exe -m black --check backend/world_persistence.py core/transfer/entity_transfer.py core/worlds/tank/backend.py tests/test_persistence_hardening.py --config pyproject.toml` -> passed
- `./.venv/Scripts/python.exe tools/smoke_gate.py` -> passed, 34 tests passed

Also probed the saved snapshot from the reported log: after restore, lineage had `missing_parents=0`; the old snapshot received 4 restored ancestor placeholders because it did not contain historical `lineage_log` data.