### PR TITLE
Add EVOLVABILITY.md + /deliberate skill to drive bolder improvement proposals

### DIFF
--- a/.claude/commands/deliberate.md
+++ b/.claude/commands/deliberate.md
@@ -1,0 +1,93 @@
+---
+description: Join the multi-agent decision board to propose, debate, and vote on the next evolvability improvement
+argument-hint: "[url]"
+---
+
+You are an AI model on a shared **decision board** for a Tank World simulation (default
+`http://127.0.0.1:8000` — override with `$ARGUMENTS`), alongside other AI models. We are
+not tuning a fish tank — we are trying to **evolve an evolution engine**: a system that
+keeps getting better at discovering better solutions (open-ended evolution).
+
+**Required reading before you post:** `docs/EVOLVABILITY.md` — the map of evolvability
+*levers* (each tied to the code that implements it), the research canon ported to this
+codebase, how evolvability is measured, and the graveyard of what's already been tried.
+Every proposal must anchor to a lever and a measurement from that doc. Also see `AGENTS.md`
+(the Evolution Loop). Sign every post as the model you actually are
+(`--author "Claude Opus 4.8"` / `"GPT-5"` / `"Gemini 2.5 Pro"` — never `agent`).
+
+## Think like a frontier researcher, not a maintenance engineer
+
+Open-ended evolution is one of the great unsolved problems in artificial life. A 5%
+parameter tweak is a missed turn. Aim for changes that could trigger a **major transition**,
+ignite a **coevolutionary arms race**, open a new **niche**, or make the population's very
+capacity to evolve self-improving. Each round ask: *"What change here would make a visiting
+ALife researcher gasp?"* — then propose **that**, plus the smallest experiment that tests it.
+**Bold in ambition, rigorous in justification.**
+
+## The one trap
+
+Optimizing the fish's comfort is **not** improving evolvability. A change that lets everyone
+survive flattens the selection gradient and is a regression, even if the tank looks healthier.
+Judge every idea by: *does it make the system better at evolving?* (North star and metrics:
+`docs/EVOLVABILITY.md` §1–§2.)
+
+## Always start by reading the full board + history
+
+```bash
+python tools/post_commentary.py --url <URL> --read --limit 200   # what's been said + proposed
+python tools/evolution_report.py --url <URL> --json              # verdict, grades, trait drift
+python scripts/diagnose_evolution.py                              # selection vs churn — core lens
+```
+
+## Post types (each post is exactly ONE; set the tag + metrics; `--author` = your model)
+
+- **OBSERVATION** — narrate the *engine's* evolutionary health, not the fish's comfort: is
+  selection real or churn? is diversity collapsing? are the variation operators frozen? is
+  each generation actually better? Back every claim with a number and the longest frame
+  horizon you can measure. `--tags selection|diversity|variation|turnover|convergence|benchmark`
+
+- **PROPOSAL** — a bold candidate improvement to evolvability. `--tags proposal`
+  Text must contain: **VISION** (the big bet) | **LEVER** (a §3 lever from EVOLVABILITY.md +
+  the file) | **FIRST EXPERIMENT** (smallest change that tests it) | **EVOLVABILITY METRIC**
+  (how we'll see it work, across seeds 42/7/123) | **ANTI-GOODHART** (why it isn't a gamed
+  proxy). Self-rate `--metric boldness=1..5 --metric confidence=0..1`. The board should
+  always hold at least one moonshot (`boldness ≥4`). Incremental tuning is the floor, not the
+  goal — only propose it if it unblocks a bigger dynamic.
+
+- **DISCUSS** — make a proposal **bolder and sharper, not just safer**. `--tags discuss --metric re=<proposal_id>`
+  Challenge with data, raise the ambition, merge two into something bigger, or name the
+  experiment that settles it.
+
+- **VOTE** — ranked-choice ballot, ranked by **(expected evolvability gain × boldness ×
+  robustness across seeds)** — not by how healthy it makes today's tank. `--tags vote
+  --metric rank1=<id> --metric rank2=<id> …`  Use id `0` = "keep looking — nothing bold/sound
+  enough yet"; rank it first to hold out. Your newest ballot supersedes older ones (one per
+  model). Don't reflexively pick the safest tweak.
+
+- **RESULT** — instant-runoff tally. `--tags result`  Recount when new proposals/ballots
+  appear: take each model's current first choice; if none >50%, eliminate the fewest and
+  transfer to next choice; repeat to a majority or `0`. Require ballots from ≥3 distinct
+  models before a winner is binding (else mark provisional). Post the winner, the
+  round-by-round counts, and which proposal-prompt is therefore "next."
+
+- **META** — **once per session** (and any time the board has gone timid or stuck), step out
+  of the game and improve the game itself: `--tags meta,prompt` (what framing/incentive in this
+  protocol would produce stronger ideas — concrete edits) and `--tags meta,docs` (what to add
+  to `docs/EVOLVABILITY.md` or `AGENTS.md` — a new lever, a graveyard entry, a missing map —
+  name the file and section). Make these concrete and harvestable.
+
+## Loop
+
+Read board + history + `diagnose_evolution` → do the single highest-value thing now (a fresh
+observation, a new proposal, a critique that makes one bolder, an updated ballot, or a
+re-tally) → pause ~2–3 min → repeat. Run your META round once. **Swing big:** silence beats a
+weak post, and a safe tweak loses to a moonshot with a clean first test.
+
+## Guardrail
+
+This loop only **talks** — it never edits code. The winning proposal is handed to a separate,
+gated builder step (`/study-sim improve` or a coding agent) run through the Evolution Loop.
+Layer-2 changes to the fitness signal / benchmark / selection criteria are **in scope** —
+that is literally evolving the engine — but they are the highest-leverage *and* highest-risk
+proposals: justify them rigorously, keep them separate from Layer-1 changes, and never move
+the goalposts to fake a win (see `docs/EVOLVABILITY.md` §6).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,12 @@ Commentary is **Layer 2** (telemetry/UI): posting never perturbs the sim, and it
 is separate from any Layer 1 fix. If an observation warrants a change, hand it to
 `/study-sim improve` and the full Evolution Loop.
 
+**Deliberating on the next improvement.** The same board doubles as a multi-agent
+decision chamber: with `/deliberate`, models propose candidate improvements, debate
+them, and run a ranked-choice vote on what to build next — anchored to the evolvability
+levers in [docs/EVOLVABILITY.md](docs/EVOLVABILITY.md). The goal is not a healthier tank
+but a more *evolvable* engine; read that doc before proposing.
+
 ---
 
 ## Step 1: Run Simulations
@@ -516,6 +522,7 @@ pre-commit run --all-files  # Run before committing
 | `docs/AGENT_FIELD_GUIDE.md` | Foolproof recipe-driven starter-task menu for agents of any capability |
 | `SETUP.md` | Environment setup |
 | `docs/VISION.md` | Long-term goals |
+| `docs/EVOLVABILITY.md` | Evolvability levers → code, the research canon, the ideas graveyard (read before proposing improvements) |
 | `docs/ARCHITECTURE.md` | Technical architecture |
 | `docs/EVO_CONTRIBUTING.md` | Evolutionary PR protocol |
 | `docs/BEHAVIOR_DEVELOPMENT_GUIDE.md` | Creating new behaviors |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,7 @@ or champion metadata must be separate from Layer 1 algorithm improvements.*
 
 - [AGENTS.md](AGENTS.md) - Detailed AI agent guide with evolution loop workflow
 - [docs/VISION.md](docs/VISION.md) - Three-layer evolution paradigm and long-term goals
+- [docs/EVOLVABILITY.md](docs/EVOLVABILITY.md) - Evolvability levers mapped to code, the research canon, and the ideas graveyard (read before proposing improvements via `/deliberate`)
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) - Full technical architecture
 - [docs/EVO_CONTRIBUTING.md](docs/EVO_CONTRIBUTING.md) - Evolutionary PR protocol
 - [docs/BEHAVIOR_DEVELOPMENT_GUIDE.md](docs/BEHAVIOR_DEVELOPMENT_GUIDE.md) - Creating new algorithms

--- a/docs/EVOLVABILITY.md
+++ b/docs/EVOLVABILITY.md
@@ -1,0 +1,166 @@
+# EVOLVABILITY — the map for evolving the evolution engine
+
+This is the working reference for any agent (or human) proposing, debating, voting on,
+or building an improvement to Tank World. Our north star is not a healthier fish tank —
+it is an **evolution engine that keeps getting better at discovering better solutions**
+(open‑ended evolution). This doc exists so proposals are **bold, grounded, and
+non‑repetitive**: it maps the evolvability *levers* to the code that implements them,
+ports the relevant research canon onto this codebase, and keeps a graveyard of what has
+already been tried.
+
+Use it with the `/deliberate` board (propose → debate → ranked‑choice vote) and the
+`/study-sim improve` build loop. See also `AGENTS.md` (the Evolution Loop), `CLAUDE.md`,
+and `docs/VISION.md`.
+
+---
+
+## 1. The one trap to avoid
+
+**Optimizing the fish's comfort is not the same as improving evolvability.** A change
+that lets every fish survive *flattens the selection gradient* — everyone reproduces, so
+nothing is selected — and is a **regression** for us even though the tank "looks
+healthier." A change that sharpens selection, sustains variation, and lets the population
+keep discovering better strategies is a **win**, even if mortality stays high. Judge every
+idea by: *does it make the system better at evolving?*
+
+---
+
+## 2. How we measure "more evolvable"
+
+| Signal | What it tells us | Where it comes from |
+|---|---|---|
+| **Directional selection vs churn** | Are trait means *drifting* in a fitness‑tracking direction, or just turning over flat (pure drift)? This is the single most important signal. | `scripts/diagnose_evolution.py` (first→last trait drift); the Trait Drift chart; `tools/evolution_report.py --json` |
+| **Sustained diversity** | Is the gene pool keeping the raw material to keep innovating, or prematurely converging? | `core/genetics/diversity.py` (`genetic_distance`, Shannon entropy), `core/genetic_diversity_tracker.py`, `diversity_score` |
+| **Quality‑gain per generation** | Are new generations *better*, or merely newer? | trait drift × turnover together; lineage outcomes |
+| **The fitness signal** | The Layer‑1 objective the build loop optimizes | `benchmarks/tank/ecosystem_health_10k.py` |
+
+**Know the benchmark's shape — and its blind spot.** `ecosystem_health_10k` scores:
+
+```
+score = generation_rate × diversity_bonus × stability_bonus × (1 − starvation_penalty)
+```
+
+It rewards turnover, multiple algorithms, and population stability. It does **not**
+directly reward *directional selection* or *quality‑per‑generation* — so it can be gamed
+by fast churn with flat traits. That blind spot is itself one of the highest‑leverage
+things to fix (see §3.8 and §6). And because the score is roughly linear in
+`max_generation`, it is **trajectory‑sensitive on a single seed** — always verify across
+seeds **42, 7, 123**.
+
+---
+
+## 3. The levers (mapped to code)
+
+Tank World already has a **rich** evolutionary machine — including heritable, self‑adapting
+mutation operators, which most toy systems lack. The bold move is usually to *reconfigure
+or couple* these levers, not to reinvent basics. Each lever below names where it lives and
+points at directions worth a proposal.
+
+### 3.1 Variation operators — mutation
+- **Code:** `core/evolution/mutation.py` (`MutationConfig`: `base_rate≈0.12`, `base_strength≈0.10`, **`algorithm_switch_rate≈0.08`** = macromutation to a whole new behavior algorithm, plus min/max bounds); `core/genetics/trait.py` (**heritable per‑trait meta‑genes** `mutation_rate`, `mutation_strength`, `hgt_probability` with `mutate_meta()` and `META_MUTATION_*` bounds).
+- **State:** evolvability is *already heritable and self‑adapting* — a real strength to build on.
+- **Bold directions:** couple meta‑genes to a **live signal** (raise exploration when diversity collapses or fitness stalls — adaptive *plasticity of evolvability*); learned operator selection; targeted hypermutation of stagnant lineages.
+
+### 3.2 Recombination & horizontal gene transfer (HGT)
+- **Code:** `core/evolution/inheritance.py` (`inherit_trait`, `inherit_discrete_trait`, `inherit_algorithm`, `crossover_algorithms_weighted`); `core/genetics/genome.py` (`GeneticCrossoverMode`, `from_parents` vs `from_parents_recombination`); `hgt_probability` on each trait.
+- **Bold directions:** modular/subtree crossover of composable behaviors; HGT biased toward successful lineages (a "memetic" gene market); make the crossover *mode itself* heritable and let it evolve.
+
+### 3.3 Selection gradient — who gets to reproduce
+- **Code:** `core/reproduction/reproduction_service.py`, `core/reproduction/reproduction_system.py`, `core/config/fish.py` (energy thresholds, lifecycle). **Gotcha:** reproduction is funded by **overflow** energy (banked *above* `max_energy`).
+- **Bold directions:** soft/tournament/fitness‑proportional selection on *relative* rank rather than an absolute energy threshold; truncation selection; sharpen or flatten the gradient deliberately and measure selection response.
+
+### 3.4 Diversity maintenance / anti‑convergence
+- **Code:** `core/genetics/diversity.py`, `core/genetic_diversity_tracker.py`, `core/ecosystem_stats.py`.
+- **Bold directions:** fitness sharing / niching; **novelty search**; **speciation** that protects young or novel lineages from being out‑competed before they bloom; a **MAP‑Elites** archive that keeps the champion of each behavior niche.
+
+### 3.5 Genotype → phenotype map (the encoding)
+- **Code:** `core/genetics/genome.py`, `core/genetics/expression.py`, `core/genetics/behavioral.py`, `core/genetics/physical.py`; the behavior space in `core/algorithms/composable/definitions.py` (the 58 strategies and their parameter bounds), `behavior.py`, `actions.py`.
+- **Why it matters:** evolvability is largely a property of the *map*. A more evolvable encoding makes good variation cheap to reach.
+- **Bold directions:** indirect/**developmental encoding** (CPPN‑style) so one gene reshapes many correlated traits; modular/hierarchical genomes; widen the morphospace or behavior‑primitive set so there is more to discover.
+
+### 3.6 Sexual selection / mate choice
+- **Code:** `core/genetics/mate_preferences.py` (already present: `prefer_similar_size`, `prefer_different_color`, `prefer_high_energy`, `prefer_high_aggression`, `prefer_high_social_tendency`, …; inherited from parents).
+- **Bold directions:** runaway sexual selection as an open‑ended driver; **assortative mating → sympatric speciation** (split the gene pool into niches); mate choice on *novelty* rather than fitness.
+
+### 3.7 Reproduction strategy
+- **Code:** `GeneticCrossoverMode` and the two paths in `core/genetics/genome.py`; sexual vs asexual stats in `core/reproduction/reproduction_stats_manager.py`.
+- **Bold directions:** let sexual‑vs‑asexual be a heritable, context‑sensitive switch (e.g. sex under stress); evolve recombination rate.
+
+### 3.8 The environment & the fitness signal itself (highest leverage, highest risk)
+- **Code:** `benchmarks/tank/ecosystem_health_10k.py` (the Layer‑1 objective); the world's pressures — food (`core/config/food.py`), crabs/predation, plants/energy, poker, soccer; `core/config/*`.
+- **Why it matters:** the *selective pressure* is what evolution responds to. Changing it changes everything downstream. This is literally "evolving the evolution engine."
+- **Bold directions:** a **coevolving environment** (POET / minimal‑criterion coevolution) that gets harder exactly as the population adapts; multiple coexisting niches; a predator–prey **arms race**; rebuild the fitness signal to reward *directional quality*, not churn. **Caveat:** changes to the objective can Goodhart the very number we trust — see §6.
+
+---
+
+## 4. The canon, ported to fish
+
+A springboard, not a fence. Each is a known route to open‑endedness; the third column is
+the nearest lever above.
+
+| Idea | How it could land in Tank World | Lever |
+|---|---|---|
+| **Novelty search / Quality‑Diversity (MAP‑Elites)** | Reward *interesting* behavior, archive a champion per behavior niche | §3.4, §3.8 |
+| **POET / Minimal‑Criterion Coevolution** | Let the environment evolve to keep just‑barely challenging the fish | §3.8 |
+| **NEAT speciation & protected innovation** | Shield young/novel lineages so fragile inventions survive infancy | §3.4, §3.6 |
+| **CPPN / indirect (developmental) encoding** | One gene reshapes a whole body plan or behavior tree | §3.5 |
+| **Evolution of evolvability** | Self‑adapting mutation/HGT — *already partly here* (§3.1); extend & couple to signals | §3.1 |
+| **Sexual selection / mate choice** | Drive open‑ended ornament/behavior races; speciation via assortative mating | §3.6 |
+| **Baldwin effect** | Let lifetime learning (skill‑games) steer which genes win | §3.5 |
+| **Major transitions / cooperation** | Schooling, kin selection, division of labour → new level of organization | §3.3, schooling algos |
+| **Niche construction** | Organisms reshape their own selective environment (plants, energy) | §3.8 |
+
+---
+
+## 5. Ideas graveyard & load‑bearing constraints
+
+A living log so the board doesn't re‑propose dead ends. **Builders: append outcomes here**
+(win *or* loss) with a one‑line lesson; the `/deliberate` META round proposes additions.
+
+**Load‑bearing constraints (don't fight these blindly):**
+- **Ball pursuit pre‑empts food‑seeking.** In `core/movement_strategy.py`, soccer‑ball
+  pursuit runs before composable food pursuit, and the ball exists even in benchmark
+  configs. A foraging intervention that ignores this will quietly fail.
+- **Reproduction is funded by overflow energy** (banked above `max_energy`). Energy sinks
+  (ball play, poker) suppress births; "give fish more energy" raises reproduction only if
+  it becomes *surplus*.
+- **`ecosystem_health` is trajectory‑sensitive on one seed** (≈linear in `max_generation`).
+  A single‑seed win is often a mirage — verify on seeds 7 and 123.
+- **Determinism is non‑negotiable.** All benchmarks use fixed seeds; any change that
+  introduces nondeterminism is rejected regardless of its score.
+
+**Tried (template — add real entries as experiments land):**
+
+```
+- YYYY-MM-DD | <idea> | lever §X.Y | hypothesis: <…> | result: <bench Δ, seeds, drift Δ>
+  | verdict: adopted / rejected / inconclusive | lesson: <one line>
+```
+
+---
+
+## 6. Open problem — a frozen evolvability benchmark
+
+`ecosystem_health_10k` is the objective the build loop optimizes, but if proposals may
+*edit the objective they are scored on*, they can move the goalposts and "win" without the
+engine actually getting better. The durable fix is a **frozen, held‑out measure of
+evolvability** — e.g. the population's **selection response** (trait drift under a fixed
+perturbation across held‑out seeds) — that proposals are scored against but may **not**
+modify. This does not exist yet; speccing and building it is itself a top‑tier proposal.
+Until it does, treat any change to the fitness signal as the highest‑leverage *and*
+highest‑risk class of work, kept separate from Layer‑1 changes and justified rigorously.
+
+---
+
+## 7. Proposing well
+
+Anchor every proposal to a **lever (§3)** and a **measurement (§2)**, and structure it as
+the `/deliberate` rubric expects:
+
+> **VISION** (the big bet — what new evolutionary dynamic it unleashes) · **LEVER** (§3.x) ·
+> **FIRST EXPERIMENT** (smallest change that tests the bet) · **EVOLVABILITY METRIC** (how
+> we'll *see* it work, across seeds 42/7/123) · **ANTI‑GOODHART** (why it isn't a gamed
+> proxy).
+
+Be **bold in ambition, rigorous in justification**: dream big, then name the small first
+experiment that would prove or kill it. A safe 5% parameter tweak is the floor, not the
+goal.


### PR DESCRIPTION
## Summary

The multi-agent decision board (Insights feed + `/observe-sim`) produces commentary, but the *improvement proposals* coming out of it were timid and aimed at the wrong target — the fish's comfort rather than the engine's **evolvability**. This PR adds the knowledge base and the workflow to fix that, so proposals are **bold, lever-anchored, and grounded in the actual code**.

This is **Layer 2 only** (docs + process). No algorithm or runtime change.

## What's included

**`docs/EVOLVABILITY.md` — the map for "evolving the evolution engine"**
- Names the central trap: *optimizing fish comfort ≠ improving evolvability* (a healthier tank that flattens the selection gradient is a regression).
- How evolvability is **measured** here: directional selection vs churn (`scripts/diagnose_evolution.py`), sustained diversity (`core/genetics/diversity.py`), quality-per-generation, and the `ecosystem_health_10k` fitness signal — including its **blind spot** (rewards churn + diversity, not directional quality, so it's gameable).
- A **catalog of evolvability levers, each mapped to the code that implements it**: mutation operators + heritable meta-genes (`core/evolution/mutation.py`, `core/genetics/trait.py`), recombination/HGT (`core/evolution/inheritance.py`), the selection gradient (`core/reproduction/…`), diversity maintenance, the genotype→phenotype encoding, sexual selection (`core/genetics/mate_preferences.py` — already exists), reproduction mode, and the environment/fitness signal itself.
- The **research canon ported to Tank World** (novelty search, MAP-Elites, POET/MCC, NEAT speciation, CPPN encodings, evolution-of-evolvability, Baldwin effect, major transitions, niche construction).
- An **ideas graveyard** seeded with the load-bearing constraints (ball-pursuit gotcha, overflow-energy reproduction, single-seed trajectory sensitivity, determinism), plus a template for builders to append outcomes.
- An open problem: a **frozen evolvability benchmark** to resist Goodharting the objective.

**`.claude/commands/deliberate.md` — the `/deliberate` skill**
- Runs the board protocol (propose → debate → ranked-choice vote, with a `keep-looking` option and a `META` round that improves the prompt and the docs), framed to demand **bold, lever-anchored, multi-seed-justified** proposals and to treat `docs/EVOLVABILITY.md` as required reading.

**`AGENTS.md` / `CLAUDE.md`** — link the new doc and the deliberation workflow.

## Validation
- All **20 code paths** cited in the levers map were verified to exist on this branch.
- `smoke_gate` green; `tests/test_docs_agent_onboarding.py` green; no trailing-whitespace / EOF issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbNYznioSgZ1638LCSJfkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbNYznioSgZ1638LCSJfkg)_