### PR TITLE
Fix memory leak in browser UI canvas renderer

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -115,12 +115,19 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
         // Initialize renderers (idempotent)
         initRenderers();
 
+        // Local cache of the active renderer to prevent recreating it on every frame in renderLoop
+        let currentRenderer: Renderer | null = null;
+        let currentWorldType = '';
+        let currentViewMode: 'side' | 'topdown' | '' = '';
+
         // Initial renderer setup - will be updated in render loop based on state
         const initialWorldType = 'tank'; // Default until state arrives
-        const effectiveViewMode = viewMode || 'side';
+        const initialViewMode = viewMode || 'side';
 
-        const renderer = rendererRegistry.getRenderer(initialWorldType, effectiveViewMode);
-        rendererRef.current = renderer;
+        currentRenderer = rendererRegistry.getRenderer(initialWorldType, initialViewMode);
+        rendererRef.current = currentRenderer;
+        currentWorldType = initialWorldType;
+        currentViewMode = initialViewMode;
 
         // Preload images
         const loadImages = async () => {
@@ -158,10 +165,22 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
                         // Petri/Soccer = topdown view
                         effectiveViewMode = 'topdown';
                     }
-                    const renderer = rendererRegistry.getRenderer(worldType, effectiveViewMode);
-                    rendererRef.current = renderer;
 
-                    renderer.render({
+                    // Only retrieve a new renderer when the worldType or viewMode changes
+                    if (!currentRenderer || worldType !== currentWorldType || effectiveViewMode !== currentViewMode) {
+                        if (currentRenderer) {
+                            if (import.meta.env.DEV) {
+                                console.debug('[Canvas] Disposing old Renderer due to mode change:', currentWorldType, currentViewMode);
+                            }
+                            currentRenderer.dispose();
+                        }
+                        currentRenderer = rendererRegistry.getRenderer(worldType, effectiveViewMode);
+                        rendererRef.current = currentRenderer;
+                        currentWorldType = worldType;
+                        currentViewMode = effectiveViewMode;
+                    }
+
+                    currentRenderer.render({
                         worldType,
                         viewMode: effectiveViewMode,
                         snapshot: currentState,
@@ -188,11 +207,12 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
 
         return () => {
             cancelAnimationFrame(animationFrameId);
-            if (rendererRef.current) {
+            if (currentRenderer) {
                 if (import.meta.env.DEV) {
                     console.debug('[Canvas] Disposing Renderer');
                 }
-                rendererRef.current.dispose();
+                currentRenderer.dispose();
+                currentRenderer = null;
                 rendererRef.current = null;
             }
         };

--- a/frontend/src/rendering/registry.test.ts
+++ b/frontend/src/rendering/registry.test.ts
@@ -27,10 +27,10 @@ describe('RendererRegistry', () => {
         expect(renderer.id).toBe('fallback');
     });
 
-    it('should cache renderer instances', () => {
+    it('should return distinct renderer instances', () => {
         rendererRegistry.register('tank', 'side', () => new MockRenderer());
         const r1 = rendererRegistry.getRenderer('tank', 'side');
         const r2 = rendererRegistry.getRenderer('tank', 'side');
-        expect(r1).toBe(r2);
+        expect(r1).not.toBe(r2);
     });
 });

--- a/frontend/src/rendering/registry.ts
+++ b/frontend/src/rendering/registry.ts
@@ -24,8 +24,6 @@ type RendererFactory = () => Renderer;
 
 class RendererRegistry {
     private factories: Map<string, RendererFactory> = new Map();
-    // Cache instantiated renderers: key = "worldType:viewMode"
-    private instances: Map<string, Renderer> = new Map();
 
     register(worldType: WorldType, viewMode: ViewMode, factory: RendererFactory) {
         const key = this.getKey(worldType, viewMode);
@@ -34,23 +32,16 @@ class RendererRegistry {
 
     getRenderer(worldType: WorldType, viewMode: ViewMode): Renderer {
         const key = this.getKey(worldType, viewMode);
-
-        if (!this.instances.has(key)) {
-            const factory = this.factories.get(key);
-            if (factory) {
-                this.instances.set(key, factory());
-            } else {
-                return new FallbackRenderer();
-            }
+        const factory = this.factories.get(key);
+        if (factory) {
+            return factory();
         }
-
-        return this.instances.get(key)!;
+        return new FallbackRenderer();
     }
 
     // Helper to clear instances if we need to full reset (e.g. hmr)
     reset() {
-        this.instances.forEach(r => r.dispose());
-        this.instances.clear();
+        // No cached instances to clear anymore as renderers are instantiated per canvas
     }
 
     // Check if a renderer is registered for this world/view combination


### PR DESCRIPTION
### Description

This PR fixes a severe browser UI memory leak that causes the simulation web interface to run out of memory and crash/stop responding after a few hours of operation.

#### Cause of the OOM:
- `RendererRegistry` was globally caching stateful renderer instances (like `TankSideRenderer`).
- When multiple canvas components were mounted (e.g. main view + tank thumbnails in the dashboard), they shared the same renderer. Because they have different contexts (`ctx`), the renderer constantly detected context changes on every frame, disposing of old `TankRenderer` sub-instances and allocating new ones (creating temporary canvases and clearing maps).
- When a thumbnail or sub-canvas unmounted, it disposed of the globally shared renderer, forcing other active canvases to recreate their internal canvases and textures.
- This resulted in an enormous GC churn and context-switching storm that eventually led to a browser OOM crash.

#### Changes Made:
- **Decoupled Registry**: Changed `getRenderer` in `registry.ts` to act as a factory that instantiates a new renderer instance on every call rather than returning a globally shared instance.
- **Canvas-Level Ownership**: Updated `Canvas.tsx` to cache its renderer instance locally in `useEffect` and only retrieve/dispose of a new renderer when `worldType` or `viewMode` changes. Disposes of the renderer cleanly upon canvas unmount.
- **Tests Updated**: Adjusted `registry.test.ts` to verify that `getRenderer` returns distinct instances, ensuring thread/element isolation.

All 43 unit tests pass successfully.
