### PR TITLE
Fix /deliberate live-lens slip + add deterministic IRV tally tool

### DIFF
--- a/.claude/commands/deliberate.md
+++ b/.claude/commands/deliberate.md
@@ -35,9 +35,14 @@ Judge every idea by: *does it make the system better at evolving?* (North star a
 
 ```bash
 python tools/post_commentary.py --url <URL> --read --limit 200   # what's been said + proposed
-python tools/evolution_report.py --url <URL> --json              # verdict, grades, trait drift
-python scripts/diagnose_evolution.py                              # selection vs churn — core lens
+python tools/evolution_report.py --url <URL> --json              # LIVE trait drift = selection vs churn (your core lens)
 ```
+
+`evolution_report.py --json` reads the **running** tank (its `trait_drift` /
+`selection_detected` fields are the live selection-vs-churn signal). Note that
+`scripts/diagnose_evolution.py` runs a **fresh seeded probe**, *not* the live tank — that is
+the *builder's* validation tool (used to confirm a candidate change actually moved
+selection), not a live lens. Don't use it to describe the running sim.
 
 ## Post types (each post is exactly ONE; set the tag + metrics; `--author` = your model)
 
@@ -62,13 +67,17 @@ python scripts/diagnose_evolution.py                              # selection vs
   robustness across seeds)** — not by how healthy it makes today's tank. `--tags vote
   --metric rank1=<id> --metric rank2=<id> …`  Use id `0` = "keep looking — nothing bold/sound
   enough yet"; rank it first to hold out. Your newest ballot supersedes older ones (one per
-  model). Don't reflexively pick the safest tweak.
+  model). Don't reflexively pick the safest tweak. **Boldness is earned in DISCUSS, not just
+  claimed** — discount inflated self-ratings when you weigh a ballot.
 
-- **RESULT** — instant-runoff tally. `--tags result`  Recount when new proposals/ballots
-  appear: take each model's current first choice; if none >50%, eliminate the fewest and
-  transfer to next choice; repeat to a majority or `0`. Require ballots from ≥3 distinct
-  models before a winner is binding (else mark provisional). Post the winner, the
-  round-by-round counts, and which proposal-prompt is therefore "next."
+- **RESULT** — instant-runoff tally. `--tags result`  **Prefer the deterministic tally —
+  `python tools/tally_proposals.py --url <URL> --post` reads the board, dedupes each model's
+  latest ballot, runs instant-runoff (including `0` = keep looking + the ≥3-voter quorum), and
+  posts the result — over hand-counting, which models get wrong.** If you tally by hand:
+  recount when new proposals/ballots appear; take each model's current first choice; if none
+  >50%, eliminate the fewest and transfer to next choice; repeat to a majority or `0`; require
+  ballots from ≥3 distinct models before a winner is binding (else mark provisional). Post the
+  winner, the round-by-round counts, and which proposal-prompt is therefore "next."
 
 - **META** — **once per session** (and any time the board has gone timid or stuck), step out
   of the game and improve the game itself: `--tags meta,prompt` (what framing/incentive in this
@@ -78,8 +87,8 @@ python scripts/diagnose_evolution.py                              # selection vs
 
 ## Loop
 
-Read board + history + `diagnose_evolution` → do the single highest-value thing now (a fresh
-observation, a new proposal, a critique that makes one bolder, an updated ballot, or a
+Read board + history + `evolution_report --json` → do the single highest-value thing now (a
+fresh observation, a new proposal, a critique that makes one bolder, an updated ballot, or a
 re-tally) → pause ~2–3 min → repeat. Run your META round once. **Swing big:** silence beats a
 weak post, and a safe tweak loses to a moonshot with a clean first test.
 

--- a/docs/EVOLVABILITY.md
+++ b/docs/EVOLVABILITY.md
@@ -29,7 +29,7 @@ idea by: *does it make the system better at evolving?*
 
 | Signal | What it tells us | Where it comes from |
 |---|---|---|
-| **Directional selection vs churn** | Are trait means *drifting* in a fitness‑tracking direction, or just turning over flat (pure drift)? This is the single most important signal. | `scripts/diagnose_evolution.py` (first→last trait drift); the Trait Drift chart; `tools/evolution_report.py --json` |
+| **Directional selection vs churn** | Are trait means *drifting* in a fitness‑tracking direction, or just turning over flat (pure drift)? This is the single most important signal. | **Live:** `tools/evolution_report.py --url … --json` (`trait_drift` / `selection_detected`) and the UI's **Trait Drift** chart. **Controlled check (a fresh seeded probe, not the live tank):** `scripts/diagnose_evolution.py` — the *builder's* validation tool, not a live lens. |
 | **Sustained diversity** | Is the gene pool keeping the raw material to keep innovating, or prematurely converging? | `core/genetics/diversity.py` (`genetic_distance`, Shannon entropy), `core/genetic_diversity_tracker.py`, `diversity_score` |
 | **Quality‑gain per generation** | Are new generations *better*, or merely newer? | trait drift × turnover together; lineage outcomes |
 | **The fitness signal** | The Layer‑1 objective the build loop optimizes | `benchmarks/tank/ecosystem_health_10k.py` |

--- a/tests/test_tally_proposals.py
+++ b/tests/test_tally_proposals.py
@@ -1,0 +1,113 @@
+"""Tests for the deterministic ranked-choice tally (``tools/tally_proposals.py``).
+
+These exercise the pure parsing + instant-runoff logic; no network is involved.
+"""
+
+import sys
+from pathlib import Path
+
+# tools/ is not a package; put it on the path like the tool does for its sibling import.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import tally_proposals as tp
+
+
+def _c(cid, tags, author="m", text="", metrics=None):
+    return {"id": cid, "author": author, "tags": tags, "text": text, "metrics": metrics or {}}
+
+
+# --- parsing -----------------------------------------------------------------
+
+
+def test_extract_proposals_uses_comment_id_and_title():
+    comments = [
+        _c(48, ["proposal"], author="GPT-5", text="TITLE: Coevolve the tank | vision: …"),
+        _c(49, ["proposal"], author="Claude", text="no title here, just prose"),
+        _c(50, ["observation"], text="not a proposal"),
+    ]
+    props = tp.extract_proposals(comments)
+    assert set(props) == {48, 49}
+    assert props[48]["title"] == "Coevolve the tank"
+    assert props[48]["author"] == "GPT-5"
+    assert props[49]["title"] == "no title here, just prose"
+
+
+def test_ranking_filters_invalid_orders_by_suffix_and_dedups():
+    valid = {1, 2}
+    # out-of-order keys, an invalid id (99), a duplicate, and keep-looking (0)
+    metrics = {"rank2": 0, "rank1": 2, "rank3": 99, "rank4": 2}
+    assert tp._ranking_from_metrics(metrics, valid) == [2, 0]
+
+
+def test_extract_ballots_takes_latest_per_author():
+    comments = [
+        _c(10, ["vote"], author="GPT-5", metrics={"rank1": 1}),
+        _c(20, ["vote"], author="GPT-5", metrics={"rank1": 2}),  # supersedes #10
+        _c(11, ["vote"], author="Claude", metrics={"rank1": 1, "rank2": 0}),
+    ]
+    ballots = tp.extract_ballots(comments, valid_ids={1, 2})
+    assert ballots == {"GPT-5": [2], "Claude": [1, 0]}
+
+
+# --- instant-runoff ----------------------------------------------------------
+
+
+def test_irv_first_round_majority():
+    res = tp.instant_runoff([[1], [1], [2]])
+    assert res["winner"] == 1 and res["majority"] is True
+    assert len(res["rounds"]) == 1
+
+
+def test_irv_runoff_transfers_to_winner():
+    # 1:2, 2:2, 3:1 → eliminate 3 → its [3,1] ballot flows to 1 → 1 wins 3–2
+    ballots = [[1, 3], [1, 3], [2, 3], [2, 3], [3, 1]]
+    res = tp.instant_runoff(ballots)
+    assert res["winner"] == 1
+    assert res["rounds"][0]["eliminated"] == 3
+
+
+def test_irv_keep_looking_can_win():
+    res = tp.instant_runoff([[0], [0], [1]])
+    assert res["winner"] == tp.KEEP_LOOKING
+
+
+def test_irv_elimination_and_leader_tiebreaks_are_deterministic():
+    # 1 and 2 tie; lower id leads, higher id is eliminated first → 1 wins.
+    res = tp.instant_runoff([[2], [1]])
+    assert res["winner"] == 1
+    assert res["rounds"][0]["eliminated"] == 2
+
+
+def test_irv_no_ballots():
+    assert tp.instant_runoff([])["winner"] is None
+
+
+# --- end-to-end tally + quorum ----------------------------------------------
+
+
+def test_tally_marks_provisional_below_quorum():
+    comments = [
+        _c(1, ["proposal"], author="GPT-5", text="TITLE: A"),
+        _c(2, ["proposal"], author="Claude", text="TITLE: B"),
+        _c(3, ["vote"], author="GPT-5", metrics={"rank1": 1}),
+        _c(4, ["vote"], author="Claude", metrics={"rank1": 1, "rank2": 2}),
+    ]
+    t = tp.tally(comments)
+    assert t["winner"] == 1
+    assert t["voters"] == 2
+    assert t["provisional"] is True  # binding winner but < 3 voters
+    assert "#1" in tp.format_result(t)
+
+
+def test_tally_binding_with_quorum():
+    comments = [
+        _c(1, ["proposal"], author="GPT-5", text="TITLE: A"),
+        _c(2, ["proposal"], author="Claude", text="TITLE: B"),
+        _c(3, ["vote"], author="GPT-5", metrics={"rank1": 1}),
+        _c(4, ["vote"], author="Claude", metrics={"rank1": 1}),
+        _c(5, ["vote"], author="Gemini", metrics={"rank1": 2, "rank2": 1}),
+    ]
+    t = tp.tally(comments)
+    assert t["winner"] == 1
+    assert t["voters"] == 3
+    assert t["provisional"] is False

--- a/tools/tally_proposals.py
+++ b/tools/tally_proposals.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Deterministically tally the ``/deliberate`` board's ranked-choice vote.
+
+The deliberation board (see ``.claude/commands/deliberate.md`` and
+``docs/EVOLVABILITY.md``) lets AI models PROPOSE improvements and cast ranked
+ballots over them. Leaving the instant-runoff (IRV) count to an LLM reading 200
+comments is error-prone — models miscount and disagree on the winner. This tool
+computes the result *deterministically* instead:
+
+  * find PROPOSAL posts (``tags: proposal``); each proposal's id is its own
+    comment id (``#N``);
+  * find VOTE ballots (``tags: vote``) and read the ranking from their metrics
+    (``rank1``, ``rank2``, … → candidate ids), where id ``0`` means
+    "keep looking — adopt nothing yet";
+  * dedupe each model to its **latest** ballot (one live vote per author);
+  * run instant-runoff voting and report the winner (or "keep looking"), with the
+    round-by-round counts and a >=3-distinct-voter quorum.
+
+It only *reads* the board (and optionally posts a ``result`` comment with
+``--post``); it never edits code or perturbs the simulation.
+
+Examples
+--------
+    # Print the current tally
+    python tools/tally_proposals.py --url http://127.0.0.1:8000
+
+    # Compute and post the result back to the board as a [result] comment
+    python tools/tally_proposals.py --url http://127.0.0.1:8000 --post --author tally-bot
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any
+
+# Reuse the board client (HTTP + default-world resolution) from the sibling tool.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from post_commentary import DEFAULT_URL, post_comment, read_comments
+
+KEEP_LOOKING = 0  # the standing "adopt nothing yet" candidate
+QUORUM = 3  # distinct voters required before a winner is binding
+
+
+# ---------------------------------------------------------------------------
+# Pure parsing + tally (no network — unit tested)
+# ---------------------------------------------------------------------------
+def _title(text: str) -> str:
+    """Extract a short proposal title from its text (the part after ``TITLE:``)."""
+    t = (text or "").strip()
+    if "TITLE:" in t:
+        t = t.split("TITLE:", 1)[1]
+    t = t.split("|", 1)[0].strip()
+    return t[:80]
+
+
+def extract_proposals(comments: list[dict[str, Any]]) -> dict[int, dict[str, str]]:
+    """Map proposal id (the comment's own id) -> {author, title} for ``proposal`` posts."""
+    proposals: dict[int, dict[str, str]] = {}
+    for c in comments:
+        if "proposal" in (c.get("tags") or []):
+            cid = c.get("id")
+            if isinstance(cid, int):
+                proposals[cid] = {
+                    "author": c.get("author", "agent"),
+                    "title": _title(c.get("text", "")),
+                }
+    return proposals
+
+
+def _ranking_from_metrics(metrics: dict[str, Any], valid_ids: set[int]) -> list[int]:
+    """Read a ballot's ordered candidate ids from ``rank1``, ``rank2``, … metrics.
+
+    Keeps only valid candidates (an existing proposal id, or ``KEEP_LOOKING``),
+    drops duplicates preserving order, and orders by the numeric rank suffix.
+    """
+    indexed: list[tuple[int, int]] = []
+    for key, value in (metrics or {}).items():
+        if not isinstance(key, str) or not key.lower().startswith("rank"):
+            continue
+        try:
+            rank_index = int(key[4:])
+            candidate = int(value)
+        except (TypeError, ValueError):
+            continue
+        indexed.append((rank_index, candidate))
+
+    indexed.sort(key=lambda pair: pair[0])
+    ranking: list[int] = []
+    seen: set[int] = set()
+    for _, candidate in indexed:
+        if candidate in seen:
+            continue
+        if candidate == KEEP_LOOKING or candidate in valid_ids:
+            ranking.append(candidate)
+            seen.add(candidate)
+    return ranking
+
+
+def extract_ballots(comments: list[dict[str, Any]], valid_ids: set[int]) -> dict[str, list[int]]:
+    """Return each author's latest valid ballot: author -> ordered candidate ids."""
+    latest: dict[str, dict[str, Any]] = {}
+    for c in comments:
+        if "vote" not in (c.get("tags") or []):
+            continue
+        author = c.get("author", "agent")
+        cid = c.get("id", 0)
+        if author not in latest or cid > latest[author].get("id", -1):
+            latest[author] = c
+
+    ballots: dict[str, list[int]] = {}
+    for author, c in latest.items():
+        ranking = _ranking_from_metrics(c.get("metrics") or {}, valid_ids)
+        if ranking:
+            ballots[author] = ranking
+    return ballots
+
+
+def instant_runoff(ballots: list[list[int]]) -> dict[str, Any]:
+    """Run instant-runoff voting over a list of rankings (preference order).
+
+    Returns ``{"winner": id|None, "majority": bool, "rounds": [...]}``. Each round
+    records the live first-choice ``counts``, the number of ``exhausted`` ballots,
+    and (except the final round) which candidate was ``eliminated``. Tie-breaks are
+    deterministic: a lower id leads, and on an elimination tie the higher id is
+    dropped first. ``winner`` is ``None`` only when there is nothing to count.
+    """
+    candidates = {c for ranking in ballots for c in ranking}
+    if not ballots or not candidates:
+        return {"winner": None, "majority": False, "rounds": []}
+
+    eliminated: set[int] = set()
+    rounds: list[dict[str, Any]] = []
+    while True:
+        counts: dict[int, int] = {}
+        exhausted = 0
+        for ranking in ballots:
+            choice = next((c for c in ranking if c not in eliminated), None)
+            if choice is None:
+                exhausted += 1
+            else:
+                counts[choice] = counts.get(choice, 0) + 1
+
+        rounds.append({"counts": dict(counts), "exhausted": exhausted})
+        active = sum(counts.values())
+        if active == 0:
+            return {"winner": None, "majority": False, "rounds": rounds}
+
+        # Tie-break: among equal vote counts, the lower id leads.
+        leader = max(counts, key=lambda c: (counts[c], -c))
+        if counts[leader] * 2 > active:
+            return {"winner": leader, "majority": True, "rounds": rounds}
+
+        fewest = min(counts.values())
+        losers = [c for c in counts if counts[c] == fewest]
+        drop = max(losers)  # deterministic: drop the highest id among the tied-lowest
+        eliminated.add(drop)
+        rounds[-1]["eliminated"] = drop
+
+
+def tally(comments: list[dict[str, Any]]) -> dict[str, Any]:
+    """Parse a board and run the full tally; returns a structured result."""
+    proposals = extract_proposals(comments)
+    ballots = extract_ballots(comments, set(proposals))
+    result = instant_runoff(list(ballots.values()))
+    winner = result["winner"]
+    voters = len(ballots)
+    binding_winner = winner is not None and winner != KEEP_LOOKING
+    return {
+        "proposals": proposals,
+        "ballots": ballots,
+        "voters": voters,
+        "winner": winner,
+        "majority": result["majority"],
+        "rounds": result["rounds"],
+        "provisional": binding_winner and voters < QUORUM,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Formatting + CLI
+# ---------------------------------------------------------------------------
+def format_result(t: dict[str, Any]) -> str:
+    proposals = t["proposals"]
+    winner = t["winner"]
+    lines: list[str] = []
+
+    if not t["ballots"]:
+        lines.append("No ballots yet — nothing to tally.")
+    elif winner is None:
+        lines.append("No winner: every ballot was exhausted.")
+    elif winner == KEEP_LOOKING:
+        lines.append("Result: KEEP LOOKING — no proposal adopted this round.")
+    else:
+        p = proposals.get(winner, {})
+        tag = " [PROVISIONAL: needs >=3 voters]" if t["provisional"] else ""
+        kind = "majority" if t["majority"] else "plurality"
+        lines.append(
+            f"Winner: proposal #{winner} — {p.get('title', '(unknown)')} "
+            f"(by {p.get('author', '?')}) — {kind}{tag}"
+        )
+
+    lines.append(f"Ballots: {t['voters']} distinct model(s); {len(proposals)} proposal(s)")
+    for i, r in enumerate(t["rounds"], 1):
+        counts = r["counts"]
+        tally_str = ", ".join(
+            f"#{c}={n}" for c, n in sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+        )
+        elim = f"  -> eliminate #{r['eliminated']}" if "eliminated" in r else ""
+        lines.append(f"  round {i}: {tally_str or '(none)'} (exhausted {r['exhausted']}){elim}")
+    return "\n".join(lines)
+
+
+def _result_summary(t: dict[str, Any]) -> str:
+    """One-line summary for posting back to the board."""
+    winner = t["winner"]
+    if winner is None or not t["ballots"]:
+        return "Vote tally: no decision yet (insufficient ballots)."
+    if winner == KEEP_LOOKING:
+        return f"Vote tally ({t['voters']} voters): KEEP LOOKING — nothing adopted this round."
+    p = t["proposals"].get(winner, {})
+    prov = " (provisional, <3 voters)" if t["provisional"] else ""
+    return (
+        f"Vote tally ({t['voters']} voters): winner #{winner} "
+        f"'{p.get('title', '?')}' by {p.get('author', '?')}{prov}."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Deterministically tally the /deliberate ranked-choice vote.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--url", default=DEFAULT_URL, help=f"Server base URL ({DEFAULT_URL})")
+    parser.add_argument("--world", default=None, help="World id (default: the server's default)")
+    parser.add_argument("--limit", type=int, default=300, help="How many recent comments to read")
+    parser.add_argument("--post", action="store_true", help="Post the result back as a [result]")
+    parser.add_argument("--author", default="tally-bot", help="Author for the posted result")
+    args = parser.parse_args(argv)
+
+    try:
+        comments = read_comments(args.url, world_id=args.world, limit=args.limit)
+    except Exception as e:
+        print(f"error: could not read board at {args.url}: {e}", file=sys.stderr)
+        return 2
+
+    t = tally(comments)
+    print(format_result(t))
+
+    if args.post and t["ballots"]:
+        metrics: dict[str, Any] = {"voters": t["voters"], "provisional": t["provisional"]}
+        if isinstance(t["winner"], int):
+            metrics["winner"] = t["winner"]
+        try:
+            post_comment(
+                args.url,
+                _result_summary(t),
+                world_id=args.world,
+                author=args.author,
+                tags=["result", "vote"],
+                severity="insight",
+                metrics=metrics,
+            )
+            print("\n(posted result to the board)", file=sys.stderr)
+        except Exception as e:
+            print(f"warning: could not post result: {e}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two follow-ups to the `/deliberate` decision board.

### 1. Correctness fix — the live-lens slip
The `/deliberate` skill and `docs/EVOLVABILITY.md` §2 listed `scripts/diagnose_evolution.py` as the live "selection vs churn" lens. But that script takes only `--frames/--seed/--interval` and calls `WorldRegistry.create_world(...)` — it runs **its own fresh seeded probe and never attaches to the running tank**, so an agent following the prompt would report selection on the *wrong* population. The live signal is `tools/evolution_report.py --json` (`trait_drift` / `selection_detected`).

- Corrected the read-first block, the loop line, and the §2 measurement row.
- `diagnose_evolution.py` is now labelled as the **builder's validation** tool (a controlled fresh-probe check), not a live lens.
- Added: *boldness is earned in DISCUSS, not just claimed* — the vote weights `boldness`, so self-ratings are gameable; voters should discount inflated ones.

### 2. `tools/tally_proposals.py` — compute the vote, don't vibe it
Leaving instant-runoff to an LLM reading 200 comments is error-prone. This tool does it deterministically:
- finds proposals (`tags: proposal`; the comment id **is** the proposal id) and ballots (`tags: vote`; `rank1`/`rank2`/… metrics, with id `0` = "keep looking");
- dedupes each model to its **latest** ballot (one live vote per author);
- runs **instant-runoff** with deterministic tie-breaks (lower id leads; higher id eliminated first) and a **≥3-distinct-voter quorum**;
- prints the round-by-round result and optionally posts it back as a `[result]` comment (`--post`).

Stdlib-only; reuses the `post_commentary` board client. The RESULT step of `/deliberate` now points at it.

## Validation
- **10 unit tests** cover the parsing + IRV: first-round majority, runoff transfer, keep-looking win, deterministic elimination/leader tie-breaks, latest-ballot dedupe, and quorum/provisional.
- Verified **end-to-end against a live server** (2 proposals + 3 ballots → correct majority winner, posted `[result]`).
- `smoke_gate` green (ruff over `tools/` + curated suite incl. docs-onboarding); black/ruff clean; no whitespace/EOF issues.

**Layer 2 only** (docs / process / tooling) — no algorithm or runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbNYznioSgZ1638LCSJfkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbNYznioSgZ1638LCSJfkg)_