### PR TITLE
Improve composable food chase caps

### DIFF
--- a/core/algorithms/composable/food_selection.py
+++ b/core/algorithms/composable/food_selection.py
@@ -13,15 +13,52 @@ from typing import TYPE_CHECKING, Any
 
 from core.config.food import (
     BASE_FOOD_DETECTION_RANGE,
+    CHASE_DISTANCE_LOW,
+    CHASE_DISTANCE_SAFE_BASE,
     FOOD_QUALITY_DISTANCE_WEIGHT,
     FOOD_SINK_ACCELERATION,
 )
+from core.config.fish import CRITICAL_ENERGY_THRESHOLD_RATIO, SAFE_ENERGY_THRESHOLD_RATIO
 from core.entities import Food as FoodClass
 from core.math_utils import Vector2
 from core.predictive_movement import predict_falling_intercept
 
 if TYPE_CHECKING:
     from core.entities import Fish
+
+
+# Critical fish keep the status-quo detection reach; the low/safe caps below
+# are the actual energy-saving change for fish with enough energy to be choosy.
+COMPOSABLE_CHASE_DISTANCE_CRITICAL = BASE_FOOD_DETECTION_RANGE
+
+
+def _numeric_energy_ratio(fish: Fish) -> float | None:
+    """Return the fish energy ratio when the object exposes it numerically."""
+    get_energy_ratio = getattr(fish, "get_energy_ratio", None)
+    if callable(get_energy_ratio):
+        ratio = get_energy_ratio()
+        if isinstance(ratio, (int, float)):
+            return max(0.0, ratio)
+
+    energy = getattr(fish, "energy", None)
+    max_energy = getattr(fish, "max_energy", None)
+    if isinstance(energy, (int, float)) and isinstance(max_energy, (int, float)) and max_energy > 0:
+        return max(0.0, energy / max_energy)
+
+    return None
+
+
+def _food_chase_distance_for_energy(fish: Fish) -> float:
+    """Return the energy-state chase cap for composable food selection."""
+    energy_ratio = _numeric_energy_ratio(fish)
+    if energy_ratio is None:
+        return BASE_FOOD_DETECTION_RANGE
+
+    if energy_ratio < CRITICAL_ENERGY_THRESHOLD_RATIO:
+        return COMPOSABLE_CHASE_DISTANCE_CRITICAL
+    if energy_ratio < SAFE_ENERGY_THRESHOLD_RATIO:
+        return float(CHASE_DISTANCE_LOW)
+    return float(CHASE_DISTANCE_SAFE_BASE)
 
 
 def predict_food_target(fish: Fish, food: Any, distance: float, prediction_skill: float) -> Vector2:
@@ -89,7 +126,9 @@ def select_food_target(fish: Fish) -> Any | None:
     env = fish.environment
 
     detection_modifier = getattr(env, "get_detection_modifier", lambda: 1.0)()
-    max_distance = BASE_FOOD_DETECTION_RANGE * detection_modifier
+    detection_distance = BASE_FOOD_DETECTION_RANGE * detection_modifier
+    chase_distance = _food_chase_distance_for_energy(fish)
+    max_distance = min(detection_distance, chase_distance)
     max_distance_sq = max_distance * max_distance
 
     if hasattr(env, "nearby_resources"):

--- a/tests/core/test_food_target_selection.py
+++ b/tests/core/test_food_target_selection.py
@@ -21,13 +21,15 @@ def _food(x: float, y: float, energy: float) -> MagicMock:
     return food
 
 
-def _fish_in(foods: list) -> MagicMock:
+def _fish_in(foods: list, energy_ratio: float | None = None) -> MagicMock:
     env = MagicMock()
     env.get_detection_modifier.return_value = 1.0
     env.nearby_resources.return_value = foods
     fish = MagicMock()
     fish.pos = Vector2(0.0, 0.0)
     fish.environment = env
+    if energy_ratio is not None:
+        fish.get_energy_ratio.return_value = energy_ratio
     return fish
 
 
@@ -55,6 +57,37 @@ def test_ignores_food_beyond_detection_range():
     """Food outside BASE_FOOD_DETECTION_RANGE (580px) is not selectable."""
     too_far = _food(600.0, 0.0, 1000.0)  # very rich but out of range
     assert select_food_target(_fish_in([too_far])) is None
+
+
+def test_safe_energy_limits_wasteful_long_chases():
+    """Well-fed fish ignore rich food beyond the safe chase cap."""
+    near_poor = _food(100.0, 0.0, 65.0)
+    far_rich = _food(200.0, 0.0, 300.0)
+
+    assert select_food_target(_fish_in([near_poor, far_rich], energy_ratio=0.50)) is near_poor
+
+
+def test_low_energy_extends_chase_distance():
+    """Hungry fish can pursue farther food when its value justifies the trip."""
+    near_poor = _food(100.0, 0.0, 65.0)
+    far_rich = _food(250.0, 0.0, 300.0)
+
+    assert select_food_target(_fish_in([near_poor, far_rich], energy_ratio=0.20)) is far_rich
+
+
+def test_recovery_band_uses_low_chase_distance_until_safe():
+    """Fish between low and safe energy still get enough reach to recover."""
+    near_poor = _food(100.0, 0.0, 65.0)
+    far_rich = _food(250.0, 0.0, 300.0)
+
+    assert select_food_target(_fish_in([near_poor, far_rich], energy_ratio=0.30)) is far_rich
+
+
+def test_critical_energy_preserves_full_detection_reach():
+    """Critical fish keep status-quo reach while the critical cap is A/B tested."""
+    far_food = _food(500.0, 0.0, 100.0)
+
+    assert select_food_target(_fish_in([far_food], energy_ratio=0.05)) is far_food
 
 
 def test_tie_break_is_deterministic_and_order_independent():


### PR DESCRIPTION
## Summary

Implements shared-board proposal #24: add energy-state chase caps to composable food selection while preserving the day/night detection multiplier.

- Critical fish keep the status-quo `BASE_FOOD_DETECTION_RANGE` reach after A/B testing showed the ecosystem benchmark preferred 580px over 450px.
- Low and recovery-band fish (`energy_ratio < SAFE_ENERGY_THRESHOLD_RATIO`) use the existing 300px low-energy chase distance.
- Safe fish use the existing 180px chase distance to avoid wasteful long-range food pursuit.
- Added focused unit coverage for safe, low, recovery-band, and critical food-target selection behavior.

## Evidence

Baseline diagnostic before edits:

- `diagnose_food_seeking.py` seed 42 hardcoded, 1000 frames: 71.7% fish-frames near food, 43.9% moving toward nearest food.
- `diagnose_evolution.py --frames 3000 --seed 42 --interval 500`: Layer 0 selection detected.

A/B note:

- `survival_5k` seed 42 favored Critical=450 (`505.26` vs `405.26`).
- `ecosystem_health_10k` seed 42 favored Critical=580/status quo (`8.0466` vs `6.7190`) with lower starvation and higher generation rate, so the final patch keeps critical fish at 580.

Champion validation:

```text
.\.venv\Scripts\python.exe tools\run_bench.py benchmarks\tank\ecosystem_health_10k.py --seed 42 --out results\food_chase_final\ecosystem_health_10k_seed42_pr.json
.\.venv\Scripts\python.exe tools\validate_improvement.py results\food_chase_final\ecosystem_health_10k_seed42_pr.json champions\tank\ecosystem_health_10k.json
```

Result:

```text
New Score: 8.046606
Old Score: 7.334041
Diff:      +0.712564
SUCCESS: Improvement detected!
```

Metadata, seed 42:

- `config_hash`: `0b6bfb9fd9cdb0b5`
- `max_generation`: 8
- `generation_rate`: 8.0
- `starvation_rate`: 0.9925
- `final_population`: 42
- `mean_population`: 44.76
- `diversity_score`: 0.2649
- `unique_algorithms`: 17

Additional candidate scores from the same final code path:

- seed 7: `8.150006`
- seed 123: `6.819384`

Trait drift confirmation after the change, 3k-frame diagnostics:

- seed 42: selection detected
- seed 7: selection detected
- seed 123: selection detected

## Validation

```text
.\.venv\Scripts\python.exe -m pytest tests/core/test_food_target_selection.py
# 10 passed

.\.venv\Scripts\python.exe tools\smoke_gate.py
# PASS: 34 passed

.\.venv\Scripts\python.exe tools\agent_gate.py
# PASS: 575 passed, 100 deselected

.\.venv\Scripts\python.exe tools\fast_gate.py
# PASS: 1758 passed, 3 skipped, 157 deselected
```

## Notes

This is a Layer 1-only change in `core/algorithms/composable/food_selection.py` plus tests. It intentionally does not change config constants, benchmark definitions, telemetry, or champion metadata.