### PR TITLE
meta/ui-insights-above-soccer: Move insights panel above soccer league

### DIFF
--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -24,12 +24,12 @@ interface TankViewProps {
 }
 
 const PANEL_CONFIG: { id: PanelId; label: string; icon: string }[] = [
+    { id: 'insights', label: 'Insights', icon: '💬' },
     { id: 'soccer', label: 'Soccer', icon: '⚽' },
     { id: 'poker', label: 'Poker', icon: '♠' },
     { id: 'trends', label: 'Trends', icon: '📈' },
     { id: 'ecosystem', label: 'Ecosystem', icon: '🌿' },
     { id: 'genetics', label: 'Genetics', icon: '🧬' },
-    { id: 'insights', label: 'Insights', icon: '💬' },
 ];
 
 export function TankView({ worldId }: TankViewProps) {
@@ -379,6 +379,12 @@ export function TankView({ worldId }: TankViewProps) {
             {/* Panel Grid */}
             {visible.length > 0 && (
                 <div className={styles.panelGrid}>
+                    {isVisible('insights') && (
+                        <CollapsiblePanel title="Insights" icon="💬">
+                            <CommentaryFeed worldId={effectiveWorldId} />
+                        </CollapsiblePanel>
+                    )}
+
                     {isVisible('soccer') && (
                         <CollapsiblePanel title="Soccer League" icon="⚽">
                             <TankSoccerTab
@@ -422,12 +428,6 @@ export function TankView({ worldId }: TankViewProps) {
                     {isVisible('genetics') && (
                         <CollapsiblePanel title="Genetics" icon="🧬">
                             <TankGeneticsTab worldId={effectiveWorldId} />
-                        </CollapsiblePanel>
-                    )}
-
-                    {isVisible('insights') && (
-                        <CollapsiblePanel title="Insights" icon="💬">
-                            <CommentaryFeed worldId={effectiveWorldId} />
                         </CollapsiblePanel>
                     )}
                 </div>


### PR DESCRIPTION
### Description

Move the Insights (commentary feed) panel above the Soccer League panel in the UI layout grid and configuration. This prioritizes the live narrative commentary for developers/users monitoring simulation evolution.

#### Changes Made:
- **`PANEL_CONFIG` reordered**: Moved `insights` to the top of the configurations list in `TankView.tsx`.
- **Layout reordered**: Positioned the collapsible panel render block for `insights` above the `soccer` block in `panelGrid`.

#### Gates Verified:
- **`smoke_gate.py`**: PASS
- **`agent_gate.py`**: PASS
- **`npm run build`**: Success (Clean compilation & bundler run)