### PR TITLE
[codex] Gate mutation escalation by diversity

### DIFF
--- a/core/agents/components/reproduction_component.py
+++ b/core/agents/components/reproduction_component.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from core.entities.base import LifeStage
     from core.genetics import Genome
+    from core.genetics.reproduction import ReproductionMutationContext
 
 
 class ReproductionComponent:
@@ -152,6 +153,8 @@ class ReproductionComponent:
         own_genome: "Genome",
         rng: Optional["Random"] = None,
         available_policies: list[str] | None = None,
+        diversity_score: float | None = None,
+        mutation_context: "ReproductionMutationContext | None" = None,
     ) -> tuple["Genome", float]:
         """Trigger instant asexual reproduction and return offspring genome.
 
@@ -162,6 +165,8 @@ class ReproductionComponent:
             own_genome: This fish's genome
             rng: Random number generator for deterministic mutation
             available_policies: Optional list of available code policy IDs for mutation
+            diversity_score: Current ecosystem diversity score if available
+            mutation_context: Population-level mutation controller state
 
         Returns:
             Tuple of (offspring_genome, energy_transfer_fraction)
@@ -173,7 +178,11 @@ class ReproductionComponent:
 
         # Create mutated clone
         offspring_genome = Genome.clone_with_mutation(
-            own_genome, rng=rng, available_policies=available_policies
+            own_genome,
+            rng=rng,
+            available_policies=available_policies,
+            diversity_score=diversity_score,
+            mutation_context=mutation_context,
         )
 
         return offspring_genome, self.ENERGY_TRANSFER_TO_BABY

--- a/core/entities/mixins/reproduction_mixin.py
+++ b/core/entities/mixins/reproduction_mixin.py
@@ -91,7 +91,7 @@ class ReproductionMixin:
         self._reproduction_component.update_cooldown()
         return ReproductionService.maybe_create_banked_offspring(cast("Fish", self))
 
-    def _create_asexual_offspring(self) -> Fish | None:
+    def _create_asexual_offspring(self, mutation_context=None) -> Fish | None:
         """Create an offspring through asexual reproduction.
 
         Called when conditions are met for instant asexual reproduction.
@@ -103,4 +103,6 @@ class ReproductionMixin:
 
         from core.reproduction.reproduction_service import ReproductionService
 
-        return ReproductionService.create_asexual_offspring(cast("Fish", self))
+        return ReproductionService.create_asexual_offspring(
+            cast("Fish", self), mutation_context=mutation_context
+        )

--- a/core/genetics/__init__.py
+++ b/core/genetics/__init__.py
@@ -25,7 +25,7 @@ from core.genetics.diversity import (
 from core.genetics.genome import GeneticCrossoverMode, Genome
 from core.genetics.physical import PHYSICAL_TRAIT_SPECS, PhysicalTraits
 from core.genetics.plant_genome import PlantGenome
-from core.genetics.reproduction import ReproductionParams
+from core.genetics.reproduction import ReproductionMutationContext, ReproductionParams
 from core.genetics.trait import (
     GeneticTrait,
     TraitSpec,
@@ -60,6 +60,7 @@ __all__ = [
     "apply_trait_values_from_dict",
     "apply_trait_meta_from_dict",
     # Reproduction API
+    "ReproductionMutationContext",
     "ReproductionParams",
     # Validation
     "validate_traits_from_specs",

--- a/core/genetics/behavioral.py
+++ b/core/genetics/behavioral.py
@@ -48,6 +48,7 @@ from core.genetics.policy_inheritance import (
     validate_code_policy,
     validate_policy_fields,
 )
+from core.genetics.reproduction import ReproductionMutationContext
 from core.genetics.trait import GeneticTrait, TraitSpec, random_genetic_trait
 
 if TYPE_CHECKING:
@@ -220,6 +221,8 @@ class BehavioralTraits:
         mutation_strength: float = 0.1,
         rng: pyrandom.Random,
         available_policies: list[str] | None = None,
+        diversity_score: float | None = None,
+        mutation_context: ReproductionMutationContext | None = None,
     ) -> "BehavioralTraits":
         """Inherit behavioral traits from two parents.
 
@@ -241,6 +244,8 @@ class BehavioralTraits:
             mutation_strength=mutation_strength,
             rng=rng,
             available_policies=available_policies,
+            diversity_score=diversity_score,
+            mutation_context=mutation_context,
         )
         return cls(**inherited)
 
@@ -255,6 +260,8 @@ class BehavioralTraits:
         mutation_strength: float = 0.1,
         rng: pyrandom.Random,
         available_policies: list[str] | None = None,
+        diversity_score: float | None = None,
+        mutation_context: ReproductionMutationContext | None = None,
     ) -> "BehavioralTraits":
         """Inherit behavioral traits by choosing a parent per trait (recombination)."""
         inherited = recombine_behavioral_traits(
@@ -266,5 +273,7 @@ class BehavioralTraits:
             mutation_strength=mutation_strength,
             rng=rng,
             available_policies=available_policies,
+            diversity_score=diversity_score,
+            mutation_context=mutation_context,
         )
         return cls(**inherited)

--- a/core/genetics/behavioral_inheritance.py
+++ b/core/genetics/behavioral_inheritance.py
@@ -23,6 +23,10 @@ from core.genetics.mate_preferences import (
     inherit_mate_preferences,
 )
 from core.genetics.policy_inheritance import inherit_single_policy
+from core.genetics.reproduction import (
+    DEFAULT_SUB_BEHAVIOR_SWITCH_RATE,
+    ReproductionMutationContext,
+)
 from core.genetics.trait import (
     GeneticTrait,
     TraitSpec,
@@ -87,6 +91,8 @@ def inherit_composable_behavior(
     mutation_rate: float,
     mutation_strength: float,
     rng: pyrandom.Random,
+    diversity_score: float | None = None,
+    mutation_context: ReproductionMutationContext | None = None,
 ) -> "ComposableBehavior":
     """Inherit composable behavior from two parents.
 
@@ -97,6 +103,9 @@ def inherit_composable_behavior(
     """
     from core.algorithms.composable import ComposableBehavior
 
+    context = mutation_context or ReproductionMutationContext.from_score(diversity_score)
+    sub_behavior_switch_rate = context.sub_behavior_switch_rate(DEFAULT_SUB_BEHAVIOR_SWITCH_RATE)
+
     if behavior1 is None and behavior2 is None:
         return ComposableBehavior.create_random(rng=rng)
     elif behavior1 is None:
@@ -105,7 +114,7 @@ def inherit_composable_behavior(
         child.mutate(
             mutation_rate=mutation_rate,
             mutation_strength=mutation_strength,
-            sub_behavior_switch_rate=0.08,
+            sub_behavior_switch_rate=sub_behavior_switch_rate,
             rng=rng,
         )
         return child
@@ -115,7 +124,7 @@ def inherit_composable_behavior(
         child.mutate(
             mutation_rate=mutation_rate,
             mutation_strength=mutation_strength,
-            sub_behavior_switch_rate=0.08,
+            sub_behavior_switch_rate=sub_behavior_switch_rate,
             rng=rng,
         )
         return child
@@ -126,7 +135,7 @@ def inherit_composable_behavior(
         weight1=weight1,
         mutation_rate=mutation_rate,
         mutation_strength=mutation_strength,
-        sub_behavior_switch_rate=0.08,  # Increased from 0.03 for more behavioral diversity
+        sub_behavior_switch_rate=sub_behavior_switch_rate,  # Increased from 0.03 for more behavioral diversity
         rng=rng,
     )
 
@@ -181,6 +190,8 @@ def inherit_behavioral_traits(
     mutation_strength: float = 0.1,
     rng: pyrandom.Random,
     available_policies: list[str] | None = None,
+    diversity_score: float | None = None,
+    mutation_context: ReproductionMutationContext | None = None,
 ) -> dict:
     """Build the inherited trait dict for BehavioralTraits.from_parents.
 
@@ -218,6 +229,8 @@ def inherit_behavioral_traits(
         mutation_rate=mutation_rate,
         mutation_strength=mutation_strength,
         rng=rng,
+        diversity_score=diversity_score,
+        mutation_context=mutation_context,
     )
     inherited["behavior"] = inherit_trait_meta(
         parent1.behavior, parent2.behavior, behavior_val, rng
@@ -294,6 +307,8 @@ def recombine_behavioral_traits(
     mutation_strength: float = 0.1,
     rng: pyrandom.Random,
     available_policies: list[str] | None = None,
+    diversity_score: float | None = None,
+    mutation_context: ReproductionMutationContext | None = None,
 ) -> dict:
     """Build the inherited trait dict for BehavioralTraits.from_parents_recombination.
 
@@ -320,6 +335,8 @@ def recombine_behavioral_traits(
         mutation_rate=mutation_rate,
         mutation_strength=mutation_strength,
         rng=rng,
+        diversity_score=diversity_score,
+        mutation_context=mutation_context,
     )
     inherited["behavior"] = inherit_trait_meta(
         parent1.behavior, parent2.behavior, behavior_val, rng

--- a/core/genetics/genome.py
+++ b/core/genetics/genome.py
@@ -15,7 +15,7 @@ from core.exceptions import GeneticsError
 from core.genetics.behavioral import BehavioralTraits
 from core.genetics.genome_codec import genome_debug_snapshot, genome_from_dict, genome_to_dict
 from core.genetics.physical import PhysicalTraits
-from core.genetics.reproduction import ReproductionParams
+from core.genetics.reproduction import ReproductionMutationContext, ReproductionParams
 from core.genetics.validation import validate_traits_from_specs
 from core.util.rng import require_rng_param
 
@@ -189,6 +189,8 @@ class Genome:
         params: ReproductionParams,
         rng: pyrandom.Random | None = None,
         available_policies: list[str] | None = None,
+        diversity_score: float | None = None,
+        mutation_context: ReproductionMutationContext | None = None,
     ) -> "Genome":
         """Create offspring genome using a parameter object for mutation inputs."""
         return cls.from_parents_weighted(
@@ -199,6 +201,8 @@ class Genome:
             mutation_strength=params.mutation_strength,
             rng=rng,
             available_policies=available_policies,
+            diversity_score=diversity_score,
+            mutation_context=mutation_context,
         )
 
     @classmethod
@@ -211,6 +215,8 @@ class Genome:
         mutation_strength: float = 0.15,  # Increased from 0.1
         rng: pyrandom.Random | None = None,
         available_policies: list[str] | None = None,
+        diversity_score: float | None = None,
+        mutation_context: ReproductionMutationContext | None = None,
     ) -> "Genome":
         """Create offspring genome with weighted contributions from parents.
 
@@ -220,10 +226,11 @@ class Genome:
         """
         rng = require_rng_param(rng, "__init__")
         parent1_weight = max(0.0, min(1.0, parent1_weight))
+        context = mutation_context or ReproductionMutationContext.from_score(diversity_score)
         adaptive_rate, adaptive_strength = ReproductionParams(
             mutation_rate=mutation_rate,
             mutation_strength=mutation_strength,
-        ).adaptive_mutation()
+        ).adaptive_mutation(context)
 
         # Inherit traits using declarative specs
         physical = PhysicalTraits.from_parents(
@@ -243,6 +250,8 @@ class Genome:
             mutation_strength=adaptive_strength,
             rng=rng,
             available_policies=available_policies,
+            diversity_score=diversity_score,
+            mutation_context=context,
         )
 
         return cls._assemble_offspring(
@@ -258,6 +267,8 @@ class Genome:
         parent: "Genome",
         rng: pyrandom.Random | None = None,
         available_policies: list[str] | None = None,
+        diversity_score: float | None = None,
+        mutation_context: ReproductionMutationContext | None = None,
     ) -> "Genome":
         """Clone a genome with mutation (asexual reproduction)."""
         return cls.from_parents_weighted_params(
@@ -267,6 +278,8 @@ class Genome:
             params=ReproductionParams(),
             rng=rng,
             available_policies=available_policies,
+            diversity_score=diversity_score,
+            mutation_context=mutation_context,
         )
 
     @classmethod
@@ -279,6 +292,8 @@ class Genome:
         crossover_mode: GeneticCrossoverMode = GeneticCrossoverMode.RECOMBINATION,
         rng: pyrandom.Random | None = None,
         available_policies: list[str] | None = None,
+        diversity_score: float | None = None,
+        mutation_context: ReproductionMutationContext | None = None,
     ) -> "Genome":
         """Create offspring genome by mixing parent genes with mutations."""
         rng = require_rng_param(rng, "__init__")
@@ -295,6 +310,8 @@ class Genome:
                 params=params,
                 rng=rng,
                 available_policies=available_policies,
+                diversity_score=diversity_score,
+                mutation_context=mutation_context,
             )
 
         if crossover_mode is GeneticCrossoverMode.DOMINANT_RECESSIVE:
@@ -302,7 +319,8 @@ class Genome:
                 "crossover_mode=%s currently behaves like recombination", crossover_mode.value
             )
 
-        adaptive_rate, adaptive_strength = params.adaptive_mutation()
+        context = mutation_context or ReproductionMutationContext.from_score(diversity_score)
+        adaptive_rate, adaptive_strength = params.adaptive_mutation(context)
 
         physical = PhysicalTraits.from_parents_recombination(
             parent1.physical,
@@ -320,6 +338,9 @@ class Genome:
             mutation_rate=adaptive_rate,
             mutation_strength=adaptive_strength,
             rng=rng,
+            available_policies=available_policies,
+            diversity_score=diversity_score,
+            mutation_context=context,
         )
 
         return cls._assemble_offspring(

--- a/core/genetics/reproduction.py
+++ b/core/genetics/reproduction.py
@@ -6,6 +6,70 @@ from dataclasses import dataclass
 
 from core.evolution.mutation import calculate_adaptive_mutation_rate
 
+DIVERSITY_ESCALATION_FLOOR = 0.20
+DIVERSITY_DANGER_FLOOR = 0.12
+DIVERSITY_RECOVERY_FLOOR = 0.25
+DEFAULT_SUB_BEHAVIOR_SWITCH_RATE = 0.08
+DANGER_SUB_BEHAVIOR_SWITCH_RATE = 0.16
+
+
+@dataclass(frozen=True)
+class ReproductionMutationContext:
+    """Population-level signals used to adapt mutation for one reproduction event.
+
+    A low diversity score alone is not enough to increase mutation. Proposal #25
+    requires a stall signal too, plus a guard that avoids randomizing a surviving
+    underrepresented lineage.
+    """
+
+    diversity_score: float | None = None
+    diversity_slope: float | None = None
+    trait_drift_stalled: bool = False
+    quality_gain_stalled: bool = False
+    escalation_active: bool = False
+    preserve_parent_lineage: bool = False
+
+    @classmethod
+    def from_score(cls, diversity_score: float | None) -> ReproductionMutationContext:
+        return cls(diversity_score=diversity_score)
+
+    @property
+    def diversity_declining(self) -> bool:
+        return self.diversity_slope is not None and self.diversity_slope < 0.0
+
+    @property
+    def has_stall_signal(self) -> bool:
+        return self.diversity_declining or self.trait_drift_stalled or self.quality_gain_stalled
+
+    @property
+    def should_escalate(self) -> bool:
+        if self.preserve_parent_lineage or self.diversity_score is None:
+            return False
+        return self.escalation_active or (
+            self.diversity_score < DIVERSITY_ESCALATION_FLOOR and self.has_stall_signal
+        )
+
+    def mutation_multiplier(self) -> float:
+        if not self.should_escalate or self.diversity_score is None:
+            return 1.0
+        if self.diversity_score < DIVERSITY_DANGER_FLOOR:
+            return 3.0
+
+        span = DIVERSITY_ESCALATION_FLOOR - DIVERSITY_DANGER_FLOOR
+        if span <= 0:
+            return 1.0
+        t = (DIVERSITY_ESCALATION_FLOOR - self.diversity_score) / span
+        return 1.0 + max(0.0, min(1.0, t))
+
+    def sub_behavior_switch_rate(
+        self, base_rate: float = DEFAULT_SUB_BEHAVIOR_SWITCH_RATE
+    ) -> float:
+        if not self.should_escalate or self.diversity_score is None:
+            return base_rate
+        if self.diversity_score < DIVERSITY_DANGER_FLOOR:
+            return DANGER_SUB_BEHAVIOR_SWITCH_RATE
+        return base_rate
+
 
 @dataclass(frozen=True)
 class ReproductionParams:
@@ -17,6 +81,21 @@ class ReproductionParams:
     mutation_rate: float = 0.15  # Increased from 0.1 for faster evolution
     mutation_strength: float = 0.15  # Increased from 0.1 for larger mutations
 
-    def adaptive_mutation(self) -> tuple[float, float]:
+    def adaptive_mutation(
+        self,
+        mutation_context: ReproductionMutationContext | float | None = None,
+    ) -> tuple[float, float]:
         """Return (adaptive_rate, adaptive_strength) after clamping."""
-        return calculate_adaptive_mutation_rate(self.mutation_rate, self.mutation_strength)
+        context: ReproductionMutationContext | None
+        if isinstance(mutation_context, (int, float)):
+            context = ReproductionMutationContext.from_score(float(mutation_context))
+        else:
+            context = mutation_context
+
+        rate = self.mutation_rate
+        strength = self.mutation_strength
+        if context is not None:
+            factor = context.mutation_multiplier()
+            rate *= factor
+            strength *= factor
+        return calculate_adaptive_mutation_rate(rate, strength)

--- a/core/reproduction/asexual_factory.py
+++ b/core/reproduction/asexual_factory.py
@@ -1,0 +1,120 @@
+"""Asexual offspring creation helpers for fish reproduction."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from core.energy.energy_utils import apply_energy_delta
+from core.util.stable_hash import stable_algorithm_id
+
+if TYPE_CHECKING:
+    from core.entities import Fish
+    from core.genetics.reproduction import ReproductionMutationContext
+
+
+def _diversity_score_for(fish: Fish) -> float | None:
+    ecosystem = getattr(fish, "ecosystem", None)
+    diversity_stats = getattr(ecosystem, "genetic_diversity_stats", None)
+    get_diversity_score = getattr(diversity_stats, "get_diversity_score", None)
+    if callable(get_diversity_score):
+        score = get_diversity_score()
+        if score is None:
+            return None
+        return float(score)
+    return None
+
+
+def maybe_create_banked_offspring(
+    fish: Fish,
+    mutation_context: ReproductionMutationContext | None = None,
+) -> Fish | None:
+    """Attempt a bank-funded asexual reproduction for a single fish."""
+    from core.config.fish import ENERGY_MAX_DEFAULT, FISH_BABY_SIZE
+    from core.entities.base import LifeStage
+
+    bank = fish._reproduction_component.overflow_energy_bank
+    baby_energy_needed = ENERGY_MAX_DEFAULT * FISH_BABY_SIZE
+
+    if (
+        fish._reproduction_component.reproduction_cooldown <= 0
+        and fish.life_stage == LifeStage.ADULT
+        and bank >= baby_energy_needed
+    ):
+        return create_asexual_offspring(fish, mutation_context=mutation_context)
+
+    return None
+
+
+def create_asexual_offspring(
+    fish: Fish,
+    mutation_context: ReproductionMutationContext | None = None,
+) -> Fish | None:
+    """Create an offspring from a parent fish through asexual reproduction."""
+    from core.config.fish import ENERGY_MAX_DEFAULT, FISH_BABY_SIZE, FISH_BASE_SPEED
+    from core.entities.fish import Fish
+    from core.genetics.reproduction import ReproductionMutationContext
+    from core.telemetry.events import ReproductionEvent
+    from core.util.rng import require_rng
+
+    rng = require_rng(fish.environment, "ReproductionService.create_asexual_offspring")
+
+    if mutation_context is None:
+        mutation_context = ReproductionMutationContext.from_score(_diversity_score_for(fish))
+
+    (
+        offspring_genome,
+        _unused_fraction,
+    ) = fish._reproduction_component.trigger_asexual_reproduction(
+        fish.genome,
+        rng=rng,
+        mutation_context=mutation_context,
+    )
+
+    pool = getattr(fish.environment, "genome_code_pool", None)
+    if pool is not None:
+        from core.genetics.code_policy_traits import (
+            mutate_code_policies,
+            validate_code_policy_ids,
+        )
+
+        mutate_code_policies(offspring_genome.behavioral, pool, rng)
+        validate_code_policy_ids(offspring_genome.behavioral, pool, rng)
+
+    baby_max_energy = (
+        ENERGY_MAX_DEFAULT * FISH_BABY_SIZE * offspring_genome.physical.size_modifier.value
+    )
+
+    bank_used = fish._reproduction_component.consume_overflow_energy_bank(baby_max_energy)
+    remaining_needed = baby_max_energy - bank_used
+    parent_transfer = min(fish.energy, remaining_needed)
+    apply_energy_delta(fish, -parent_transfer, source="asexual_reproduction")
+    baby_initial_energy = bank_used + parent_transfer
+
+    (min_x, min_y), (max_x, max_y) = fish.environment.get_bounds()
+    offset_x = rng.uniform(-30, 30)
+    offset_y = rng.uniform(-30, 30)
+    baby_x = max(min_x, min(max_x - 50, fish.pos.x + offset_x))
+    baby_y = max(min_y, min(max_y - 50, fish.pos.y + offset_y))
+
+    baby = Fish(
+        environment=fish.environment,
+        movement_strategy=fish.movement_strategy.__class__(),
+        species=fish.species,
+        x=baby_x,
+        y=baby_y,
+        speed=FISH_BASE_SPEED,
+        genome=offspring_genome,
+        generation=fish.generation + 1,
+        ecosystem=fish.ecosystem,
+        initial_energy=baby_initial_energy,
+        parent_id=fish.fish_id,
+    )
+
+    composable = fish.genome.behavioral.behavior
+    if composable is not None and composable.value is not None:
+        behavior_id = composable.value.behavior_id
+        algorithm_id = stable_algorithm_id(behavior_id)
+        fish._emit_event(ReproductionEvent(algorithm_id, is_asexual=True))
+
+    fish.visual_state.set_birth_effect(60)
+    return baby

--- a/core/reproduction/mutation_controller.py
+++ b/core/reproduction/mutation_controller.py
@@ -1,0 +1,112 @@
+"""Diversity feedback controller for reproduction-time mutation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from core.genetics.reproduction import (
+    DIVERSITY_ESCALATION_FLOOR,
+    DIVERSITY_RECOVERY_FLOOR,
+    ReproductionMutationContext,
+)
+
+if TYPE_CHECKING:
+    from core.entities import Fish
+
+
+class DiversityMutationController:
+    """Build mutation contexts from population diversity and lineage signals."""
+
+    SAMPLE_INTERVAL_FRAMES = 500
+    STALL_WINDOW_FRAMES = 10_000
+    UNDERREPRESENTED_LINEAGE_SHARE = 0.15
+
+    def __init__(
+        self,
+        *,
+        diversity_score_provider: Callable[[], float | None],
+        fish_provider: Callable[[], list[Fish]],
+    ) -> None:
+        self._diversity_score_provider = diversity_score_provider
+        self._fish_provider = fish_provider
+        self._diversity_samples: list[tuple[int, float]] = []
+        self._escalation_active = False
+
+    def record_diversity_sample(self, frame: int) -> None:
+        score = self._diversity_score_provider()
+        if score is None:
+            return
+        if (
+            self._diversity_samples
+            and frame - self._diversity_samples[-1][0] < self.SAMPLE_INTERVAL_FRAMES
+        ):
+            return
+
+        self._diversity_samples.append((frame, score))
+        min_frame = frame - self.STALL_WINDOW_FRAMES
+        while self._diversity_samples and self._diversity_samples[0][0] < min_frame:
+            self._diversity_samples.pop(0)
+
+    def context_for_parents(self, *parents: Fish) -> ReproductionMutationContext:
+        diversity_score = self._diversity_score_provider()
+        diversity_slope = self._diversity_slope()
+        diversity_declining = diversity_slope is not None and diversity_slope < 0.0
+
+        if diversity_score is None or (
+            self._escalation_active and diversity_score >= DIVERSITY_RECOVERY_FLOOR
+        ):
+            self._escalation_active = False
+        elif (
+            not self._escalation_active
+            and diversity_score < DIVERSITY_ESCALATION_FLOOR
+            and diversity_declining
+        ):
+            self._escalation_active = True
+
+        return ReproductionMutationContext(
+            diversity_score=diversity_score,
+            diversity_slope=diversity_slope,
+            escalation_active=self._escalation_active,
+            preserve_parent_lineage=self._preserve_underrepresented_lineage(parents),
+        )
+
+    def _diversity_slope(self) -> float | None:
+        if len(self._diversity_samples) < 2:
+            return None
+        first_frame, first_score = self._diversity_samples[0]
+        last_frame, last_score = self._diversity_samples[-1]
+        frame_span = last_frame - first_frame
+        if frame_span <= 0:
+            return None
+        return (last_score - first_score) / frame_span
+
+    def _preserve_underrepresented_lineage(self, parents: tuple[Fish, ...]) -> bool:
+        fish_list = self._fish_provider()
+        if len(fish_list) < 4 or not parents:
+            return False
+
+        counts: dict[str, int] = {}
+        for fish in fish_list:
+            behavior_id = self._behavior_id_for(fish)
+            if behavior_id is not None:
+                counts[behavior_id] = counts.get(behavior_id, 0) + 1
+
+        if len(counts) <= 1:
+            return False
+
+        population = len(fish_list)
+        for parent in parents:
+            behavior_id = self._behavior_id_for(parent)
+            if behavior_id is None:
+                continue
+            if counts.get(behavior_id, 0) / population <= self.UNDERREPRESENTED_LINEAGE_SHARE:
+                return True
+        return False
+
+    @staticmethod
+    def _behavior_id_for(fish: Fish) -> str | None:
+        behavior = fish.genome.behavioral.behavior
+        if behavior is None or behavior.value is None:
+            return None
+        return behavior.value.behavior_id

--- a/core/reproduction/reproduction_service.py
+++ b/core/reproduction/reproduction_service.py
@@ -7,10 +7,16 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from core.energy.energy_utils import apply_energy_delta
+from core.reproduction.asexual_factory import (
+    create_asexual_offspring,
+    maybe_create_banked_offspring,
+)
+from core.reproduction.mutation_controller import DiversityMutationController
 from core.util.stable_hash import stable_algorithm_id
 
 if TYPE_CHECKING:
     from core.entities import Fish
+    from core.genetics.reproduction import ReproductionMutationContext
     from core.poker.integration.poker_interaction import PokerInteraction
     from core.simulation import SimulationEngine
 
@@ -42,6 +48,10 @@ class ReproductionService:
         self._emergency_spawns: int = 0
         self._poker_reproductions: int = 0
         self._plant_asexual_reproductions: int = 0
+        self._mutation_controller = DiversityMutationController(
+            diversity_score_provider=self._get_diversity_score,
+            fish_provider=self._get_fish_entities,
+        )
 
         try:
             cooldown = engine.config.ecosystem.emergency_spawn_cooldown
@@ -53,6 +63,7 @@ class ReproductionService:
         """Run reproduction logic for the current frame."""
         fish_list = self._get_fish_entities()
         self._update_cooldowns(fish_list)
+        self._mutation_controller.record_diversity_sample(frame)
 
         fish_count = len(fish_list)
 
@@ -188,7 +199,8 @@ class ReproductionService:
         ):
             return None
 
-        baby = winner_fish._create_asexual_offspring()
+        mutation_context = self._mutation_context_for_parents(winner_fish)
+        baby = self.create_asexual_offspring(winner_fish, mutation_context=mutation_context)
         if baby is None:
             return None
 
@@ -214,14 +226,24 @@ class ReproductionService:
         }
 
     def _get_fish_entities(self) -> list[Fish]:
-        # engine.entity_manager is a typed property and get_fish() is the canonical
-        # typed fish view; the prior getattr/callable/cast dance guarded a fallback
-        # branch that could never run (get_fish always exists).
         return self._engine.entity_manager.get_fish()
 
     def _update_cooldowns(self, fish_list: list[Fish]) -> None:
         for fish in fish_list:
             fish._reproduction_component.update_cooldown()
+
+    def _get_diversity_score(self) -> float | None:
+        ecosystem = self._engine.ecosystem
+        if ecosystem is None:
+            return None
+        diversity_stats = getattr(ecosystem, "genetic_diversity_stats", None)
+        if diversity_stats is None:
+            return None
+        score = diversity_stats.get_diversity_score()
+        return None if score is None else float(score)
+
+    def _mutation_context_for_parents(self, *parents: Fish) -> ReproductionMutationContext:
+        return self._mutation_controller.context_for_parents(*parents)
 
     def _handle_banked_asexual_reproduction(self, fish_list: list[Fish], fish_count: int) -> int:
         spawned = 0
@@ -239,7 +261,8 @@ class ReproductionService:
             ):
                 continue
 
-            baby = self.maybe_create_banked_offspring(fish)
+            mutation_context = self._mutation_context_for_parents(fish)
+            baby = self.maybe_create_banked_offspring(fish, mutation_context=mutation_context)
             if baby is None:
                 continue
 
@@ -281,7 +304,11 @@ class ReproductionService:
             asexual_trait = fish.genome.behavioral.asexual_reproduction_chance.value
             rng = fish.environment.rng
             if rng.random() < asexual_trait:
-                baby = fish._create_asexual_offspring()
+                mutation_context = self._mutation_context_for_parents(fish)
+                try:
+                    baby = fish._create_asexual_offspring(mutation_context=mutation_context)
+                except TypeError:
+                    baby = fish._create_asexual_offspring()
                 if baby is not None:
                     if self._engine.request_spawn(baby, reason="asexual_reproduction"):
                         baby.register_birth()
@@ -355,10 +382,12 @@ class ReproductionService:
         fish_list = self._get_fish_entities()
         if fish_list:
             parent = self._select_diverse_parent(fish_list)
+            mutation_context = self._mutation_context_for_parents(parent)
             # Clone with light mutation to maintain diversity
             genome = Genome.clone_with_mutation(
                 parent=parent.genome,
                 rng=self._engine.rng,
+                mutation_context=mutation_context,
             )
             generation = parent.generation  # Inherit generation for tracking
         else:
@@ -444,32 +473,17 @@ class ReproductionService:
         return best_fish
 
     def _get_repro_credit_required(self) -> float:
-        # config and config.soccer are always present (typed dataclass fields with
-        # defaults), so read them directly and let mypy guard the field names.
         soccer_cfg = self._engine.config.soccer
         if not soccer_cfg.enabled or soccer_cfg.repro_reward_mode != "credits":
             return 0.0
         return max(0.0, soccer_cfg.repro_credit_required)
 
     @staticmethod
-    def maybe_create_banked_offspring(fish: Fish) -> Fish | None:
-        """Attempt a bank-funded asexual reproduction for a single fish."""
-        from core.config.fish import ENERGY_MAX_DEFAULT, FISH_BABY_SIZE
-        from core.entities.base import LifeStage
-
-        bank = fish._reproduction_component.overflow_energy_bank
-        baby_energy_needed = ENERGY_MAX_DEFAULT * FISH_BABY_SIZE
-
-        life_stage = fish.life_stage
-
-        if (
-            fish._reproduction_component.reproduction_cooldown <= 0
-            and life_stage == LifeStage.ADULT
-            and bank >= baby_energy_needed
-        ):
-            return fish._create_asexual_offspring()
-
-        return None
+    def maybe_create_banked_offspring(
+        fish: Fish,
+        mutation_context: ReproductionMutationContext | None = None,
+    ) -> Fish | None:
+        return maybe_create_banked_offspring(fish, mutation_context=mutation_context)
 
     def _create_post_poker_offspring(self, winner: Fish, mate: Fish) -> Fish | None:
         from core.config.fish import (
@@ -488,6 +502,8 @@ class ReproductionService:
         if winner.environment is None:
             return None
 
+        mutation_context = self._mutation_context_for_parents(winner, mate)
+
         offspring_genome = Genome.from_parents_weighted_params(
             parent1=winner.genome,
             parent2=mate.genome,
@@ -497,6 +513,7 @@ class ReproductionService:
                 mutation_strength=POST_POKER_MUTATION_STRENGTH,
             ),
             rng=self._engine.rng,
+            mutation_context=mutation_context,
         )
 
         # Pool-aware per-kind policy mutation (prevents cross-kind contamination)
@@ -586,78 +603,8 @@ class ReproductionService:
         return baby
 
     @staticmethod
-    def create_asexual_offspring(fish: Fish) -> Fish | None:
-        """Create an offspring from a parent fish through asexual reproduction."""
-        from core.config.fish import ENERGY_MAX_DEFAULT, FISH_BABY_SIZE, FISH_BASE_SPEED
-        from core.entities.fish import Fish
-        from core.telemetry.events import ReproductionEvent
-        from core.util.rng import require_rng
-
-        rng = require_rng(fish.environment, "ReproductionService.create_asexual_offspring")
-
-        # Generate offspring genome (also sets cooldown)
-        (
-            offspring_genome,
-            _unused_fraction,
-        ) = fish._reproduction_component.trigger_asexual_reproduction(
-            fish.genome,
-            rng=rng,
-        )
-
-        # Pool-aware per-kind policy mutation
-        pool = getattr(fish.environment, "genome_code_pool", None)
-        if pool is not None:
-            from core.genetics.code_policy_traits import (
-                mutate_code_policies,
-                validate_code_policy_ids,
-            )
-
-            mutate_code_policies(offspring_genome.behavioral, pool, rng)
-            validate_code_policy_ids(offspring_genome.behavioral, pool, rng)
-
-        # Calculate baby's max energy capacity
-        baby_max_energy = (
-            ENERGY_MAX_DEFAULT * FISH_BABY_SIZE * offspring_genome.physical.size_modifier.value
-        )
-
-        # Use banked overflow energy first, then draw from parent
-        bank_used = fish._reproduction_component.consume_overflow_energy_bank(baby_max_energy)
-        remaining_needed = baby_max_energy - bank_used
-        parent_transfer = min(fish.energy, remaining_needed)
-        apply_energy_delta(fish, -parent_transfer, source="asexual_reproduction")
-        baby_initial_energy = bank_used + parent_transfer
-
-        # Create offspring near parent
-        bounds = fish.environment.get_bounds()
-        (min_x, min_y), (max_x, max_y) = bounds
-
-        offset_x = rng.uniform(-30, 30)
-        offset_y = rng.uniform(-30, 30)
-        baby_x = max(min_x, min(max_x - 50, fish.pos.x + offset_x))
-        baby_y = max(min_y, min(max_y - 50, fish.pos.y + offset_y))
-
-        baby = Fish(
-            environment=fish.environment,
-            movement_strategy=fish.movement_strategy.__class__(),
-            species=fish.species,
-            x=baby_x,
-            y=baby_y,
-            speed=FISH_BASE_SPEED,
-            genome=offspring_genome,
-            generation=fish.generation + 1,
-            ecosystem=fish.ecosystem,
-            initial_energy=baby_initial_energy,
-            parent_id=fish.fish_id,
-        )
-
-        # Record reproduction stats
-        composable = fish.genome.behavioral.behavior
-        if composable is not None and composable.value is not None:
-            behavior_id = composable.value.behavior_id
-            algorithm_id = stable_algorithm_id(behavior_id)
-            fish._emit_event(ReproductionEvent(algorithm_id, is_asexual=True))
-
-        # Set visual birth effect timer
-        fish.visual_state.set_birth_effect(60)
-
-        return baby
+    def create_asexual_offspring(
+        fish: Fish,
+        mutation_context: ReproductionMutationContext | None = None,
+    ) -> Fish | None:
+        return create_asexual_offspring(fish, mutation_context=mutation_context)

--- a/tests/test_god_class_limits.py
+++ b/tests/test_god_class_limits.py
@@ -50,7 +50,7 @@ LEGACY_MAX_LINES: dict[str, int] = {
     "core/poker/simulation/hand_engine.py": 754,
     "core/poker/stats/poker_stats_manager.py": 578,
     "core/poker/strategy/composable/strategy.py": 764,
-    "core/reproduction/reproduction_service.py": 663,
+    "core/reproduction/reproduction_service.py": 610,
     "core/simulation/engine.py": 595,
     "core/solutions/benchmark.py": 543,
     "core/solutions/tracker.py": 590,

--- a/tests/test_reproduction_params.py
+++ b/tests/test_reproduction_params.py
@@ -1,6 +1,9 @@
 import random
 
-from core.genetics import Genome, ReproductionParams
+import pytest
+
+from core.genetics import Genome, ReproductionMutationContext, ReproductionParams
+from core.genetics.reproduction import DANGER_SUB_BEHAVIOR_SWITCH_RATE
 
 
 def test_from_parents_weighted_params_matches_direct_call() -> None:
@@ -27,3 +30,46 @@ def test_from_parents_weighted_params_matches_direct_call() -> None:
     )
 
     assert child_params.debug_snapshot() == child_direct.debug_snapshot()
+
+
+def test_low_diversity_without_stall_signal_does_not_escalate_mutation() -> None:
+    params = ReproductionParams(mutation_rate=0.15, mutation_strength=0.15)
+
+    rate, strength = params.adaptive_mutation(ReproductionMutationContext(diversity_score=0.11))
+
+    assert rate == pytest.approx(0.15)
+    assert strength == pytest.approx(0.15)
+
+
+def test_declining_low_diversity_escalates_with_bounds() -> None:
+    params = ReproductionParams(mutation_rate=0.15, mutation_strength=0.15)
+
+    rate, strength = params.adaptive_mutation(
+        ReproductionMutationContext(diversity_score=0.11, diversity_slope=-0.00001)
+    )
+
+    assert rate == pytest.approx(0.35)
+    assert strength == pytest.approx(0.25)
+
+
+def test_lineage_preservation_blocks_escalation() -> None:
+    params = ReproductionParams(mutation_rate=0.15, mutation_strength=0.15)
+
+    rate, strength = params.adaptive_mutation(
+        ReproductionMutationContext(
+            diversity_score=0.11,
+            diversity_slope=-0.00001,
+            preserve_parent_lineage=True,
+        )
+    )
+
+    assert rate == pytest.approx(0.15)
+    assert strength == pytest.approx(0.15)
+
+
+def test_danger_zone_escalates_behavior_switch_rate_only_when_active() -> None:
+    inactive = ReproductionMutationContext(diversity_score=0.11)
+    active = ReproductionMutationContext(diversity_score=0.11, diversity_slope=-0.00001)
+
+    assert inactive.sub_behavior_switch_rate(0.08) == pytest.approx(0.08)
+    assert active.sub_behavior_switch_rate(0.08) == pytest.approx(DANGER_SUB_BEHAVIOR_SWITCH_RATE)


### PR DESCRIPTION
## Summary

Implements board proposal #25: diversity-gated mutation/HGT escalation with hysteresis and lineage preservation.

- Adds `ReproductionMutationContext` so mutation rate/strength and composable sub-behavior switching escalate only when low diversity also has a stall/negative-trend signal.
- Adds `DiversityMutationController` to sample diversity over a rolling 10k-frame window, activate below 0.20 with decline, recover at 0.25, and preserve underrepresented parent lineages.
- Extracts asexual offspring construction into `core/reproduction/asexual_factory.py`, keeping `reproduction_service.py` under its god-class guard.
- Threads mutation context through weighted crossover, asexual reproduction, emergency clone spawning, and post-poker offspring paths.

## Evidence

Reproduction diagnostic before implementation:

```bash
.\.venv\Scripts\python.exe scripts/diagnose_evolution.py --frames 10000 --seed 42 --interval 1000
```

Baseline result: selection active, 5 generations advanced; pursuit -47.9%, prediction -7.1%, stamina +46.3%, aggression -26.6%, size +16.4%.

Candidate benchmark:

```bash
.\.venv\Scripts\python.exe tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 42 --out C:\Users\mike\AppData\Local\Temp\tank-build25\ecosystem_seed42.json
.\.venv\Scripts\python.exe tools/validate_improvement.py C:\Users\mike\AppData\Local\Temp\tank-build25\ecosystem_seed42.json champions/tank/ecosystem_health_10k.json
```

Seed 42 score: `8.333443779264227` vs champion `7.334041`, diff `+0.999402`.
Metadata: `config_hash=0b6bfb9fd9cdb0b5`, `max_generation=8`, `generation_rate=8.0`, `starvation_rate=0.9958`, `unique_algorithms=22`, `diversity_score=0.2815`, `mean_pop=50.46`, `final_pop=48`.

Determinism:

```bash
.\.venv\Scripts\python.exe tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 42 --verify-determinism --out C:\Users\mike\AppData\Local\Temp\tank-build25\ecosystem_seed42_verify.json
```

Result: passed.

Trait drift diagnostics after implementation:

```bash
.\.venv\Scripts\python.exe scripts/diagnose_evolution.py --frames 10000 --seed 42 --interval 1000
.\.venv\Scripts\python.exe scripts/diagnose_evolution.py --frames 10000 --seed 7 --interval 1000
.\.venv\Scripts\python.exe scripts/diagnose_evolution.py --frames 10000 --seed 123 --interval 1000
```

Results: seed 42 advanced 8 generations with selection active; seed 7 advanced 7 generations with selection active; seed 123 advanced 8 generations with selection active.

Additional candidate benchmarks:

- Seed 7: score `9.461400845238579`, `max_generation=9`, `diversity_score=0.294`, `final_pop=49`.
- Seed 123: score `6.342182324980881`, `max_generation=7`, `diversity_score=0.1764`, `final_pop=53`.

## Validation

```bash
.\.venv\Scripts\python.exe -m pytest tests/test_god_class_limits.py tests/test_reproduction_params.py tests/test_life_evolution_flow.py::test_multi_generation_reproduction tests/test_reproduction_credits.py::test_reproduction_requires_credits -q
.\.venv\Scripts\python.exe tools/smoke_gate.py
.\.venv\Scripts\python.exe tools/fast_gate.py
.\.venv\Scripts\python.exe tools/agent_gate.py
```

Results:

- Focused tests: 9 passed.
- Smoke gate: passed.
- Fast gate: passed, 1753 passed, 3 skipped, 157 deselected.
- Agent gate: passed, 575 passed, 100 deselected after smoke.
