### PR TITLE
[codex] Activate heritable mate choice in proximity mating

### DIFF
--- a/core/reproduction/sexual_factory.py
+++ b/core/reproduction/sexual_factory.py
@@ -288,7 +288,7 @@ def _find_proximity_mate(
     config: ProximityMatingConfig,
 ) -> Fish | None:
     max_dist_sq = config.max_distance * config.max_distance
-    candidates: list[tuple[float, int, Fish]] = []
+    candidates: list[tuple[float, float, int, Fish]] = []
 
     for mate in fish_list:
         if mate is parent or mate.fish_id in used:
@@ -297,12 +297,13 @@ def _find_proximity_mate(
             continue
         dist_sq = _distance_sq(parent, mate)
         if dist_sq <= max_dist_sq:
-            candidates.append((dist_sq, mate.fish_id, mate))
+            attraction = parent.genome.calculate_mate_attraction(mate.genome)
+            candidates.append((attraction, dist_sq, mate.fish_id, mate))
 
     if not candidates:
         return None
-    candidates.sort(key=lambda item: (item[0], item[1]))
-    return candidates[0][2]
+    candidates.sort(key=lambda item: (-item[0], item[1], item[2]))
+    return candidates[0][3]
 
 
 def _mutate_code_policies(parent: Fish, offspring_genome, engine: SimulationEngine) -> None:

--- a/tests/test_proximity_mate_choice.py
+++ b/tests/test_proximity_mate_choice.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core.entities.base import LifeStage
+from core.genetics import BehavioralTraits, GeneticTrait, Genome, PhysicalTraits
+from core.reproduction.sexual_factory import ProximityMatingConfig, _find_proximity_mate
+
+
+def _genome(*, aggression: float, mate_preferences: dict[str, float] | None = None) -> Genome:
+    physical = PhysicalTraits(
+        size_modifier=GeneticTrait(1.0),
+        color_hue=GeneticTrait(0.5),
+        template_id=GeneticTrait(0),
+        fin_size=GeneticTrait(1.0),
+        tail_size=GeneticTrait(1.0),
+        body_aspect=GeneticTrait(1.0),
+        eye_size=GeneticTrait(1.0),
+        pattern_intensity=GeneticTrait(0.5),
+        pattern_type=GeneticTrait(0),
+        lifespan_modifier=GeneticTrait(1.0),
+    )
+    behavioral = BehavioralTraits(
+        aggression=GeneticTrait(aggression),
+        social_tendency=GeneticTrait(0.5),
+        pursuit_aggression=GeneticTrait(0.5),
+        prediction_skill=GeneticTrait(0.5),
+        hunting_stamina=GeneticTrait(0.5),
+        asexual_reproduction_chance=GeneticTrait(0.5),
+        poker_strategy=GeneticTrait(None),
+        mate_preferences=GeneticTrait(mate_preferences or {}),
+    )
+    return Genome(physical=physical, behavioral=behavioral)
+
+
+def _fish(fish_id: int, *, x: float, aggression: float, mate_preferences=None):
+    return SimpleNamespace(
+        fish_id=fish_id,
+        species="fish1.png",
+        life_stage=LifeStage.ADULT,
+        energy=100.0,
+        max_energy=100.0,
+        width=10.0,
+        height=10.0,
+        pos=SimpleNamespace(x=x, y=0.0),
+        genome=_genome(aggression=aggression, mate_preferences=mate_preferences),
+        _reproduction_component=SimpleNamespace(reproduction_cooldown=0),
+        is_dead=lambda: False,
+    )
+
+
+def _config() -> ProximityMatingConfig:
+    return ProximityMatingConfig(
+        max_distance=100.0,
+        min_energy_ratio=0.1,
+        parent_energy_contribution=0.2,
+        mutation_rate=0.1,
+        mutation_strength=0.1,
+    )
+
+
+def test_proximity_mating_prefers_heritable_attraction_over_nearest_mate():
+    parent = _fish(
+        1,
+        x=0.0,
+        aggression=0.5,
+        mate_preferences={"prefer_high_aggression": 1.0},
+    )
+    nearest_low_aggression = _fish(2, x=10.0, aggression=0.0)
+    farther_high_aggression = _fish(3, x=40.0, aggression=1.0)
+
+    mate = _find_proximity_mate(
+        parent,
+        [parent, nearest_low_aggression, farther_high_aggression],
+        set(),
+        _config(),
+    )
+
+    assert mate is farther_high_aggression
+
+
+def test_proximity_mating_uses_distance_as_attraction_tiebreaker():
+    parent = _fish(1, x=0.0, aggression=0.5)
+    nearest = _fish(2, x=10.0, aggression=0.5)
+    farther = _fish(3, x=40.0, aggression=0.5)
+
+    mate = _find_proximity_mate(parent, [parent, farther, nearest], set(), _config())
+
+    assert mate is nearest


### PR DESCRIPTION
## Summary

Activates the existing heritable mate preference system in standard proximity mating. Eligible mates inside the existing `STANDARD_MATING_DISTANCE` are now ranked by `Genome.calculate_mate_attraction()`, with distance and `fish_id` retained as deterministic tie-breakers. This gives the dormant `mate_preferences` genome dict a direct reproductive role without changing survival gates, energy thresholds, benchmarks, or champion metadata.

Adds focused tests proving that:

- a farther but genetically preferred in-range mate beats the nearest mate
- equal-attraction candidates still fall back to closest-distance selection

## Evidence

Mandate: decision-board proposal #5, Runaway Mate Choice / heritable mate preferences for sympatric speciation.

Current-code baseline from clean `master` worktree vs candidate branch:

| seed | baseline score | candidate score | diversity baseline -> candidate |
| --- | ---: | ---: | --- |
| 42 | 9.319506 | 8.382516 | 0.2735 -> 0.2645 |
| 7 | 7.042807 | 10.081288 | 0.2712 -> 0.3249 |
| 123 | 9.451222 | 9.196421 | 0.3728 -> 0.2952 |

Average score: `8.604512 -> 9.220075` (`+7.15%`). This is a mixed result, not an all-seeds win: seed 7 improves substantially while seeds 42 and 123 dip. Candidate diversity remains above the proposal floor of `>0.25` on all three seeds, but average diversity does not improve.

Controlled diagnostics:

- `py scripts\diagnose_evolution.py --frames 10000 --seed 42`: directional selection detected
- `py scripts\diagnose_evolution.py --frames 10000 --seed 7`: directional selection detected
- `py scripts\diagnose_evolution.py --frames 10000 --seed 123`: directional selection detected

Champion note: `py tools\validate_improvement.py %TEMP%\runaway_mate_choice_seed42.json champions\tank\ecosystem_health_10k.json` reports a config hash mismatch (`43b81b3f6651a28a` vs champion `0b6bfb9fd9cdb0b5`), so this PR does not update champion metadata.

## Validation

- `py -m pytest tests\test_proximity_mate_choice.py -q` -> 2 passed
- `py tools\smoke_gate.py` -> passed, 34 tests
- `py tools\fast_gate.py` -> passed, 1772 passed, 3 skipped, 157 deselected
- `py tools\agent_gate.py` -> passed, 575 passed, 100 deselected
- `py tools\run_bench.py benchmarks\tank\ecosystem_health_10k.py --seed 42`
- `py tools\run_bench.py benchmarks\tank\ecosystem_health_10k.py --seed 7`
- `py tools\run_bench.py benchmarks\tank\ecosystem_health_10k.py --seed 123`
