### PR TITLE
[codex] Cap zigzag sprint penalty

### DIFF
--- a/core/algorithms/composable/actions.py
+++ b/core/algorithms/composable/actions.py
@@ -243,6 +243,10 @@ class BehaviorActionsMixin:
             zigzag = math.sin(self._zigzag_phase) * amplitude
             vx = direction.x * speed + perp.x * zigzag
             vy = direction.y * speed + perp.y * zigzag
+            magnitude = math.hypot(vx, vy)
+            if magnitude > speed > 0:
+                scale = speed / magnitude
+                vx, vy = vx * scale, vy * scale
             return vx, vy
 
         elif self.food_approach == FoodApproach.PATROL_ROUTE:

--- a/tests/test_zigzag_velocity_budget.py
+++ b/tests/test_zigzag_velocity_budget.py
@@ -1,0 +1,79 @@
+import math
+import random
+from types import SimpleNamespace
+
+from core.algorithms.composable.behavior import ComposableBehavior
+from core.algorithms.composable.definitions import (
+    FoodApproach,
+    PokerEngagement,
+    SocialMode,
+    ThreatResponse,
+)
+from core.entities.resources import Food
+from core.genetics import Genome
+from core.genetics.trait import GeneticTrait
+from core.math_utils import Vector2
+
+
+class _FoodEnv:
+    def __init__(self, food):
+        self.rng = random.Random(42)
+        self.food = food
+
+    def get_detection_modifier(self):
+        return 1.0
+
+    def nearby_agents_by_type(self, fish, radius, agent_type):
+        return [self.food] if agent_type is Food else []
+
+    def nearby_resources(self, fish, radius):
+        return [self.food]
+
+
+class _FishStub:
+    def __init__(self):
+        self.pos = Vector2(0, 0)
+        self.vel = Vector2(0, 0)
+        self.speed = 1.0
+        self.energy = 75
+        self.max_energy = 150
+        self.genome = Genome.random(use_algorithm=True, rng=random.Random(7))
+        self.genome.behavioral.pursuit_aggression = GeneticTrait(0.5)
+        self.genome.behavioral.prediction_skill = GeneticTrait(0.5)
+        self.genome.behavioral.hunting_stamina = GeneticTrait(1.0)
+
+    def can_eat(self):
+        return True
+
+
+def test_zigzag_search_preserves_pattern_without_exceeding_pursuit_speed_budget():
+    food = SimpleNamespace(
+        pos=Vector2(100, 0),
+        vel=Vector2(0, 0),
+        get_energy_value=lambda: 10.0,
+    )
+    fish = _FishStub()
+    fish.environment = _FoodEnv(food)
+    behavior = ComposableBehavior(
+        ThreatResponse.FREEZE,
+        FoodApproach.ZIGZAG_SEARCH,
+        SocialMode.SOLO,
+        PokerEngagement.PASSIVE,
+        {
+            "pursuit_speed": 0.9,
+            "zigzag_amplitude": 0.6,
+            "zigzag_frequency": 0.05,
+        },
+    )
+
+    direct_speed_budget = 0.9 * (1.0 + 0.5 * 0.4) * (1.0 + (1.0 - 0.5) * 0.3)
+    magnitudes = []
+    lateral_components = []
+
+    for _ in range(160):
+        vx, vy = behavior._execute_food_approach(fish)
+        magnitudes.append(math.hypot(vx, vy))
+        lateral_components.append(abs(vy))
+
+    assert max(magnitudes) <= direct_speed_budget + 1e-9
+    assert max(lateral_components) > 0.01


### PR DESCRIPTION
## Summary

Implements board proposal #30: `ZIGZAG_SEARCH` keeps its lateral search direction, but the composed pursuit+lateral vector is normalized back to the same pursuit-speed budget when the lateral component would exceed it. This prevents zigzag from silently commanding more total movement than direct pursuit and paying extra sprint cost for the search pattern itself.

## Root Cause

`core/algorithms/composable/actions.py` added the sinusoidal perpendicular zigzag component after computing the pursuit speed. Before this PR, a focused probe with identical traits showed Direct Pursuit at magnitude `1.242`, while Zigzag ranged `1.242-1.3793` and exceeded the direct budget on `160/160` sampled frames.

## Changes

- Cap `ZIGZAG_SEARCH` output magnitude back to its pursuit-speed budget while preserving direction.
- Add `tests/test_zigzag_velocity_budget.py` to assert zigzag keeps lateral motion without exceeding Direct Pursuit's comparable speed budget.

## Reproduction And Metrics

Problem reproduction:

```bash
python main.py --headless --max-frames 10000 --stats-interval 5000 --export-stats results/builder30_baseline_seed42_10k.json --seed 42
```

Baseline export: `626/645` deaths by starvation, starvation fraction `0.9705`.

Focused vector probe:

- Before: Zigzag over budget `160/160` frames, max magnitude `1.3793` vs direct budget `1.242`.
- After: Zigzag over budget `0/160` frames, max magnitude `1.242`.

Champion comparison:

```bash
python tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 42 --out results/builder30_ecosystem_health_10k_seed42.json
python tools/validate_improvement.py results/builder30_ecosystem_health_10k_seed42.json champions/tank/ecosystem_health_10k.json
```

- New score: `8.333443779264227`
- Champion score: `7.3340413254670995`
- Diff: `+0.9994024537971275`
- Metadata: `starvation_rate=0.9958`, `max_generation=8`, `diversity_score=0.2815`, `mean_population=50.46`

Additional seeds:

```bash
python tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 7 --out results/builder30_ecosystem_health_10k_seed7.json
python tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 123 --out results/builder30_ecosystem_health_10k_seed123.json
```

- Seed 7 score: `9.461400845238579`
- Seed 123 score: `7.292821075823143`

Determinism:

```bash
python tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 42 --verify-determinism --out results/builder30_ecosystem_health_10k_seed42_determinism.json
```

Result: determinism check passed.

Trait drift:

```bash
python scripts/diagnose_evolution.py --frames 10000 --seed 42 --interval 1000
python scripts/diagnose_evolution.py --frames 10000 --seed 7 --interval 1000
python scripts/diagnose_evolution.py --frames 10000 --seed 123 --interval 1000
```

All three runs reported directional selection and active Layer 0 evolution:

- Seed 42: generations advanced `7`; selected drift includes pursuit aggression `-22.7%`, stamina `-15.9%`, speed `+29.4%`.
- Seed 7: generations advanced `8`; selected drift includes prediction skill `+140.0%`, aggression `+55.6%`, speed `+17.9%`.
- Seed 123: generations advanced `8`; selected drift includes pursuit aggression `+5.3%`, stamina `-14.7%`, speed `-15.6%`.

## Validation

```bash
python -m pytest tests/test_zigzag_velocity_budget.py tests/test_god_class_limits.py
python tools/smoke_gate.py
python tools/agent_gate.py
python tools/fast_gate.py
```

Results:

- Focused tests: `3 passed`
- Smoke gate: passed
- Agent gate: passed (`575 passed, 100 deselected` in curated suite)
- Fast gate: passed (`1745 passed, 3 skipped, 157 deselected`)
