### PR TITLE
[codex] Restore Red Queen proximity mating

### DIFF
--- a/core/agents/components/reproduction_component.py
+++ b/core/agents/components/reproduction_component.py
@@ -4,9 +4,8 @@ This module provides the ReproductionComponent class which handles reproduction-
 functionality for fish, specifically asexual reproduction and cooldown tracking.
 
 Note on Sexual Reproduction:
-    Sexual reproduction occurs ONLY via poker games, not through traditional mating.
-    When fish win poker games, they may trigger reproduction with their opponent.
-    This design centralizes reproduction logic in PokerSystem.
+    Sexual reproduction can happen through standard proximity mating or through
+    poker games. ReproductionService owns the actual birth accounting.
 
 Note: All reproduction is instant (no pregnancy/gestation period). Asexual reproduction
 triggers immediately when conditions are met, and offspring are created in the same frame.
@@ -31,8 +30,8 @@ class ReproductionComponent:
     - Offspring genome generation
     - Overflow energy banking for reproduction
 
-    Note: Sexual reproduction happens via poker games (see PokerSystem).
-    This component does NOT handle mate selection or attraction.
+    Note: Sexual reproduction happens via ReproductionService; this component
+    does NOT handle mate selection or attraction.
 
     All reproduction is instant - there is no pregnancy/gestation period.
 

--- a/core/config/fish.py
+++ b/core/config/fish.py
@@ -80,6 +80,13 @@ REPRODUCTION_COOLDOWN = 0  # No cooldown - reproduce whenever bank has enough en
 REPRODUCTION_ENERGY_COST = 60.0  # Energy cost to give birth
 MATING_DISTANCE = 60.0  # Maximum distance for mating (pixels)
 
+# Standard proximity mating: symmetric "sneaker" sex-vs-cloning trade-off.
+STANDARD_MATING_DISTANCE = 60.0
+STANDARD_MATING_MIN_ENERGY_RATIO = 0.50
+STANDARD_MATING_PARENT_ENERGY_CONTRIBUTION = 0.50
+STANDARD_MATING_MUTATION_RATE = 0.15
+STANDARD_MATING_MUTATION_STRENGTH = 0.15
+
 # Lowered to 0.70 to make reproduction achievable while still requiring healthy fish
 POST_POKER_REPRODUCTION_ENERGY_THRESHOLD = 0.70
 POST_POKER_REPRODUCTION_WINNER_PROB = 0.4  # Probability winner offers reproduction (40%)

--- a/core/entities/mixins/reproduction_mixin.py
+++ b/core/entities/mixins/reproduction_mixin.py
@@ -71,11 +71,35 @@ class ReproductionMixin:
         )
 
     def try_mate(self, other: Fish) -> bool:
-        """Attempt to mate with another fish.
+        """Return whether this fish can standard-mate with another fish.
 
-        Standard mating is disabled; fish only reproduce sexually after poker games.
+        Offspring creation is centralized in ReproductionService; this method
+        preserves the protocol-facing eligibility check.
         """
-        return False
+        from core.config.fish import STANDARD_MATING_DISTANCE, STANDARD_MATING_MIN_ENERGY_RATIO
+        from core.entities.base import LifeStage
+
+        if other is self or other.species != self.species:
+            return False
+        if hasattr(self, "is_dead") and self.is_dead():
+            return False
+        if hasattr(other, "is_dead") and other.is_dead():
+            return False
+        if self.life_stage != LifeStage.ADULT or other.life_stage != LifeStage.ADULT:
+            return False
+        if (
+            self._reproduction_component.reproduction_cooldown > 0
+            or other._reproduction_component.reproduction_cooldown > 0
+        ):
+            return False
+        if self.energy < self.max_energy * STANDARD_MATING_MIN_ENERGY_RATIO:
+            return False
+        if other.energy < other.max_energy * STANDARD_MATING_MIN_ENERGY_RATIO:
+            return False
+
+        dx = (self.pos.x + self.width * 0.5) - (other.pos.x + other.width * 0.5)
+        dy = (self.pos.y + self.height * 0.5) - (other.pos.y + other.height * 0.5)
+        return dx * dx + dy * dy <= STANDARD_MATING_DISTANCE * STANDARD_MATING_DISTANCE
 
     def update_reproduction(self) -> Fish | None:
         """Update reproduction state and potentially create offspring.

--- a/core/entities/mixins/reproduction_mixin.py
+++ b/core/entities/mixins/reproduction_mixin.py
@@ -64,10 +64,11 @@ class ReproductionMixin:
 
     def can_reproduce(self) -> bool:
         """Check if fish can reproduce (delegates to ReproductionComponent)."""
+        fish = cast("Fish", self)
         return self._reproduction_component.can_reproduce(
             self._lifecycle_component.life_stage,
             self.energy,
-            self.max_energy,  # type: ignore[attr-defined]  # provided by EnergyManagementMixin
+            fish.max_energy,
         )
 
     def try_mate(self, other: Fish) -> bool:
@@ -79,27 +80,30 @@ class ReproductionMixin:
         from core.config.fish import STANDARD_MATING_DISTANCE, STANDARD_MATING_MIN_ENERGY_RATIO
         from core.entities.base import LifeStage
 
-        if other is self or other.species != self.species:
+        fish = cast("Fish", self)
+        if other is fish or other.species != fish.species:
             return False
-        if hasattr(self, "is_dead") and self.is_dead():
+        if fish.is_dead():
             return False
         if hasattr(other, "is_dead") and other.is_dead():
             return False
-        if self.life_stage != LifeStage.ADULT or other.life_stage != LifeStage.ADULT:
+        if fish.life_stage != LifeStage.ADULT or other.life_stage != LifeStage.ADULT:
             return False
         if (
-            self._reproduction_component.reproduction_cooldown > 0
+            fish._reproduction_component.reproduction_cooldown > 0
             or other._reproduction_component.reproduction_cooldown > 0
         ):
             return False
-        if self.energy < self.max_energy * STANDARD_MATING_MIN_ENERGY_RATIO:
+        self_max_energy = fish.max_energy
+        other_max_energy = float(other.max_energy)
+        if fish.energy < self_max_energy * STANDARD_MATING_MIN_ENERGY_RATIO:
             return False
-        if other.energy < other.max_energy * STANDARD_MATING_MIN_ENERGY_RATIO:
+        if other.energy < other_max_energy * STANDARD_MATING_MIN_ENERGY_RATIO:
             return False
 
-        dx = (self.pos.x + self.width * 0.5) - (other.pos.x + other.width * 0.5)
-        dy = (self.pos.y + self.height * 0.5) - (other.pos.y + other.height * 0.5)
-        return dx * dx + dy * dy <= STANDARD_MATING_DISTANCE * STANDARD_MATING_DISTANCE
+        dx = (fish.pos.x + fish.width * 0.5) - (other.pos.x + other.width * 0.5)
+        dy = (fish.pos.y + fish.height * 0.5) - (other.pos.y + other.height * 0.5)
+        return bool(dx * dx + dy * dy <= STANDARD_MATING_DISTANCE * STANDARD_MATING_DISTANCE)
 
     def update_reproduction(self) -> Fish | None:
         """Update reproduction state and potentially create offspring.

--- a/core/reproduction/reproduction_service.py
+++ b/core/reproduction/reproduction_service.py
@@ -6,13 +6,15 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from core.energy.energy_utils import apply_energy_delta
 from core.reproduction.asexual_factory import (
     create_asexual_offspring,
     maybe_create_banked_offspring,
 )
 from core.reproduction.mutation_controller import DiversityMutationController
-from core.util.stable_hash import stable_algorithm_id
+from core.reproduction.sexual_factory import (
+    create_post_poker_offspring,
+    run_proximity_mating_cycle,
+)
 
 if TYPE_CHECKING:
     from core.entities import Fish
@@ -29,11 +31,14 @@ class ReproductionFrameStats:
 
     banked_asexual: int = 0
     trait_asexual: int = 0
+    proximity_sexual: int = 0
     emergency_spawns: int = 0
 
     @property
     def total(self) -> int:
-        return self.banked_asexual + self.trait_asexual + self.emergency_spawns
+        return (
+            self.banked_asexual + self.trait_asexual + self.proximity_sexual + self.emergency_spawns
+        )
 
 
 class ReproductionService:
@@ -47,6 +52,7 @@ class ReproductionService:
         self._banked_asexual_triggered: int = 0
         self._emergency_spawns: int = 0
         self._poker_reproductions: int = 0
+        self._proximity_reproductions: int = 0
         self._plant_asexual_reproductions: int = 0
         self._mutation_controller = DiversityMutationController(
             diversity_score_provider=self._get_diversity_score,
@@ -67,6 +73,9 @@ class ReproductionService:
 
         fish_count = len(fish_list)
 
+        proximity = self._handle_proximity_mating(fish_list, fish_count)
+        fish_count += proximity
+
         banked = self._handle_banked_asexual_reproduction(fish_list, fish_count)
         fish_count += banked
 
@@ -78,6 +87,7 @@ class ReproductionService:
         return ReproductionFrameStats(
             banked_asexual=banked,
             trait_asexual=trait,
+            proximity_sexual=proximity,
             emergency_spawns=emergency,
         )
 
@@ -222,6 +232,7 @@ class ReproductionService:
             "emergency_spawns": self._emergency_spawns,
             "last_emergency_spawn_frame": self._last_emergency_spawn_frame,
             "poker_reproductions": self._poker_reproductions,
+            "proximity_reproductions": self._proximity_reproductions,
             "plant_asexual_reproductions": self._plant_asexual_reproductions,
         }
 
@@ -318,6 +329,17 @@ class ReproductionService:
                         spawned += 1
                         fish_count += 1
 
+        return spawned
+
+    def _handle_proximity_mating(self, fish_list: list[Fish], fish_count: int) -> int:
+        spawned = run_proximity_mating_cycle(
+            engine=self._engine,
+            fish_list=fish_list,
+            fish_count=fish_count,
+            required_credits=self._get_repro_credit_required(),
+            mutation_context_provider=self._mutation_context_for_parents,
+        )
+        self._proximity_reproductions += spawned
         return spawned
 
     def _handle_emergency_spawning(self, frame: int, fish_count: int) -> int:
@@ -486,121 +508,12 @@ class ReproductionService:
         return maybe_create_banked_offspring(fish, mutation_context=mutation_context)
 
     def _create_post_poker_offspring(self, winner: Fish, mate: Fish) -> Fish | None:
-        from core.config.fish import (
-            ENERGY_MAX_DEFAULT,
-            FISH_BABY_SIZE,
-            FISH_BASE_SPEED,
-            POST_POKER_CROSSOVER_WINNER_WEIGHT,
-            POST_POKER_MUTATION_RATE,
-            POST_POKER_MUTATION_STRENGTH,
-            POST_POKER_PARENT_ENERGY_CONTRIBUTION,
-            REPRODUCTION_COOLDOWN,
+        return create_post_poker_offspring(
+            winner,
+            mate,
+            self._engine,
+            self._mutation_context_for_parents(winner, mate),
         )
-        from core.entities import Fish
-        from core.genetics import Genome, ReproductionParams
-
-        if winner.environment is None:
-            return None
-
-        mutation_context = self._mutation_context_for_parents(winner, mate)
-
-        offspring_genome = Genome.from_parents_weighted_params(
-            parent1=winner.genome,
-            parent2=mate.genome,
-            parent1_weight=POST_POKER_CROSSOVER_WINNER_WEIGHT,
-            params=ReproductionParams(
-                mutation_rate=POST_POKER_MUTATION_RATE,
-                mutation_strength=POST_POKER_MUTATION_STRENGTH,
-            ),
-            rng=self._engine.rng,
-            mutation_context=mutation_context,
-        )
-
-        # Pool-aware per-kind policy mutation (prevents cross-kind contamination)
-        pool = getattr(winner.environment, "genome_code_pool", None)
-        if pool is not None:
-            from core.genetics.code_policy_traits import (
-                mutate_code_policies,
-                validate_code_policy_ids,
-            )
-
-            mutate_code_policies(offspring_genome.behavioral, pool, self._engine.rng)
-            validate_code_policy_ids(offspring_genome.behavioral, pool, self._engine.rng)
-
-        baby_max_energy = (
-            ENERGY_MAX_DEFAULT * FISH_BABY_SIZE * offspring_genome.physical.size_modifier.value
-        )
-        if baby_max_energy <= 0:
-            return None
-
-        winner_contrib = max(0.0, winner.energy * POST_POKER_PARENT_ENERGY_CONTRIBUTION)
-        mate_contrib = max(0.0, mate.energy * POST_POKER_PARENT_ENERGY_CONTRIBUTION)
-        total_contrib = winner_contrib + mate_contrib
-        if total_contrib <= 0:
-            return None
-
-        if total_contrib > baby_max_energy:
-            scale = baby_max_energy / total_contrib
-            winner_contrib *= scale
-            mate_contrib *= scale
-            total_contrib = baby_max_energy
-
-        apply_energy_delta(winner, -winner_contrib, source="post_poker_reproduction")
-        apply_energy_delta(mate, -mate_contrib, source="post_poker_reproduction")
-
-        winner._reproduction_component.reproduction_cooldown = max(
-            winner._reproduction_component.reproduction_cooldown,
-            REPRODUCTION_COOLDOWN,
-        )
-        mate._reproduction_component.reproduction_cooldown = max(
-            mate._reproduction_component.reproduction_cooldown,
-            REPRODUCTION_COOLDOWN,
-        )
-
-        (min_x, min_y), (max_x, max_y) = winner.environment.get_bounds()
-        mid_x = (winner.pos.x + mate.pos.x) * 0.5
-        mid_y = (winner.pos.y + mate.pos.y) * 0.5
-        baby_x = mid_x + self._engine.rng.uniform(-30, 30)
-        baby_y = mid_y + self._engine.rng.uniform(-30, 30)
-        baby_x = max(min_x, min(max_x - 50, baby_x))
-        baby_y = max(min_y, min(max_y - 50, baby_y))
-
-        baby = Fish(
-            environment=winner.environment,
-            movement_strategy=winner.movement_strategy.__class__(),
-            species=winner.species,
-            x=baby_x,
-            y=baby_y,
-            speed=FISH_BASE_SPEED,
-            genome=offspring_genome,
-            generation=max(winner.generation, mate.generation) + 1,
-            ecosystem=winner.ecosystem,
-            initial_energy=total_contrib,
-            parent_id=winner.fish_id,
-        )
-
-        if winner.ecosystem is not None:
-            composable = winner.genome.behavioral.behavior
-            if composable is not None and composable.value is not None:
-                behavior_id = composable.value.behavior_id
-                algorithm_id = stable_algorithm_id(behavior_id)
-                winner.ecosystem.record_reproduction(algorithm_id, is_asexual=False)
-            winner.ecosystem.record_mating_attempt(True)
-
-        winner.visual_state.set_birth_effect(60)
-        mate.visual_state.set_birth_effect(60)
-
-        # Determinism anchor: post-poker reproduction has always drawn one engine
-        # RNG value here (it picked which parent's learned state the offspring
-        # inherited). That inherited state has been removed, but dropping the draw
-        # would reshuffle the shared seeded stream for every poker-on config and
-        # trip the golden-replay/benchmark guards. Retain the draw so this removal
-        # stays byte-identical; drop it via a coordinated re-record when this path
-        # is next intentionally changed. (See docs/POKER_SEAM_PROPOSAL.md: minigame
-        # state should not draw from the core RNG.)
-        self._engine.rng.random()
-
-        return baby
 
     @staticmethod
     def create_asexual_offspring(

--- a/core/reproduction/reproduction_system.py
+++ b/core/reproduction/reproduction_system.py
@@ -32,6 +32,7 @@ class ReproductionSystem(BaseSystem):
             details={
                 "banked_asexual": stats.banked_asexual,
                 "trait_asexual": stats.trait_asexual,
+                "proximity_sexual": stats.proximity_sexual,
                 "emergency_spawns": stats.emergency_spawns,
             },
         )

--- a/core/reproduction/sexual_factory.py
+++ b/core/reproduction/sexual_factory.py
@@ -1,0 +1,363 @@
+"""Sexual reproduction helpers for fish reproduction paths."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from core.energy.energy_utils import apply_energy_delta
+from core.util.stable_hash import stable_algorithm_id
+
+if TYPE_CHECKING:
+    from core.entities import Fish
+    from core.genetics.reproduction import ReproductionMutationContext
+    from core.simulation import SimulationEngine
+
+
+MutationContextProvider = Callable[["Fish", "Fish"], "ReproductionMutationContext"]
+
+
+@dataclass(frozen=True)
+class ProximityMatingConfig:
+    """Local gates for standard proximity mating."""
+
+    max_distance: float
+    min_energy_ratio: float
+    parent_energy_contribution: float
+    mutation_rate: float
+    mutation_strength: float
+
+
+def run_proximity_mating_cycle(
+    *,
+    engine: SimulationEngine,
+    fish_list: list[Fish],
+    fish_count: int,
+    required_credits: float,
+    mutation_context_provider: MutationContextProvider,
+) -> int:
+    """Attempt deterministic proximity mating for eligible fish pairs."""
+    from core.config.fish import (
+        STANDARD_MATING_DISTANCE,
+        STANDARD_MATING_MIN_ENERGY_RATIO,
+        STANDARD_MATING_MUTATION_RATE,
+        STANDARD_MATING_MUTATION_STRENGTH,
+        STANDARD_MATING_PARENT_ENERGY_CONTRIBUTION,
+    )
+
+    if len(fish_list) < 2:
+        return 0
+
+    ecosystem = engine.ecosystem
+    if ecosystem is not None and fish_count >= ecosystem.max_population:
+        return 0
+
+    config = ProximityMatingConfig(
+        max_distance=STANDARD_MATING_DISTANCE,
+        min_energy_ratio=STANDARD_MATING_MIN_ENERGY_RATIO,
+        parent_energy_contribution=STANDARD_MATING_PARENT_ENERGY_CONTRIBUTION,
+        mutation_rate=STANDARD_MATING_MUTATION_RATE,
+        mutation_strength=STANDARD_MATING_MUTATION_STRENGTH,
+    )
+    spawned = 0
+    used: set[int] = set()
+    sorted_fish = sorted(fish_list, key=_fish_sort_key)
+
+    for parent in sorted_fish:
+        if parent.fish_id in used or not _can_try_standard_mating(parent, config):
+            continue
+        if ecosystem is not None and not ecosystem.can_reproduce(fish_count):
+            break
+
+        mate = _find_proximity_mate(parent, sorted_fish, used, config)
+        if mate is None:
+            continue
+        if required_credits > 0 and (
+            not parent._reproduction_component.has_repro_credits(required_credits)
+            or not mate._reproduction_component.has_repro_credits(required_credits)
+        ):
+            continue
+
+        mutation_context = mutation_context_provider(parent, mate)
+        baby = create_standard_mating_offspring(parent, mate, engine, config, mutation_context)
+        if baby is None:
+            continue
+
+        if engine.request_spawn(baby, reason="proximity_mating"):
+            baby.register_birth()
+            lifecycle_system = engine.lifecycle_system
+            if lifecycle_system is not None:
+                lifecycle_system.record_birth()
+            if required_credits > 0:
+                parent._reproduction_component.consume_repro_credits(required_credits)
+                mate._reproduction_component.consume_repro_credits(required_credits)
+            used.add(parent.fish_id)
+            used.add(mate.fish_id)
+            spawned += 1
+            fish_count += 1
+
+    return spawned
+
+
+def create_standard_mating_offspring(
+    parent: Fish,
+    mate: Fish,
+    engine: SimulationEngine,
+    config: ProximityMatingConfig,
+    mutation_context: ReproductionMutationContext,
+) -> Fish | None:
+    """Create a 50/50 proximity-mating offspring with local energy costs."""
+    from core.config.fish import ENERGY_MAX_DEFAULT, FISH_BABY_SIZE, FISH_BASE_SPEED
+    from core.entities import Fish
+    from core.genetics import Genome
+
+    if parent.environment is None:
+        return None
+
+    offspring_genome = Genome.from_parents(
+        parent1=parent.genome,
+        parent2=mate.genome,
+        mutation_rate=config.mutation_rate,
+        mutation_strength=config.mutation_strength,
+        rng=engine.rng,
+        mutation_context=mutation_context,
+    )
+
+    _mutate_code_policies(parent, offspring_genome, engine)
+
+    baby_max_energy = (
+        ENERGY_MAX_DEFAULT * FISH_BABY_SIZE * offspring_genome.physical.size_modifier.value
+    )
+    if baby_max_energy <= 0:
+        return None
+
+    parent_contrib = baby_max_energy * config.parent_energy_contribution
+    mate_contrib = baby_max_energy * config.parent_energy_contribution
+    if parent.energy < parent_contrib or mate.energy < mate_contrib:
+        return None
+
+    apply_energy_delta(parent, -parent_contrib, source="proximity_mating")
+    apply_energy_delta(mate, -mate_contrib, source="proximity_mating")
+
+    cooldown = parent._reproduction_component.REPRODUCTION_COOLDOWN
+    parent._reproduction_component.reproduction_cooldown = max(
+        parent._reproduction_component.reproduction_cooldown,
+        cooldown,
+    )
+    mate._reproduction_component.reproduction_cooldown = max(
+        mate._reproduction_component.reproduction_cooldown,
+        cooldown,
+    )
+
+    baby_x, baby_y = _offspring_position(parent, mate, engine, jitter=30.0)
+    baby = Fish(
+        environment=parent.environment,
+        movement_strategy=parent.movement_strategy.__class__(),
+        species=parent.species,
+        x=baby_x,
+        y=baby_y,
+        speed=FISH_BASE_SPEED,
+        genome=offspring_genome,
+        generation=max(parent.generation, mate.generation) + 1,
+        ecosystem=parent.ecosystem,
+        initial_energy=parent_contrib + mate_contrib,
+        parent_id=parent.fish_id,
+    )
+
+    _record_successful_mating(parent)
+    parent.visual_state.set_birth_effect(60)
+    mate.visual_state.set_birth_effect(60)
+    return baby
+
+
+def create_post_poker_offspring(
+    winner: Fish,
+    mate: Fish,
+    engine: SimulationEngine,
+    mutation_context: ReproductionMutationContext,
+) -> Fish | None:
+    """Create a post-poker offspring while preserving legacy RNG behavior."""
+    from core.config.fish import (
+        ENERGY_MAX_DEFAULT,
+        FISH_BABY_SIZE,
+        FISH_BASE_SPEED,
+        POST_POKER_CROSSOVER_WINNER_WEIGHT,
+        POST_POKER_MUTATION_RATE,
+        POST_POKER_MUTATION_STRENGTH,
+        POST_POKER_PARENT_ENERGY_CONTRIBUTION,
+        REPRODUCTION_COOLDOWN,
+    )
+    from core.entities import Fish
+    from core.genetics import Genome, ReproductionParams
+
+    if winner.environment is None:
+        return None
+
+    offspring_genome = Genome.from_parents_weighted_params(
+        parent1=winner.genome,
+        parent2=mate.genome,
+        parent1_weight=POST_POKER_CROSSOVER_WINNER_WEIGHT,
+        params=ReproductionParams(
+            mutation_rate=POST_POKER_MUTATION_RATE,
+            mutation_strength=POST_POKER_MUTATION_STRENGTH,
+        ),
+        rng=engine.rng,
+        mutation_context=mutation_context,
+    )
+
+    _mutate_code_policies(winner, offspring_genome, engine)
+
+    baby_max_energy = (
+        ENERGY_MAX_DEFAULT * FISH_BABY_SIZE * offspring_genome.physical.size_modifier.value
+    )
+    if baby_max_energy <= 0:
+        return None
+
+    winner_contrib = max(0.0, winner.energy * POST_POKER_PARENT_ENERGY_CONTRIBUTION)
+    mate_contrib = max(0.0, mate.energy * POST_POKER_PARENT_ENERGY_CONTRIBUTION)
+    total_contrib = winner_contrib + mate_contrib
+    if total_contrib <= 0:
+        return None
+
+    if total_contrib > baby_max_energy:
+        scale = baby_max_energy / total_contrib
+        winner_contrib *= scale
+        mate_contrib *= scale
+        total_contrib = baby_max_energy
+
+    apply_energy_delta(winner, -winner_contrib, source="post_poker_reproduction")
+    apply_energy_delta(mate, -mate_contrib, source="post_poker_reproduction")
+
+    winner._reproduction_component.reproduction_cooldown = max(
+        winner._reproduction_component.reproduction_cooldown,
+        REPRODUCTION_COOLDOWN,
+    )
+    mate._reproduction_component.reproduction_cooldown = max(
+        mate._reproduction_component.reproduction_cooldown,
+        REPRODUCTION_COOLDOWN,
+    )
+
+    baby_x, baby_y = _offspring_position(winner, mate, engine, jitter=30.0)
+    baby = Fish(
+        environment=winner.environment,
+        movement_strategy=winner.movement_strategy.__class__(),
+        species=winner.species,
+        x=baby_x,
+        y=baby_y,
+        speed=FISH_BASE_SPEED,
+        genome=offspring_genome,
+        generation=max(winner.generation, mate.generation) + 1,
+        ecosystem=winner.ecosystem,
+        initial_energy=total_contrib,
+        parent_id=winner.fish_id,
+    )
+
+    _record_successful_mating(winner)
+    winner.visual_state.set_birth_effect(60)
+    mate.visual_state.set_birth_effect(60)
+
+    # Determinism anchor: post-poker reproduction has always drawn one engine
+    # RNG value here (it picked which parent's learned state the offspring
+    # inherited). That inherited state has been removed, but dropping the draw
+    # would reshuffle the shared seeded stream for every poker-on config and
+    # trip the golden-replay/benchmark guards. Retain the draw so this removal
+    # stays byte-identical; drop it via a coordinated re-record when this path
+    # is next intentionally changed.
+    engine.rng.random()
+
+    return baby
+
+
+def _can_try_standard_mating(fish: Fish, config: ProximityMatingConfig) -> bool:
+    from core.entities.base import LifeStage
+
+    if hasattr(fish, "is_dead") and fish.is_dead():
+        return False
+    if fish.life_stage != LifeStage.ADULT:
+        return False
+    if fish._reproduction_component.reproduction_cooldown > 0:
+        return False
+    return fish.energy >= fish.max_energy * config.min_energy_ratio
+
+
+def _find_proximity_mate(
+    parent: Fish,
+    fish_list: list[Fish],
+    used: set[int],
+    config: ProximityMatingConfig,
+) -> Fish | None:
+    max_dist_sq = config.max_distance * config.max_distance
+    candidates: list[tuple[float, int, Fish]] = []
+
+    for mate in fish_list:
+        if mate is parent or mate.fish_id in used:
+            continue
+        if mate.species != parent.species or not _can_try_standard_mating(mate, config):
+            continue
+        dist_sq = _distance_sq(parent, mate)
+        if dist_sq <= max_dist_sq:
+            candidates.append((dist_sq, mate.fish_id, mate))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: (item[0], item[1]))
+    return candidates[0][2]
+
+
+def _mutate_code_policies(parent: Fish, offspring_genome, engine: SimulationEngine) -> None:
+    pool = getattr(parent.environment, "genome_code_pool", None)
+    if pool is None:
+        return
+
+    from core.genetics.code_policy_traits import (
+        mutate_code_policies,
+        validate_code_policy_ids,
+    )
+
+    mutate_code_policies(offspring_genome.behavioral, pool, engine.rng)
+    validate_code_policy_ids(offspring_genome.behavioral, pool, engine.rng)
+
+
+def _record_successful_mating(parent: Fish) -> None:
+    if parent.ecosystem is None:
+        return
+    composable = parent.genome.behavioral.behavior
+    if composable is not None and composable.value is not None:
+        behavior_id = composable.value.behavior_id
+        algorithm_id = stable_algorithm_id(behavior_id)
+        parent.ecosystem.record_reproduction(algorithm_id, is_asexual=False)
+    parent.ecosystem.record_mating_attempt(True)
+
+
+def _offspring_position(
+    parent: Fish,
+    mate: Fish,
+    engine: SimulationEngine,
+    *,
+    jitter: float,
+) -> tuple[float, float]:
+    (min_x, min_y), (max_x, max_y) = parent.environment.get_bounds()
+    mid_x = (parent.pos.x + mate.pos.x) * 0.5
+    mid_y = (parent.pos.y + mate.pos.y) * 0.5
+    baby_x = mid_x + engine.rng.uniform(-jitter, jitter)
+    baby_y = mid_y + engine.rng.uniform(-jitter, jitter)
+    baby_x = max(min_x, min(max_x - 50, baby_x))
+    baby_y = max(min_y, min(max_y - 50, baby_y))
+    return baby_x, baby_y
+
+
+def _distance_sq(a: Fish, b: Fish) -> float:
+    ax, ay = _center(a)
+    bx, by = _center(b)
+    dx = ax - bx
+    dy = ay - by
+    return dx * dx + dy * dy
+
+
+def _center(fish: Fish) -> tuple[float, float]:
+    return fish.pos.x + fish.width * 0.5, fish.pos.y + fish.height * 0.5
+
+
+def _fish_sort_key(fish: Fish) -> int:
+    return fish.fish_id

--- a/tests/test_proximity_mating.py
+++ b/tests/test_proximity_mating.py
@@ -1,0 +1,174 @@
+"""Standard proximity mating through ReproductionService."""
+
+from __future__ import annotations
+
+import random
+from typing import cast
+
+from core.config.fish import (
+    ENERGY_MAX_DEFAULT,
+    FISH_BABY_SIZE,
+    STANDARD_MATING_PARENT_ENERGY_CONTRIBUTION,
+)
+from core.config.simulation_config import SimulationConfig
+from core.entities import Fish, LifeStage
+from core.genetics import Genome
+from core.movement_strategy import AlgorithmicMovement
+from core.reproduction.reproduction_service import ReproductionService
+from core.world import World
+
+
+class _MiniEcosystem:
+    def __init__(self) -> None:
+        self._next_fish_id = 1
+        self.reproductions: list[bool] = []
+        self.mating_attempts: list[bool] = []
+        self.births = 0
+
+    def generate_new_fish_id(self) -> int:
+        fish_id = self._next_fish_id
+        self._next_fish_id += 1
+        return fish_id
+
+    def record_birth(self, *_args, **_kwargs) -> None:
+        self.births += 1
+
+    def record_reproduction(self, _algorithm_id: int, is_asexual: bool = False) -> None:
+        self.reproductions.append(is_asexual)
+
+    def record_mating_attempt(self, success: bool) -> None:
+        self.mating_attempts.append(success)
+
+    def record_energy_burn(self, _source: str, _amount: float) -> None:
+        return None
+
+    def record_energy_gain(self, _source: str, _amount: float) -> None:
+        return None
+
+
+class _MiniEnvironment:
+    def __init__(self) -> None:
+        self.width = 300
+        self.height = 200
+        self.rng = random.Random(42)
+
+    def get_bounds(self):
+        return (0.0, 0.0), (float(self.width), float(self.height))
+
+    def list_policy_component_ids(self, _kind: str) -> list[str]:
+        return []
+
+
+class _EntityManager:
+    def __init__(self, fish: list[Fish]) -> None:
+        self._fish = fish
+
+    def get_fish(self) -> list[Fish]:
+        return list(self._fish)
+
+
+class _LifecycleSystem:
+    def __init__(self) -> None:
+        self.births = 0
+
+    def record_birth(self) -> None:
+        self.births += 1
+
+
+class _MiniEngine:
+    def __init__(self, fish: list[Fish], env: _MiniEnvironment) -> None:
+        self.entity_manager = _EntityManager(fish)
+        self.environment = env
+        self.rng = env.rng
+        self.ecosystem = None
+        self.lifecycle_system = _LifecycleSystem()
+        self.config = SimulationConfig.headless_fast()
+        self.spawned: list[Fish] = []
+        self.spawn_reasons: list[str] = []
+
+    def request_spawn(self, entity: Fish, *, reason: str) -> bool:
+        self.spawned.append(entity)
+        self.spawn_reasons.append(reason)
+        return True
+
+
+def _adult_fish(
+    env: _MiniEnvironment,
+    ecosystem: _MiniEcosystem,
+    *,
+    x: float,
+    y: float,
+    energy_ratio: float,
+) -> Fish:
+    genome = Genome.random(use_algorithm=True, rng=env.rng)
+    genome.physical.size_modifier.value = 1.0
+    fish = Fish(
+        environment=cast(World, env),
+        movement_strategy=AlgorithmicMovement(),
+        species="test_fish",
+        x=x,
+        y=y,
+        speed=2.0,
+        genome=genome,
+        generation=2,
+        ecosystem=cast("object", ecosystem),
+        initial_energy=ENERGY_MAX_DEFAULT * energy_ratio,
+    )
+    fish.force_life_stage(LifeStage.ADULT)
+    fish.energy = fish.max_energy * energy_ratio
+    fish._reproduction_component.reproduction_cooldown = 0
+    fish.genome.behavioral.asexual_reproduction_chance.value = 1.0
+    return fish
+
+
+def test_proximity_mating_spawns_sexual_offspring_before_cloning() -> None:
+    env = _MiniEnvironment()
+    ecosystem = _MiniEcosystem()
+    parent = _adult_fish(env, ecosystem, x=80, y=80, energy_ratio=1.0)
+    mate = _adult_fish(env, ecosystem, x=100, y=80, energy_ratio=1.0)
+    engine = _MiniEngine([parent, mate], env)
+    service = ReproductionService(cast("SimpleNamespace", engine))
+
+    parent_energy_before = parent.energy
+    mate_energy_before = mate.energy
+
+    assert parent.try_mate(mate)
+    stats = service.update_frame(1)
+
+    assert stats.proximity_sexual == 1
+    assert stats.trait_asexual == 0
+    assert len(engine.spawned) == 1
+    assert engine.spawn_reasons == ["proximity_mating"]
+    assert engine.lifecycle_system.births == 1
+    assert service.get_debug_info()["proximity_reproductions"] == 1
+
+    baby = engine.spawned[0]
+    expected_contribution = (
+        ENERGY_MAX_DEFAULT
+        * FISH_BABY_SIZE
+        * baby.genome.physical.size_modifier.value
+        * STANDARD_MATING_PARENT_ENERGY_CONTRIBUTION
+    )
+    assert parent.energy == parent_energy_before - expected_contribution
+    assert mate.energy == mate_energy_before - expected_contribution
+    assert baby.generation == 3
+    assert baby.parent_id == parent.fish_id
+    assert False in ecosystem.reproductions
+    assert ecosystem.mating_attempts == [True]
+
+
+def test_proximity_mating_requires_local_parent_energy() -> None:
+    env = _MiniEnvironment()
+    ecosystem = _MiniEcosystem()
+    parent = _adult_fish(env, ecosystem, x=80, y=80, energy_ratio=0.49)
+    mate = _adult_fish(env, ecosystem, x=100, y=80, energy_ratio=1.0)
+    parent.genome.behavioral.asexual_reproduction_chance.value = 0.0
+    mate.genome.behavioral.asexual_reproduction_chance.value = 0.0
+    engine = _MiniEngine([parent, mate], env)
+    service = ReproductionService(cast("SimpleNamespace", engine))
+
+    assert not parent.try_mate(mate)
+    stats = service.update_frame(1)
+
+    assert stats.proximity_sexual == 0
+    assert engine.spawned == []


### PR DESCRIPTION
## Summary

Implements the elected board proposal #10, restoring standard proximity-based sexual reproduction as an endogenous sex-vs-cloning trade-off while keeping poker mating as the separate display/contest path.

Changes:
- Add standard proximity mating in `ReproductionService.update_frame()` before asexual paths.
- Use deterministic `fish_id` pair ordering, one mating per fish per frame, local `>=50%` parent energy gates, symmetric 50/50 baby-energy contribution, and `ReproductionComponent.REPRODUCTION_COOLDOWN` for standard mating.
- Extract sexual offspring creation into `core/reproduction/sexual_factory.py`, preserving the post-poker RNG anchor and keeping `reproduction_service.py` below its god-class ratchet.
- Update `try_mate()` from a disabled stub into a standard-mating eligibility predicate.
- Add focused proximity-mating tests.

## Why

Live/board evidence showed sexual recombination was functionally unavailable during chronic resource stress, producing clonal sweeps and diversity loss. This restores recombination as a normal local reproductive option without adding a global diversity override or changing the benchmark objective.

## Benchmark Evidence

Benchmark command:

```powershell
.\.venv\Scripts\python.exe tools\run_bench.py benchmarks\tank\ecosystem_health_10k.py --seed <seed> --out results\prop10_ecosystem_health_10k_seed<seed>.json
```

Compared against a clean `master` worktree using the same command:

| Seed | Baseline | Candidate | Delta | Generation | Diversity | Starvation |
|---:|---:|---:|---:|---:|---:|---:|
| 42 | 8.046606 | 9.319506 | +15.8% | 8 -> 9 | 0.2649 -> 0.2735 | 0.9925 -> 0.9904 |
| 7 | 8.150006 | 7.042807 | -13.6% | 8 -> 7 | 0.2314 -> 0.2712 | 0.9947 -> 0.9746 |
| 123 | 6.819384 | 9.451222 | +38.6% | 7 -> 9 | 0.3228 -> 0.3728 | 0.9912 -> 0.9884 |
| Mean | 7.671999 | 8.604512 | +12.2% | | | |

Champion comparison note: `tools/validate_improvement.py results\prop10_ecosystem_health_10k_seed42.json champions\tank\ecosystem_health_10k.json` correctly refused direct comparison because adding standard-mating config constants changes the `config_hash`. The branch was therefore compared against a clean `master` worktree instead of claiming a champion-validated score.

## Trait Drift / Evolvability

Controlled validation:

```powershell
.\.venv\Scripts\python.exe scripts\diagnose_evolution.py --frames 10000 --seed 42
.\.venv\Scripts\python.exe scripts\diagnose_evolution.py --frames 10000 --seed 7
.\.venv\Scripts\python.exe scripts\diagnose_evolution.py --frames 10000 --seed 123
```

All three seeds reported directional selection detected. Seed 42 advanced 8 generations after the change versus 5 in the pre-change probe.

## Validation

```powershell
.\.venv\Scripts\python.exe -m pytest tests\test_proximity_mating.py -q
.\.venv\Scripts\python.exe tools\smoke_gate.py
.\.venv\Scripts\python.exe tools\agent_gate.py
.\.venv\Scripts\python.exe tools\fast_gate.py
.\.venv\Scripts\python.exe tools\run_bench.py benchmarks\tank\ecosystem_health_10k.py --seed 42 --verify-determinism --out results\prop10_ecosystem_health_10k_seed42_verify.json
```

Results:
- Proximity tests: 2 passed.
- Smoke gate: passed.
- Agent gate: 575 passed, 100 deselected.
- Fast gate: 1770 passed, 3 skipped, 157 deselected.
- Determinism check: passed.