### PR TITLE
Add agent commentary feed (Insights tab) for narrating a running sim

### DIFF
--- a/.claude/commands/observe-sim.md
+++ b/.claude/commands/observe-sim.md
@@ -1,0 +1,104 @@
+---
+description: Study the running simulation and post interesting commentary to the UI's Insights feed
+argument-hint: "[url] [watch]"
+---
+
+You are a **colour commentator** for a Tank World simulation that is running
+right now. Your job: study its live state and progress, then post short,
+genuinely interesting observations to the simulation's **Insights** feed so a
+human watching the web UI sees what you see. You observe and narrate - you do
+**not** change the world or the code.
+
+Arguments (optional): `$ARGUMENTS`
+- A URL (e.g. `http://127.0.0.1:8000`) selects the server. Default:
+  `http://127.0.0.1:8000`.
+- `watch` means keep narrating: re-observe on an interval and post only
+  *genuinely new* observations, until the user stops you.
+
+The two tools you use:
+- `tools/evolution_report.py` - read-only assessment of the running sim (the
+  same engine behind `/study-sim`).
+- `tools/post_commentary.py` - posts a comment to the UI (`POST
+  /api/world/<id>/commentary`). Posting is additive telemetry; it never perturbs
+  the sim.
+
+## 1. See what's already been said (don't repeat yourself)
+
+```bash
+python tools/post_commentary.py --url http://127.0.0.1:8000 --read --limit 15
+```
+
+Read the recent feed first. Your value is *new* signal - never restate a comment
+that is already there, and don't re-post the same observation each cycle.
+
+## 2. Observe the simulation
+
+```bash
+python tools/evolution_report.py --url http://127.0.0.1:8000 --json
+```
+
+Read the JSON. The signals worth narrating (see `AGENTS.md` -> "Studying a
+Running Simulation" and the "Healthy Ecosystem Indicators" table):
+- **Selection vs churn** - is any heritable trait under directional selection
+  (trait drift >=5%), or are generations turning over with flat means? This is
+  the single most interesting thing to call out.
+- **Foraging / death causes** - starvation as a fraction of deaths; the
+  ball-pursuit-vs-food-seeking gotcha; emergency spawns.
+- **Population & turnover** - stable vs boom/bust; generation rate per 10k
+  frames; reproduction success.
+- **Diversity** - converging gene pool vs healthy spread.
+- **Energy economy** - where energy comes from and what's burning the surplus
+  that funds reproduction.
+
+## 3. Distill 1-3 comments worth a human's attention
+
+Good commentary is **specific and evidence-backed**, not vague. Tie each comment
+to a number and, where it helps, a frame horizon. Bad: "Fish are evolving."
+Good: "Directional selection on pursuit_aggression: population mean +12% over the
+last 40k frames while speed stayed flat - foraging, not size, is what's winning."
+
+Pick a `severity` that matches the signal, and tag it:
+- `info` - a neutral notable fact ("Population steady at ~38 fish for 30k frames").
+- `insight` - a real evolutionary finding (directional selection, a trend break).
+- `warning` - something off ("Starvation is 91% of deaths").
+- `concern` - something urgent ("3 emergency spawns in 5k frames - population is
+  collapsing").
+
+Useful tags: `selection`, `foraging`, `turnover`, `diversity`, `population`,
+`energy`, `poker`, `soccer`.
+
+## 4. Post them
+
+```bash
+python tools/post_commentary.py --url http://127.0.0.1:8000 \
+  --author "$TANK_AGENT" \
+  --text "Directional selection on pursuit_aggression: mean +12% over 40k frames" \
+  --severity insight --tags selection,foraging \
+  --metric max_generation=14 --metric pursuit_aggression_drift_pct=12
+```
+
+Attach a couple of supporting numbers with `--metric KEY=VALUE` so the comment
+is auditable in the UI. Set `--author` to who you are (it defaults to
+`$TANK_AGENT` or `agent`).
+
+## 5. Watch mode (only if `watch` was passed)
+
+Narrate continuously: re-run steps 1-4 on an interval (a few minutes is plenty
+for a long run), and **post only when you actually have something new** - a trend
+that changed, a threshold crossed, a new generation milestone. Silence is correct
+when nothing interesting happened; do not pad the feed. Stop when the user says
+so.
+
+(`tools/post_commentary.py --watch --cmd "..."` exists for a *scripted*,
+non-LLM narrator that posts a command's output verbatim. As the LLM commentator,
+prefer driving the loop yourself so each post carries an actual insight.)
+
+## Guardrails
+
+- Observation is **read-only** - `evolution_report.py` never perturbs the sim,
+  and posting a comment only appends to the feed. Keep it that way.
+- Be **non-repetitive** and **evidence-backed**. Every comment should earn its
+  place with a specific number or trend.
+- This is **Layer 2** (telemetry/UI). If your observations suggest a *fix*, that
+  is a separate `/study-sim improve` task with the full Evolution Loop - do not
+  change algorithms from here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,49 @@ improvement with a reproduction command, seed, score, and metadata. Keep Layer 1
 benchmarks, or telemetry. Confirm selection is genuinely occurring (trait drift),
 not just generation churn, with `scripts/diagnose_evolution.py`.
 
+### Narrating the simulation to the UI (the Insights feed)
+
+Assessment usually lives only in your chat transcript. To surface what you notice
+**on the simulation UI itself**, post it to the world's **Insights** feed, where
+it shows up live in the web UI's `💬 Insights` tab. Any agent with network access
+to the server can do this - it is a plain HTTP POST, so you do not need to be the
+process running the sim.
+
+The `/observe-sim` slash command wraps the whole observe -> distill -> post loop.
+Under it are two read/write tools:
+
+```bash
+# Read what's already been posted (so you don't repeat earlier comments)
+python tools/post_commentary.py --url http://127.0.0.1:8000 --read --limit 15
+
+# Post a short, evidence-backed observation to the Insights feed
+python tools/post_commentary.py --url http://127.0.0.1:8000 \
+  --text "Directional selection on pursuit_aggression: mean +12% over 40k frames" \
+  --severity insight --tags selection,foraging \
+  --metric max_generation=14 --metric pursuit_aggression_drift_pct=12
+```
+
+The REST surface (see `backend/routers/commentary.py`) is:
+
+- `POST /api/world/<id>/commentary` - body `{text, author?, tags?, severity?,
+  metrics?}`; `<id>` may be the literal `default`.
+- `GET  /api/world/<id>/commentary?limit=&since_id=` - recent comments (what the
+  UI polls, and what you read to avoid repeating yourself).
+
+What makes a **good** comment: it is *specific and evidence-backed*, tied to a
+number and a frame horizon, and *non-repetitive*. Pull the signal from the
+`evolution_report.py` JSON - directional **selection vs churn** (trait drift),
+**foraging / death causes**, **population turnover**, **diversity**, and the
+**energy economy** that funds reproduction. Choose a `severity`
+(`info` < `insight` < `warning` < `concern`) that matches the signal, and tag it
+(`selection`, `foraging`, `turnover`, `diversity`, `population`, `energy`, ...).
+Bad: "Fish are evolving." Good: "Starvation is 91% of deaths and fish are
+clustering at the ball instead of foraging - foraging is broken, not slow."
+
+Commentary is **Layer 2** (telemetry/UI): posting never perturbs the sim, and it
+is separate from any Layer 1 fix. If an observation warrants a change, hand it to
+`/study-sim improve` and the full Evolution Loop.
+
 ---
 
 ## Step 1: Run Simulations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,12 @@ cd frontend && npm run dev        # Frontend on :3000
 
 # Validate improvement against champion
 python tools/validate_improvement.py results.json champions/tank/survival_5k.json
+
+# Study a running sim and post commentary to the UI's Insights feed (/observe-sim)
+python tools/evolution_report.py --url http://127.0.0.1:8000 --json   # observe (read-only)
+python tools/post_commentary.py --url http://127.0.0.1:8000 \
+    --text "Selection on pursuit_aggression: +12% over 40k frames" --severity insight --tags selection
+python tools/post_commentary.py --read --limit 15                     # read the feed back
 ```
 
 ## Project Structure

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -299,7 +299,15 @@ def create_app(
 
 def _setup_routers(app: FastAPI, ctx: AppContext) -> None:
     """Setup and include all API routers."""
-    from backend.routers import connections, discovery, metrics, servers, transfers, websocket
+    from backend.routers import (
+        commentary,
+        connections,
+        discovery,
+        metrics,
+        servers,
+        transfers,
+        websocket,
+    )
     from backend.routers.solutions import create_solutions_router
     from backend.routers.worlds import setup_worlds_router
 
@@ -343,5 +351,9 @@ def _setup_routers(app: FastAPI, ctx: AppContext) -> None:
     # Setup metrics history router
     metrics_router = metrics.setup_router(ctx.world_manager)
     app.include_router(metrics_router)
+
+    # Setup agent commentary router (the "Insights" feed)
+    commentary_router = commentary.setup_router(ctx.world_manager)
+    app.include_router(commentary_router)
 
     ctx.logger.info("All API routers configured successfully")

--- a/backend/commentary_store.py
+++ b/backend/commentary_store.py
@@ -1,0 +1,204 @@
+"""Commentary store for agent observations about a running simulation.
+
+This is the storage backend for the **Insights** feature. AI agents (or humans)
+studying a *live* simulation POST short, evidence-backed observations about its
+state and progress, and the web UI shows them as a live feed - a colour
+commentator narrating the evolution. It mirrors the ring-buffer + REST-poll
+shape of :mod:`backend.metrics_history`.
+
+The store is deliberately tiny and dependency-free: it holds a bounded list of
+comment dicts, assigns each a monotonic ``id``, and stamps the simulation frame
+and wall-clock time at which the comment was added. It only *records annotations
+about* the simulation; it never reads or mutates simulation state, so posting a
+comment can never perturb a running experiment.
+
+Each comment is a plain JSON-serializable dict::
+
+    {
+        "id": int,            # monotonic, per-store
+        "created_at": float,  # epoch seconds when posted
+        "frame": int,         # simulation frame at post time
+        "author": str,        # agent / model name (free text)
+        "text": str,          # the observation itself
+        "tags": list[str],    # e.g. ["selection", "foraging"]
+        "severity": str,      # one of VALID_SEVERITIES
+        "metrics": dict|None, # optional small numbers the agent attached
+    }
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Bumped only on breaking changes to the comment shape below.
+SCHEMA_VERSION = 1
+
+# Severity an agent may attach, ordered low -> high importance. Anything else
+# is coerced to DEFAULT_SEVERITY so the UI can rely on a closed set.
+VALID_SEVERITIES = ("info", "insight", "warning", "concern")
+DEFAULT_SEVERITY = "info"
+
+# Bounds that keep the buffer small and each poll cheap. These are generous
+# enough for a multi-day run (the oldest comments scroll off, like metrics).
+DEFAULT_MAX_COMMENTS = 200
+MAX_TEXT_LEN = 2000
+MAX_AUTHOR_LEN = 80
+MAX_TAGS = 8
+MAX_TAG_LEN = 40
+MAX_METRICS_KEYS = 24
+
+
+class CommentaryStore:
+    """Bounded ring buffer of agent commentary for a single world."""
+
+    def __init__(
+        self,
+        world_id: str | None = None,
+        max_comments: int = DEFAULT_MAX_COMMENTS,
+    ) -> None:
+        self.schema_version = SCHEMA_VERSION
+        self.world_id = world_id or "unknown"
+        self.max_comments = max_comments
+        self.comments: list[dict[str, Any]] = []
+        self._next_id = 1
+
+    def add(
+        self,
+        text: str,
+        *,
+        author: str | None = None,
+        tags: Any = None,
+        severity: str | None = None,
+        metrics: Any = None,
+        frame: int = 0,
+        created_at: float | None = None,
+    ) -> dict[str, Any]:
+        """Validate and append a comment, returning the stored dict.
+
+        Raises ``ValueError`` if ``text`` is empty/whitespace. All other fields
+        are sanitized (clamped, coerced, defaulted) rather than rejected so a
+        slightly-malformed agent payload still lands as a usable comment.
+        """
+        clean_text = (text or "").strip()
+        if not clean_text:
+            raise ValueError("comment text must not be empty")
+        clean_text = clean_text[:MAX_TEXT_LEN]
+
+        clean_author = ((author or "").strip()[:MAX_AUTHOR_LEN]) or "agent"
+
+        clean_severity = (severity or DEFAULT_SEVERITY).strip().lower()
+        if clean_severity not in VALID_SEVERITIES:
+            clean_severity = DEFAULT_SEVERITY
+
+        comment = {
+            "id": self._next_id,
+            "created_at": float(created_at) if created_at is not None else time.time(),
+            "frame": int(frame) if frame is not None else 0,
+            "author": clean_author,
+            "text": clean_text,
+            "tags": self._clean_tags(tags),
+            "severity": clean_severity,
+            "metrics": self._clean_metrics(metrics),
+        }
+        self._next_id += 1
+        self.comments.append(comment)
+
+        # Keep the buffer within capacity (drop oldest first).
+        if len(self.comments) > self.max_comments:
+            self.comments.pop(0)
+
+        return comment
+
+    @staticmethod
+    def _clean_tags(tags: Any) -> list[str]:
+        """Normalize tags to a short list of non-empty strings.
+
+        Accepts a list/tuple of strings or a single comma/space-separated
+        string; anything else yields an empty list.
+        """
+        if not tags:
+            return []
+        if isinstance(tags, str):
+            tags = tags.replace(",", " ").split()
+        if not isinstance(tags, (list, tuple)):
+            return []
+
+        result: list[str] = []
+        for raw in tags:
+            if not isinstance(raw, str):
+                continue
+            tag = raw.strip()[:MAX_TAG_LEN]
+            if tag:
+                result.append(tag)
+            if len(result) >= MAX_TAGS:
+                break
+        return result
+
+    @staticmethod
+    def _clean_metrics(metrics: Any) -> dict[str, Any] | None:
+        """Keep an optional small dict of scalar metrics the agent attached."""
+        if not isinstance(metrics, dict) or not metrics:
+            return None
+        cleaned: dict[str, Any] = {}
+        for key, value in metrics.items():
+            if not isinstance(key, str):
+                continue
+            if isinstance(value, (int, float, str, bool)) or value is None:
+                cleaned[key[:MAX_TAG_LEN]] = value
+            if len(cleaned) >= MAX_METRICS_KEYS:
+                break
+        return cleaned or None
+
+    def recent(self, limit: int | None = None, since_id: int | None = None) -> list[dict[str, Any]]:
+        """Return stored comments, newest last.
+
+        ``since_id`` returns only comments with a larger id (incremental polling);
+        ``limit`` caps the result to the most recent N.
+        """
+        items = self.comments
+        if since_id is not None:
+            items = [c for c in items if c.get("id", 0) > since_id]
+        if limit is not None and limit >= 0:
+            items = items[-limit:]
+        return list(items)
+
+    def clear(self) -> int:
+        """Drop all comments; returns how many were removed."""
+        count = len(self.comments)
+        self.comments = []
+        return count
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize for the REST API and for world save/restore."""
+        return {
+            "schema_version": self.schema_version,
+            "world_id": self.world_id,
+            "max_comments": self.max_comments,
+            "next_id": self._next_id,
+            "comments": self.comments,
+        }
+
+    def load(self, payload: dict[str, Any] | None) -> None:
+        """Restore from a payload, tolerating missing/invalid formats."""
+        if not payload or not isinstance(payload, dict):
+            return
+        try:
+            self.schema_version = payload.get("schema_version", SCHEMA_VERSION)
+            self.world_id = payload.get("world_id", self.world_id)
+            self.max_comments = payload.get("max_comments", self.max_comments)
+            self.comments = payload.get("comments", []) or []
+            # Keep ids monotonic across a restart even if next_id was absent.
+            self._next_id = payload.get("next_id") or (
+                max((c.get("id", 0) for c in self.comments), default=0) + 1
+            )
+            logger.info(
+                "CommentaryStore: loaded %d comments for world %s",
+                len(self.comments),
+                self.world_id,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("CommentaryStore: failed to load payload (%s); starting empty.", e)

--- a/backend/routers/commentary.py
+++ b/backend/routers/commentary.py
@@ -1,0 +1,108 @@
+"""Agent commentary REST API router (the "Insights" feed).
+
+This is the network surface for the Insights feature: any agent (or human) with
+access to the simulation server can POST a short observation about a running
+world, and the web UI polls these endpoints to render them as a live feed.
+
+Endpoints (mounted under ``/api/world``):
+
+    POST   /api/world/{world_id}/commentary   add a comment
+    GET    /api/world/{world_id}/commentary   list recent comments
+    DELETE /api/world/{world_id}/commentary   clear all comments
+
+``world_id`` accepts the literal ``"default"`` to target the server's default
+world, so an agent can comment without first discovering the world id. The write
+path is purely additive telemetry (see ``SimulationRunner.add_commentary``); it
+never mutates simulation state.
+"""
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from backend.world_manager import WorldManager
+
+logger = logging.getLogger(__name__)
+
+
+class CommentaryRequest(BaseModel):
+    """Body for posting a comment.
+
+    Only ``text`` is required. ``tags`` is intentionally permissive (a list of
+    strings or a single comma/space-separated string) and every field is
+    sanitized by ``CommentaryStore.add`` so a slightly-malformed agent payload
+    still lands as a usable comment instead of a 422.
+    """
+
+    text: str
+    author: str | None = None
+    tags: Any = None
+    severity: str | None = None
+    metrics: dict[str, Any] | None = None
+
+
+def setup_router(world_manager: WorldManager) -> APIRouter:
+    """Create and configure the commentary router."""
+    router = APIRouter(prefix="/api/world", tags=["commentary"])
+
+    def _resolve_world(world_id: str):
+        """Resolve a world id (supporting "default"); raise 404 if unknown."""
+        resolved = world_id
+        if world_id == "default":
+            resolved = world_manager.default_world_id or world_id
+        instance = world_manager.get_world(resolved)
+        if instance is None:
+            raise HTTPException(status_code=404, detail=f"World not found: {world_id}")
+        return instance
+
+    @router.post("/{world_id}/commentary")
+    async def post_commentary(world_id: str, request: CommentaryRequest) -> JSONResponse:
+        """Add an agent observation to a world's commentary feed."""
+        instance = _resolve_world(world_id)
+        try:
+            comment = instance.runner.add_commentary(
+                request.text,
+                author=request.author,
+                tags=request.tags,
+                severity=request.severity,
+                metrics=request.metrics,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+        return JSONResponse({"status": "ok", "comment": comment}, status_code=201)
+
+    @router.get("/{world_id}/commentary")
+    async def get_commentary(
+        world_id: str,
+        limit: int | None = Query(default=None, ge=0, le=500),
+        since_id: int | None = Query(default=None, ge=0),
+    ) -> JSONResponse:
+        """List recent comments for a world (newest last).
+
+        ``since_id`` returns only comments newer than that id (incremental
+        polling); ``limit`` caps the result to the most recent N.
+        """
+        instance = _resolve_world(world_id)
+        store = instance.runner.commentary
+        comments = store.recent(limit=limit, since_id=since_id)
+        return JSONResponse(
+            {
+                "schema_version": store.schema_version,
+                "world_id": store.world_id,
+                "count": len(comments),
+                "comments": comments,
+            }
+        )
+
+    @router.delete("/{world_id}/commentary")
+    async def clear_commentary(world_id: str) -> JSONResponse:
+        """Clear all comments for a world."""
+        instance = _resolve_world(world_id)
+        cleared = instance.runner.commentary.clear()
+        return JSONResponse({"status": "ok", "cleared": cleared})
+
+    return router

--- a/backend/simulation_runner.py
+++ b/backend/simulation_runner.py
@@ -24,6 +24,7 @@ from backend.runner.perf_tracker import PerfTracker
 from backend.runner.state_builders import collect_poker_stats_payload
 from backend.runner.state_publisher import StatePublisher
 from backend.runner.world_hooks import get_hooks_for_world
+from backend.commentary_store import CommentaryStore
 from backend.metrics_history import MetricsHistory
 from backend.state_payloads import EntitySnapshot, PokerStatsPayload, StatsPayload
 from backend.world_registry import create_world, get_world_metadata
@@ -130,6 +131,9 @@ class SimulationRunner(CommandHandlerMixin):
         # Initialize metrics history tracking
         self.metrics_history = MetricsHistory(world_id=self.world_id)
 
+        # Initialize agent commentary buffer (the "Insights" feed)
+        self.commentary = CommentaryStore(world_id=self.world_id)
+
     def _require_hook_attr(self, attr: str) -> None:
         """Raise AttributeError if the world hooks don't support the attribute."""
         if not hasattr(self.world_hooks, attr):
@@ -195,6 +199,10 @@ class SimulationRunner(CommandHandlerMixin):
         # Update metrics history world_id
         if hasattr(self, "metrics_history") and self.metrics_history is not None:
             self.metrics_history.world_id = world_id
+
+        # Update commentary buffer world_id
+        if hasattr(self, "commentary") and self.commentary is not None:
+            self.commentary.world_id = world_id
 
         # Update hooks with new world identity
         if hasattr(self.world_hooks, "update_benchmark_tracker_path"):
@@ -410,6 +418,7 @@ class SimulationRunner(CommandHandlerMixin):
             )
             self.world.runner = self
             self.metrics_history = MetricsHistory(world_id=self.world_id)
+            self.commentary = CommentaryStore(world_id=self.world_id)
             # Use getattr/setattr or direct access if known to be an adapter
             if hasattr(self.world, "frame_count"):
                 self.world.frame_count = 0
@@ -508,6 +517,32 @@ class SimulationRunner(CommandHandlerMixin):
         """
 
         return self._entity_snapshot_builder.to_snapshot(entity)
+
+    def add_commentary(
+        self,
+        text: str,
+        *,
+        author: str | None = None,
+        tags: Any = None,
+        severity: str | None = None,
+        metrics: Any = None,
+    ) -> dict[str, Any]:
+        """Record an agent observation about this world (the Insights feed).
+
+        Stamps the comment with the current simulation frame and appends it to
+        the commentary buffer. This is purely additive telemetry - it reads
+        ``frame_count`` but never mutates simulation state, so posting a comment
+        cannot perturb a running experiment.
+        """
+        with self.lock:
+            return self.commentary.add(
+                text,
+                author=author,
+                tags=tags,
+                severity=severity,
+                metrics=metrics,
+                frame=self.frame_count,
+            )
 
     def handle_command(self, command: str, data: dict[str, Any] | None = None):
         """Handle a command from the client.

--- a/backend/world_persistence.py
+++ b/backend/world_persistence.py
@@ -201,6 +201,9 @@ def save_world_state(
                 # Persist metrics history if available
                 if hasattr(runner, "metrics_history") and runner.metrics_history is not None:
                     snapshot["metrics_history"] = runner.metrics_history.to_payload()
+                # Persist agent commentary (the Insights feed) if available
+                if hasattr(runner, "commentary") and runner.commentary is not None:
+                    snapshot["commentary"] = runner.commentary.to_payload()
                 return save_snapshot_data(world_id, snapshot)
 
         logger.warning(f"World {world_id[:8]} does not support state capture")
@@ -280,6 +283,15 @@ def restore_world_from_snapshot(
         ):
             if "metrics_history" in snapshot:
                 runner.metrics_history.load(snapshot["metrics_history"])
+
+        # Restore agent commentary (the Insights feed) if present
+        if (
+            runner is not None
+            and hasattr(runner, "commentary")
+            and runner.commentary is not None
+            and "commentary" in snapshot
+        ):
+            runner.commentary.load(snapshot["commentary"])
 
         # Clear existing entities via EntityManager (authoritative path)
         engine._entity_manager.clear()

--- a/core/poker/evaluation/auto_evaluate_poker.py
+++ b/core/poker/evaluation/auto_evaluate_poker.py
@@ -46,6 +46,19 @@ def request_shutdown() -> None:
     _shutdown_requested = True
 
 
+def clear_shutdown() -> None:
+    """Clear a previously-requested shutdown.
+
+    Symmetric with :func:`request_shutdown`. Because the flag is a process
+    global, a shutdown requested by one server/app lifecycle would otherwise
+    persist and abort a later, unrelated evaluation in the same process (this
+    bites test suites, where a TestClient lifespan teardown calls
+    ``request_shutdown``). Resetting it lets a fresh evaluation run.
+    """
+    global _shutdown_requested
+    _shutdown_requested = False
+
+
 def is_shutdown_requested() -> bool:
     """Check if shutdown has been requested."""
     return _shutdown_requested

--- a/frontend/src/components/CommentaryFeed.module.css
+++ b/frontend/src/components/CommentaryFeed.module.css
@@ -1,0 +1,125 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px 14px;
+    max-height: 520px;
+}
+
+.subtitle {
+    margin: 0;
+    font-size: 12px;
+    color: #94a3b8;
+    line-height: 1.4;
+}
+
+.list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.item {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px 12px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-left-width: 3px;
+    border-radius: 8px;
+}
+
+.itemHeader {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.severityIcon {
+    font-size: 14px;
+    line-height: 1;
+}
+
+.author {
+    font-size: 13px;
+    font-weight: 600;
+    color: #e2e8f0;
+}
+
+.meta {
+    font-size: 11px;
+    color: #94a3b8;
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+.text {
+    margin: 0;
+    font-size: 13px;
+    color: #cbd5e1;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.tag {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: #cbd5e1;
+    background: rgba(148, 163, 184, 0.14);
+    border-radius: 4px;
+    padding: 1px 6px;
+}
+
+.metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 2px;
+}
+
+.metric {
+    font-size: 10px;
+    color: #94a3b8;
+    font-family: var(--font-mono, monospace);
+}
+
+.metricValue {
+    color: #e2e8f0;
+}
+
+.empty {
+    padding: 16px 12px;
+    font-size: 12px;
+    color: #94a3b8;
+    line-height: 1.5;
+    text-align: center;
+}
+
+.empty code {
+    color: #cbd5e1;
+    background: rgba(148, 163, 184, 0.12);
+    border-radius: 3px;
+    padding: 1px 4px;
+    font-size: 11px;
+}
+
+.error {
+    padding: 8px 12px;
+    font-size: 12px;
+    color: #ef4444;
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 6px;
+}

--- a/frontend/src/components/CommentaryFeed.test.tsx
+++ b/frontend/src/components/CommentaryFeed.test.tsx
@@ -1,0 +1,20 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { CommentaryFeed } from './CommentaryFeed';
+
+describe('CommentaryFeed', () => {
+    it('renders the Insights intro before any comments load', () => {
+        // useEffect (and thus the polling fetch) does not run under SSR, so this
+        // exercises the static initial render without needing to mock fetch.
+        const html = renderToString(<CommentaryFeed worldId="world-1" />);
+
+        expect(html).toContain('Live observations posted by agents');
+        expect(html).toContain('/observe-sim');
+    });
+
+    it('does not crash when worldId is undefined', () => {
+        const html = renderToString(<CommentaryFeed worldId={undefined} />);
+        expect(html).toContain('post_commentary.py');
+    });
+});

--- a/frontend/src/components/CommentaryFeed.tsx
+++ b/frontend/src/components/CommentaryFeed.tsx
@@ -1,0 +1,149 @@
+/**
+ * CommentaryFeed - the "Insights" tab.
+ *
+ * Renders a live feed of agent observations about the running simulation,
+ * posted via POST /api/world/{world_id}/commentary (see backend/commentary_store.py
+ * and tools/post_commentary.py). Polls the GET endpoint every few seconds and
+ * shows the most recent comments newest-first.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { config } from '../config';
+import type { CommentaryItem, CommentarySeverity, CommentaryResponse } from '../types/simulation';
+import styles from './CommentaryFeed.module.css';
+
+const POLL_INTERVAL_MS = 4000;
+const FETCH_LIMIT = 100;
+
+const SEVERITY: Record<CommentarySeverity, { icon: string; color: string }> = {
+    info: { icon: '💬', color: '#94a3b8' },
+    insight: { icon: '🔬', color: '#3b82f6' },
+    warning: { icon: '⚠️', color: '#fbbf24' },
+    concern: { icon: '🚨', color: '#ef4444' },
+};
+
+function severityStyle(severity: CommentarySeverity) {
+    return SEVERITY[severity] ?? SEVERITY.info;
+}
+
+function timeAgo(epochSeconds: number): string {
+    const secs = Math.max(0, Math.floor(Date.now() / 1000 - epochSeconds));
+    if (secs < 60) return `${secs}s ago`;
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+}
+
+interface CommentaryFeedProps {
+    worldId: string | undefined;
+}
+
+export function CommentaryFeed({ worldId }: CommentaryFeedProps) {
+    const [comments, setComments] = useState<CommentaryItem[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [loaded, setLoaded] = useState(false);
+    const mountedRef = useRef(true);
+
+    const effectiveId = worldId || 'default';
+
+    const fetchComments = useCallback(async () => {
+        try {
+            const url = `${config.commentaryUrl(effectiveId)}?limit=${FETCH_LIMIT}`;
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            const data: CommentaryResponse = await response.json();
+            if (!mountedRef.current) return;
+            // Newest first for a commentary feed.
+            const sorted = [...(data.comments ?? [])].sort((a, b) => b.id - a.id);
+            setComments(sorted);
+            setError(null);
+            setLoaded(true);
+        } catch (e) {
+            if (!mountedRef.current) return;
+            setError(e instanceof Error ? e.message : 'Failed to load commentary');
+            setLoaded(true);
+        }
+    }, [effectiveId]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        fetchComments();
+        const interval = setInterval(fetchComments, POLL_INTERVAL_MS);
+        return () => {
+            mountedRef.current = false;
+            clearInterval(interval);
+        };
+    }, [fetchComments]);
+
+    return (
+        <div className={styles.container}>
+            <p className={styles.subtitle}>
+                Live observations posted by agents studying this simulation. Launch one with{' '}
+                <code>/observe-sim</code> or <code>python tools/post_commentary.py</code>.
+            </p>
+
+            {error && comments.length === 0 && (
+                <div className={styles.error}>Could not load commentary: {error}</div>
+            )}
+
+            {loaded && !error && comments.length === 0 && (
+                <div className={styles.empty}>
+                    No commentary yet. An agent can post one with{' '}
+                    <code>python tools/post_commentary.py --text "..."</code> or by POSTing to{' '}
+                    <code>/api/world/{effectiveId}/commentary</code>.
+                </div>
+            )}
+
+            {comments.length > 0 && (
+                <div className={styles.list}>
+                    {comments.map((c) => {
+                        const sev = severityStyle(c.severity);
+                        return (
+                            <div
+                                key={c.id}
+                                className={styles.item}
+                                style={{ borderLeftColor: sev.color }}
+                            >
+                                <div className={styles.itemHeader}>
+                                    <span className={styles.severityIcon} title={c.severity}>
+                                        {sev.icon}
+                                    </span>
+                                    <span className={styles.author}>{c.author}</span>
+                                    <span className={styles.meta}>
+                                        frame {c.frame.toLocaleString()} · {timeAgo(c.created_at)}
+                                    </span>
+                                </div>
+                                <p className={styles.text}>{c.text}</p>
+                                {c.tags.length > 0 && (
+                                    <div className={styles.tags}>
+                                        {c.tags.map((tag) => (
+                                            <span key={tag} className={styles.tag}>
+                                                {tag}
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+                                {c.metrics && Object.keys(c.metrics).length > 0 && (
+                                    <div className={styles.metrics}>
+                                        {Object.entries(c.metrics).map(([k, v]) => (
+                                            <span key={k} className={styles.metric}>
+                                                {k}=
+                                                <span className={styles.metricValue}>
+                                                    {String(v)}
+                                                </span>
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useVisiblePanels, type PanelId } from '../hooks/useVisiblePanels';
 import { Canvas } from './Canvas';
+import { CommentaryFeed } from './CommentaryFeed';
 import { ControlPanel } from './ControlPanel';
 import { PokerScoreDisplay } from './PokerScoreDisplay';
 import { WorldModeSelector } from './WorldModeSelector';
@@ -28,6 +29,7 @@ const PANEL_CONFIG: { id: PanelId; label: string; icon: string }[] = [
     { id: 'trends', label: 'Trends', icon: '📈' },
     { id: 'ecosystem', label: 'Ecosystem', icon: '🌿' },
     { id: 'genetics', label: 'Genetics', icon: '🧬' },
+    { id: 'insights', label: 'Insights', icon: '💬' },
 ];
 
 export function TankView({ worldId }: TankViewProps) {
@@ -36,7 +38,7 @@ export function TankView({ worldId }: TankViewProps) {
     const [showEffects, setShowEffects] = useState(true);
     const [showSoccer, setShowSoccer] = useState<boolean | null>(null);  // null = not yet synced from server
     const userToggledSoccer = useRef(false);  // Track if user manually toggled
-    const { visible, toggle, isVisible } = useVisiblePanels(['soccer', 'ecosystem']);
+    const { visible, toggle, isVisible } = useVisiblePanels(['soccer', 'ecosystem', 'insights']);
 
     // Sync showSoccer state from server on initial load and ongoing updates
     useEffect(() => {
@@ -420,6 +422,12 @@ export function TankView({ worldId }: TankViewProps) {
                     {isVisible('genetics') && (
                         <CollapsiblePanel title="Genetics" icon="🧬">
                             <TankGeneticsTab worldId={effectiveWorldId} />
+                        </CollapsiblePanel>
+                    )}
+
+                    {isVisible('insights') && (
+                        <CollapsiblePanel title="Insights" icon="💬">
+                            <CommentaryFeed worldId={effectiveWorldId} />
                         </CollapsiblePanel>
                     )}
                 </div>

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -150,6 +150,15 @@ export const config = {
     get serversApiUrl(): string {
         return `${this.apiBaseUrl}/api/servers`;
     },
+
+    /**
+     * Get API URL for a world's agent-commentary feed (the "Insights" tab).
+     * Accepts "default" to target the server's default world.
+     * @param worldId - The world ID (or "default")
+     */
+    commentaryUrl(worldId: string): string {
+        return `${this.apiBaseUrl}/api/world/${worldId}/commentary`;
+    },
 } as const;
 
 export type Config = typeof config;

--- a/frontend/src/hooks/useVisiblePanels.ts
+++ b/frontend/src/hooks/useVisiblePanels.ts
@@ -1,9 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
 
-export type PanelId = 'soccer' | 'poker' | 'ecosystem' | 'genetics' | 'trends';
+export type PanelId = 'soccer' | 'poker' | 'ecosystem' | 'genetics' | 'trends' | 'insights';
 
 const STORAGE_KEY = 'tankview.visiblePanels.v1';
-const ALL_PANELS: PanelId[] = ['soccer', 'poker', 'ecosystem', 'genetics', 'trends'];
+const ALL_PANELS: PanelId[] = ['soccer', 'poker', 'ecosystem', 'genetics', 'trends', 'insights'];
 
 function sanitizePanels(value: unknown, fallback: PanelId[]): PanelId[] {
     if (!Array.isArray(value)) return fallback;

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -814,3 +814,30 @@ export interface MetricsHistory {
     max_samples: number;
     samples: MetricsSample[];
 }
+
+/**
+ * A single agent observation posted to a world's "Insights" feed.
+ * Mirrors backend/commentary_store.py.
+ */
+export type CommentarySeverity = 'info' | 'insight' | 'warning' | 'concern';
+
+export interface CommentaryItem {
+    id: number;
+    created_at: number; // epoch seconds
+    frame: number; // simulation frame at post time
+    author: string;
+    text: string;
+    tags: string[];
+    severity: CommentarySeverity;
+    metrics?: Record<string, number | string | boolean | null> | null;
+}
+
+/**
+ * Response shape from GET /api/world/{world_id}/commentary.
+ */
+export interface CommentaryResponse {
+    schema_version: number;
+    world_id: string;
+    count: number;
+    comments: CommentaryItem[];
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,23 @@ def _register_contracts():
     register_builtin_contracts_for_tests()
 
 
+@pytest.fixture(autouse=True)
+def _reset_poker_shutdown_flag():
+    """Reset the global poker auto-evaluate shutdown flag between tests.
+
+    ``core.poker.evaluation.auto_evaluate_poker`` uses a process-global
+    ``_shutdown_requested`` flag so Ctrl+C can stop background games. Any test
+    that spins up the app (e.g. via ``TestClient``) trips ``request_shutdown``
+    in the lifespan teardown, leaving the flag set for the rest of the process -
+    which then makes later poker evaluations bail out early. Clearing it before
+    each test keeps that state from leaking across tests.
+    """
+    from core.poker.evaluation.auto_evaluate_poker import clear_shutdown
+
+    clear_shutdown()
+    yield
+
+
 @pytest.fixture
 def seeded_rng():
     """Provide a deterministic RNG for tests."""

--- a/tests/test_commentary.py
+++ b/tests/test_commentary.py
@@ -1,0 +1,225 @@
+"""Tests for the agent-commentary feature (the "Insights" feed).
+
+Covers the storage layer (``backend.commentary_store.CommentaryStore``) and the
+REST endpoints (``backend.routers.commentary``) wired through the app factory.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app_factory import AppContext, create_app
+from backend.commentary_store import DEFAULT_SEVERITY, CommentaryStore
+from backend.world_manager import WorldManager
+
+# ---------------------------------------------------------------------------
+# CommentaryStore unit tests (no server)
+# ---------------------------------------------------------------------------
+
+
+def test_add_returns_stamped_comment():
+    store = CommentaryStore(world_id="w1")
+    c = store.add(
+        "Selection is real",
+        author="claude",
+        tags=["selection"],
+        severity="insight",
+        metrics={"max_generation": 12},
+        frame=41500,
+    )
+    assert c["id"] == 1
+    assert c["frame"] == 41500
+    assert c["author"] == "claude"
+    assert c["text"] == "Selection is real"
+    assert c["tags"] == ["selection"]
+    assert c["severity"] == "insight"
+    assert c["metrics"] == {"max_generation": 12}
+    assert isinstance(c["created_at"], float)
+
+
+def test_text_is_stripped_and_empty_rejected():
+    store = CommentaryStore()
+    assert store.add("  hello  ")["text"] == "hello"
+    with pytest.raises(ValueError):
+        store.add("   ")
+    with pytest.raises(ValueError):
+        store.add("")
+
+
+def test_text_truncated_to_cap():
+    from backend.commentary_store import MAX_TEXT_LEN
+
+    store = CommentaryStore()
+    c = store.add("x" * (MAX_TEXT_LEN + 500))
+    assert len(c["text"]) == MAX_TEXT_LEN
+
+
+def test_tags_accept_string_or_list_and_are_capped():
+    from backend.commentary_store import MAX_TAGS
+
+    store = CommentaryStore()
+    assert store.add("a", tags="selection, foraging")["tags"] == ["selection", "foraging"]
+    assert store.add("b", tags=["one", "two"])["tags"] == ["one", "two"]
+    many = store.add("c", tags=[f"t{i}" for i in range(MAX_TAGS + 5)])
+    assert len(many["tags"]) == MAX_TAGS
+    # Non-string junk is ignored.
+    assert store.add("d", tags=[1, None, "ok"])["tags"] == ["ok"]
+
+
+def test_invalid_severity_defaults():
+    store = CommentaryStore()
+    assert store.add("a", severity="bogus")["severity"] == DEFAULT_SEVERITY
+    assert store.add("b", severity=None)["severity"] == DEFAULT_SEVERITY
+    assert store.add("c", severity="WARNING")["severity"] == "warning"
+
+
+def test_metrics_are_sanitized():
+    store = CommentaryStore()
+    # Non-scalar values are dropped; scalars are kept.
+    c = store.add("a", metrics={"gen": 12, "rate": 0.5, "note": "ok", "bad": [1, 2]})
+    assert c["metrics"] == {"gen": 12, "rate": 0.5, "note": "ok"}
+    # A non-dict, or an all-junk dict, yields None.
+    assert store.add("b", metrics="nope")["metrics"] is None
+    assert store.add("c", metrics={"bad": [1]})["metrics"] is None
+
+
+def test_recent_limit_and_since_id():
+    store = CommentaryStore()
+    for i in range(5):
+        store.add(f"comment {i}")
+    assert [c["id"] for c in store.recent()] == [1, 2, 3, 4, 5]
+    assert [c["id"] for c in store.recent(limit=2)] == [4, 5]
+    assert [c["id"] for c in store.recent(since_id=3)] == [4, 5]
+    assert store.recent(since_id=5) == []
+
+
+def test_ring_buffer_drops_oldest():
+    store = CommentaryStore(max_comments=3)
+    for i in range(5):
+        store.add(f"c{i}")
+    ids = [c["id"] for c in store.comments]
+    assert ids == [3, 4, 5]  # oldest two dropped, ids stay monotonic
+
+
+def test_clear():
+    store = CommentaryStore()
+    store.add("a")
+    store.add("b")
+    assert store.clear() == 2
+    assert store.comments == []
+
+
+def test_payload_roundtrip_preserves_monotonic_ids():
+    store = CommentaryStore(world_id="w1")
+    store.add("a")
+    store.add("b")
+    payload = store.to_payload()
+
+    restored = CommentaryStore()
+    restored.load(payload)
+    assert [c["id"] for c in restored.comments] == [1, 2]
+    # New ids continue after the restored maximum.
+    assert restored.add("c")["id"] == 3
+
+
+def test_load_tolerates_garbage():
+    store = CommentaryStore()
+    store.load(None)
+    store.load({"unexpected": True})
+    assert store.comments == []
+    assert store.add("a")["id"] == 1
+
+
+# ---------------------------------------------------------------------------
+# REST endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client_and_world():
+    """Create a test client with a fresh paused tank world; yield (client, world_id)."""
+    context = AppContext(world_manager=WorldManager())
+    app = create_app(context=context, server_id="test-server")
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/worlds",
+            json={
+                "world_type": "tank",
+                "name": "Commentary Test",
+                "persistent": False,
+                "seed": 42,
+                "start_paused": True,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        world_id = resp.json()["world_id"]
+        yield client, world_id
+
+
+def test_post_and_get_comment(client_and_world):
+    client, world_id = client_and_world
+    resp = client.post(
+        f"/api/world/{world_id}/commentary",
+        json={
+            "text": "Starvation is 91% of deaths",
+            "author": "claude",
+            "tags": "foraging",
+            "severity": "warning",
+            "metrics": {"starvation_pct": 0.91},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    comment = resp.json()["comment"]
+    assert comment["id"] == 1
+    assert comment["author"] == "claude"
+    assert comment["severity"] == "warning"
+    assert comment["tags"] == ["foraging"]
+    assert comment["metrics"] == {"starvation_pct": 0.91}
+    assert isinstance(comment["frame"], int)
+
+    got = client.get(f"/api/world/{world_id}/commentary")
+    assert got.status_code == 200
+    body = got.json()
+    assert body["count"] == 1
+    assert body["comments"][0]["text"] == "Starvation is 91% of deaths"
+
+
+def test_post_to_default_world(client_and_world):
+    client, _ = client_and_world
+    resp = client.post("/api/world/default/commentary", json={"text": "via default"})
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["comment"]["author"] == "agent"  # default author
+
+    got = client.get("/api/world/default/commentary")
+    assert got.status_code == 200
+    assert any(c["text"] == "via default" for c in got.json()["comments"])
+
+
+def test_post_empty_text_is_400(client_and_world):
+    client, world_id = client_and_world
+    resp = client.post(f"/api/world/{world_id}/commentary", json={"text": "   "})
+    assert resp.status_code == 400
+
+
+def test_unknown_world_is_404(client_and_world):
+    client, _ = client_and_world
+    assert client.get("/api/world/does-not-exist/commentary").status_code == 404
+    assert (
+        client.post("/api/world/does-not-exist/commentary", json={"text": "hi"}).status_code == 404
+    )
+
+
+def test_get_since_id_filters(client_and_world):
+    client, world_id = client_and_world
+    for i in range(3):
+        client.post(f"/api/world/{world_id}/commentary", json={"text": f"c{i}"})
+    body = client.get(f"/api/world/{world_id}/commentary", params={"since_id": 2}).json()
+    assert [c["id"] for c in body["comments"]] == [3]
+
+
+def test_delete_clears(client_and_world):
+    client, world_id = client_and_world
+    client.post(f"/api/world/{world_id}/commentary", json={"text": "a"})
+    resp = client.delete(f"/api/world/{world_id}/commentary")
+    assert resp.status_code == 200
+    assert resp.json()["cleared"] == 1
+    assert client.get(f"/api/world/{world_id}/commentary").json()["count"] == 0

--- a/tests/test_god_class_limits.py
+++ b/tests/test_god_class_limits.py
@@ -42,7 +42,7 @@ LEGACY_MAX_LINES: dict[str, int] = {
     "core/interfaces.py": 663,
     "core/minigames/soccer/engine.py": 778,
     "core/mixed_poker/interaction.py": 728,
-    "core/poker/evaluation/auto_evaluate_poker.py": 581,
+    "core/poker/evaluation/auto_evaluate_poker.py": 594,
     "core/poker/evaluation/comprehensive_benchmark.py": 601,
     "core/poker/evaluation/evolution_benchmark_tracker.py": 623,
     "core/poker/human_poker_game.py": 863,

--- a/tools/post_commentary.py
+++ b/tools/post_commentary.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Post agent commentary to a running Tank World simulation (the "Insights" feed).
+
+This is the thin, dependency-free client an AI agent (or a human) uses to share
+an observation about a *running* simulation so it shows up live in the web UI's
+**Insights** tab. It is the write counterpart to the read-only
+``tools/evolution_report.py``: that tool tells you *what* is happening; this one
+*narrates it to the UI*.
+
+It talks to the commentary REST API (see ``backend/routers/commentary.py``):
+
+    POST   /api/world/{world_id}/commentary
+    GET    /api/world/{world_id}/commentary
+
+Posting is purely additive telemetry - it never perturbs the simulation.
+
+Examples
+--------
+    # Post a single observation to the default world
+    python tools/post_commentary.py --url http://127.0.0.1:8000 \
+        --text "Selection is real: pursuit_aggression mean +12% over 40k frames" \
+        --tags selection,foraging --severity insight --author claude
+
+    # Attach a couple of supporting numbers
+    python tools/post_commentary.py --text "Starvation dominates deaths" \
+        --severity warning --metric starvation_pct=0.91 --metric max_generation=14
+
+    # Read back what agents have already said (so you don't repeat yourself)
+    python tools/post_commentary.py --read --limit 10
+
+    # Scripted narrator: run a command each interval and post its stdout
+    python tools/post_commentary.py --watch --interval 300 \
+        --cmd "python tools/evolution_report.py --url http://127.0.0.1:8000 --oneline"
+
+For the LLM-driven "live narrator" loop (re-observe and post *genuinely
+interesting* insights), use the ``/observe-sim`` skill, which drives this tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+DEFAULT_URL = "http://127.0.0.1:8000"
+DEFAULT_INTERVAL = 300.0
+VALID_SEVERITIES = ("info", "insight", "warning", "concern")
+
+
+# ---------------------------------------------------------------------------
+# HTTP (stdlib only; trusted local/LAN URL pointing at the user's own server)
+# ---------------------------------------------------------------------------
+def _http_get_json(url: str, timeout: float = 10.0) -> Any:
+    with urlopen(url, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def _http_post_json(url: str, payload: dict[str, Any], timeout: float = 10.0) -> Any:
+    data = json.dumps(payload).encode("utf-8")
+    req = Request(url, data=data, method="POST", headers={"Content-Type": "application/json"})
+    with urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8")
+        return json.loads(body) if body else {}
+
+
+def resolve_world_id(base_url: str, world_id: str | None) -> str:
+    """Return an explicit world id, falling back to the server's default world.
+
+    If the default cannot be resolved, returns the literal ``"default"`` - the
+    API understands it - so commenting still works on a single-world server.
+    """
+    if world_id:
+        return world_id
+    try:
+        data = _http_get_json(f"{base_url}/api/worlds/default/id")
+        return str(data["world_id"])
+    except Exception:
+        return "default"
+
+
+# ---------------------------------------------------------------------------
+# Public helpers (importable)
+# ---------------------------------------------------------------------------
+def post_comment(
+    base_url: str,
+    text: str,
+    *,
+    world_id: str | None = None,
+    author: str | None = None,
+    tags: Any = None,
+    severity: str | None = None,
+    metrics: dict[str, Any] | None = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """POST one comment; returns the stored comment dict from the server."""
+    base_url = base_url.rstrip("/")
+    wid = resolve_world_id(base_url, world_id)
+    payload: dict[str, Any] = {"text": text}
+    if author:
+        payload["author"] = author
+    if tags:
+        payload["tags"] = tags
+    if severity:
+        payload["severity"] = severity
+    if metrics:
+        payload["metrics"] = metrics
+    result = _http_post_json(f"{base_url}/api/world/{wid}/commentary", payload, timeout=timeout)
+    return result.get("comment", result) if isinstance(result, dict) else {}
+
+
+def read_comments(
+    base_url: str,
+    *,
+    world_id: str | None = None,
+    limit: int | None = None,
+    since_id: int | None = None,
+    timeout: float = 10.0,
+) -> list[dict[str, Any]]:
+    """GET recent comments for a world (newest last)."""
+    base_url = base_url.rstrip("/")
+    wid = resolve_world_id(base_url, world_id)
+    query = []
+    if limit is not None:
+        query.append(f"limit={limit}")
+    if since_id is not None:
+        query.append(f"since_id={since_id}")
+    suffix = ("?" + "&".join(query)) if query else ""
+    data = _http_get_json(f"{base_url}/api/world/{wid}/commentary{suffix}", timeout=timeout)
+    comments = data.get("comments", []) if isinstance(data, dict) else []
+    return list(comments)
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+def _parse_metric_value(raw: str) -> Any:
+    """Coerce a CLI metric value to int/float/bool when it looks like one."""
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    low = raw.strip().lower()
+    if low in ("true", "false"):
+        return low == "true"
+    return raw
+
+
+def _parse_metrics(pairs: list[str] | None) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+    for item in pairs or []:
+        if "=" not in item:
+            print(f"warning: ignoring --metric '{item}' (expected KEY=VALUE)", file=sys.stderr)
+            continue
+        key, raw = item.split("=", 1)
+        key = key.strip()
+        if key:
+            metrics[key] = _parse_metric_value(raw)
+    return metrics
+
+
+def _parse_tags(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    return [t.strip() for t in raw.replace(",", " ").split() if t.strip()]
+
+
+def _format_comment(c: dict[str, Any]) -> str:
+    sev = c.get("severity", "info")
+    author = c.get("author", "agent")
+    frame = c.get("frame", 0)
+    tags = c.get("tags") or []
+    tag_str = (" [" + ", ".join(tags) + "]") if tags else ""
+    return f"#{c.get('id', '?')} {sev:<8} {author} @frame {frame}{tag_str}\n    {c.get('text', '')}"
+
+
+def _run_cmd(cmd: str) -> str:
+    """Run a shell command and return its stdout (for --watch narrator mode)."""
+    import subprocess  # local import: only needed in watch mode
+
+    proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if proc.returncode != 0:
+        err = proc.stderr.strip() or f"exit code {proc.returncode}"
+        print(f"warning: --cmd failed: {err}", file=sys.stderr)
+    return proc.stdout.strip()
+
+
+def _resolve_text(text_arg: str | None) -> str:
+    """Resolve --text, reading stdin when it is '-'."""
+    if text_arg == "-":
+        return sys.stdin.read().strip()
+    return (text_arg or "").strip()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Post or read agent commentary on a running Tank World simulation.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--url", default=DEFAULT_URL, help=f"Server base URL (default: {DEFAULT_URL})")
+    p.add_argument("--world", default=None, help="World id (default: the server's default world)")
+    p.add_argument("--text", default=None, help="Comment text (use '-' to read from stdin)")
+    p.add_argument(
+        "--author",
+        default=os.getenv("TANK_AGENT") or "agent",
+        help="Author name (default: $TANK_AGENT or 'agent')",
+    )
+    p.add_argument("--tags", default=None, help="Comma/space-separated tags")
+    p.add_argument(
+        "--severity",
+        default="info",
+        choices=VALID_SEVERITIES,
+        help="Severity (default: info)",
+    )
+    p.add_argument(
+        "--metric",
+        action="append",
+        dest="metrics",
+        metavar="KEY=VALUE",
+        help="Attach a metric (repeatable); numbers are parsed as numbers",
+    )
+    p.add_argument("--read", action="store_true", help="Read recent comments instead of posting")
+    p.add_argument("--limit", type=int, default=None, help="Max comments for --read")
+    p.add_argument("--since-id", type=int, default=None, help="Only comments newer than this id")
+    p.add_argument("--watch", action="store_true", help="Loop forever (scripted narrator)")
+    p.add_argument(
+        "--interval",
+        type=float,
+        default=DEFAULT_INTERVAL,
+        help=f"Seconds between --watch iterations (default: {DEFAULT_INTERVAL:.0f})",
+    )
+    p.add_argument(
+        "--cmd", default=None, help="In --watch mode, run this each interval and post its stdout"
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    base_url = args.url.rstrip("/")
+
+    # --- read mode -------------------------------------------------------
+    if args.read:
+        try:
+            comments = read_comments(
+                base_url, world_id=args.world, limit=args.limit, since_id=args.since_id
+            )
+        except (HTTPError, URLError) as e:
+            print(f"error: could not reach {base_url}: {e}", file=sys.stderr)
+            return 2
+        if not comments:
+            print("(no commentary yet)")
+            return 0
+        for c in comments:
+            print(_format_comment(c))
+        return 0
+
+    metrics = _parse_metrics(args.metrics)
+    tags = _parse_tags(args.tags)
+
+    # --- watch / narrator mode ------------------------------------------
+    if args.watch:
+        if not args.cmd:
+            print(
+                "error: --watch needs --cmd (the command whose stdout becomes each comment).\n"
+                "For an LLM-driven narrator that forms its own insights, use the /observe-sim "
+                "skill instead.",
+                file=sys.stderr,
+            )
+            return 2
+        print(
+            f"watching: posting `{args.cmd}` output to {base_url} every {args.interval:.0f}s "
+            "(Ctrl-C to stop)",
+            file=sys.stderr,
+        )
+        try:
+            while True:
+                text = _run_cmd(args.cmd)
+                if text:
+                    try:
+                        c = post_comment(
+                            base_url,
+                            text,
+                            world_id=args.world,
+                            author=args.author,
+                            tags=tags,
+                            severity=args.severity,
+                            metrics=metrics or None,
+                        )
+                        print(_format_comment(c))
+                    except (HTTPError, URLError) as e:
+                        print(f"warning: post failed: {e}", file=sys.stderr)
+                else:
+                    print("warning: --cmd produced no output; skipping", file=sys.stderr)
+                time.sleep(max(1.0, args.interval))
+        except KeyboardInterrupt:
+            print("\nstopped.", file=sys.stderr)
+            return 0
+
+    # --- one-shot post mode ---------------------------------------------
+    text = _resolve_text(args.text)
+    if not text:
+        print("error: --text is required (or pipe text and pass --text -)", file=sys.stderr)
+        return 2
+
+    try:
+        comment = post_comment(
+            base_url,
+            text,
+            world_id=args.world,
+            author=args.author,
+            tags=tags,
+            severity=args.severity,
+            metrics=metrics or None,
+        )
+    except HTTPError as e:
+        detail = ""
+        try:
+            detail = json.loads(e.read().decode("utf-8")).get("detail", "")
+        except Exception:
+            pass
+        print(f"error: server returned {e.code}: {detail or e.reason}", file=sys.stderr)
+        return 2
+    except URLError as e:
+        print(f"error: could not reach {base_url}: {e}", file=sys.stderr)
+        return 2
+
+    print(_format_comment(comment))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Agents studying a live simulation can now post observations that surface **on the simulation UI**. Any process with network access to the server can `POST` a short, evidence-backed comment and it appears live in a new **💬 Insights** tab — turning an agent into a colour commentator for the evolution.

This closes the gap where an agent's assessment (`/study-sim`, `tools/evolution_report.py`) only ever lived in its chat transcript. It is entirely **Layer 2** (telemetry / UI / docs / tooling) — no algorithm or config change.

## What's included

**Backend**
- `backend/commentary_store.py` — `CommentaryStore`, a bounded ring buffer of comments (`id` / `frame` / `author` / `text` / `tags` / `severity` / `metrics`), modelled on `MetricsHistory`, with input sanitization and `to_payload()` / `load()`.
- `SimulationRunner.add_commentary()` stamps the current sim frame; the store is persisted with the world (`world_persistence`) so commentary survives restarts.
- `backend/routers/commentary.py` — `POST` / `GET` / `DELETE /api/world/{id}/commentary` (`id` may be the literal `default`); registered in `app_factory`.

**Frontend**
- `CommentaryFeed.tsx` polls the `GET` endpoint and renders a live, newest-first feed with severity icons, tag chips, and attached metrics — surfaced as a new **Insights** panel in `TankView` (default-visible).

**Tooling & docs**
- `tools/post_commentary.py` — stdlib-only post/read client (`--read`, `--metric KEY=VALUE`, stdin via `--text -`, and a scripted `--watch --cmd` narrator).
- New `/observe-sim` skill drives the observe → distill → post loop (one-shot, plus a `--watch` live-narrator mode).
- `AGENTS.md` gains a "Narrating the simulation to the UI" section (what makes a *good*, evidence-backed comment); `CLAUDE.md` Quick Commands updated.

## Drive-by: a pre-existing test-isolation fix

Adding a `TestClient`-based test surfaced a latent bug: the poker auto-evaluate's process-global `_shutdown_requested` flag is set by **any** app-lifespan teardown and never reset, so it leaked across tests and aborted later poker evaluations. (`tests/test_worlds_api.py` already tripped this; the new `tests/test_commentary.py` sorts alphabetically *before* the poker tests, so it newly exposed it.) Fixed with a public `clear_shutdown()` + an autouse `conftest` fixture that resets it between tests; re-pinned that file's god-class line count.

## How to use it

```bash
# Observe (read-only) then narrate to the UI
python tools/evolution_report.py --url http://127.0.0.1:8000 --json
python tools/post_commentary.py --url http://127.0.0.1:8000 \
  --text "Selection is real: pursuit_aggression mean +12% over 40k frames" \
  --severity insight --tags selection,foraging --metric max_generation=14

# Or just drive the whole loop
/observe-sim
```

## Validation

- `fast_gate` — **1744 passed**, 3 skipped (incl. 17 new commentary tests).
- Frontend — production `npm run build` (tsc + vite), ESLint, and **43 vitest** tests pass (incl. 2 new).
- mypy clean on changed `core/` file; black / ruff clean.
- Verified end-to-end against a live server: observe → post → the exact `GET .../commentary?limit=100` endpoint the UI polls returns the right shape; persistence confirmed across restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbNYznioSgZ1638LCSJfkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbNYznioSgZ1638LCSJfkg)_