### PR TITLE
[codex] Add frozen selection-response assay

### DIFF
--- a/benchmarks/tank/selection_response_10k.py
+++ b/benchmarks/tank/selection_response_10k.py
@@ -1,0 +1,252 @@
+"""Frozen selection-response assay for Tank World evolvability.
+
+This benchmark measures whether a population shows directional heritable trait
+response while retaining enough diversity to keep evolving. It intentionally
+complements ``ecosystem_health_10k``: that benchmark rewards generation speed,
+while this assay decomposes selection response per generation so fast churn with
+flat or collapsing traits is visible.
+
+The multi-seed held-out surface is ``tools/run_selection_response_assay.py``.
+This module remains a normal single-seed benchmark so it works with
+``tools/run_bench.py`` and the existing config-hash/determinism machinery.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import time
+from collections.abc import Callable
+from typing import Any
+
+from core.entities import Fish
+from core.services.stats.trait_trends import EVOLUTION_TRAIT_KEYS, compute_trait_means
+from core.worlds import WorldRegistry
+
+BENCHMARK_ID = "tank/selection_response_10k"
+FRAMES = 10000
+SAMPLE_INTERVAL = 1000
+FROZEN_SEEDS = (42, 7, 123)
+TRAIT_DRIFT_SELECTION_PCT = 5.0
+
+WORLD_CONFIG: dict[str, Any] = {
+    "headless": True,
+    "screen_width": 2000,
+    "screen_height": 2000,
+    "max_population": 60,
+    "critical_population_threshold": 5,
+    "emergency_spawn_cooldown": 90,
+    "poker_activity_enabled": False,
+    "plants_enabled": False,
+    "auto_food_spawn_rate": 9,
+    "soccer_enabled": False,
+}
+
+CONFIG: dict[str, Any] = {
+    "frames": FRAMES,
+    "sample_interval": SAMPLE_INTERVAL,
+    "trait_drift_selection_pct": TRAIT_DRIFT_SELECTION_PCT,
+    "frozen_seeds": FROZEN_SEEDS,
+    "world_config": WORLD_CONFIG,
+}
+
+
+def run(
+    seed: int, fingerprint_callback: Callable[[Any, int], None] | None = None
+) -> dict[str, Any]:
+    """Run the frozen selection-response benchmark for one seed."""
+    start_time = time.time()
+    samples = collect_samples(seed=seed, frames=FRAMES, interval=SAMPLE_INTERVAL)
+    runtime = time.time() - start_time
+    result = score_samples(samples, seed=seed, runtime_seconds=runtime)
+    if fingerprint_callback is not None:
+        # This benchmark collects internal samples rather than exposing every
+        # frame. Re-run through the canonical world loop when fingerprints are
+        # requested so the caller still gets comparable replay artifacts.
+        _run_fingerprint_pass(seed, fingerprint_callback)
+    return result
+
+
+def collect_samples(seed: int, frames: int, interval: int) -> list[dict[str, Any]]:
+    """Run a deterministic headless tank world and sample evolvability signals."""
+    config = dict(WORLD_CONFIG)
+    world = WorldRegistry.create_world("tank", seed=seed, config=config)
+    world.reset(seed=seed, config=config)
+
+    samples: list[dict[str, Any]] = []
+    for frame in range(1, frames + 1):
+        world.step()
+        if frame % interval == 0:
+            samples.append(_sample_world(world, frame))
+        if frame % 2000 == 0:
+            print(f"  Frame {frame}/{frames}...", file=sys.stderr)
+    return samples
+
+
+def score_samples(
+    samples: list[dict[str, Any]], *, seed: int, runtime_seconds: float = 0.0
+) -> dict[str, Any]:
+    """Score pre-collected samples and return the benchmark result dict."""
+    if len(samples) < 2:
+        return {
+            "benchmark_id": BENCHMARK_ID,
+            "seed": seed,
+            "score": 0.0,
+            "runtime_seconds": runtime_seconds,
+            "metadata": {
+                "frames": FRAMES,
+                "sample_interval": SAMPLE_INTERVAL,
+                "samples": len(samples),
+                "reason": "insufficient_samples",
+            },
+        }
+
+    first = samples[0]
+    last = samples[-1]
+    frames_covered = max(1, int(last["frame"]) - int(first["frame"]))
+    generations_advanced = max(0, int(last["max_generation"]) - int(first["max_generation"]))
+    generation_rate = generations_advanced / (frames_covered / 10000.0)
+
+    drift = _trait_drift(first.get("traits", {}), last.get("traits", {}))
+    selected = [item for item in drift.values() if item["selection"]]
+    mean_selected_abs_drift = (
+        sum(abs(item["pct"]) for item in selected) / len(selected) if selected else 0.0
+    )
+    selected_fraction = len(selected) / max(len(EVOLUTION_TRAIT_KEYS), 1)
+    drift_per_generation = mean_selected_abs_drift / max(generations_advanced, 1)
+
+    diversity_first = float(first.get("diversity_score", 0.0) or 0.0)
+    diversity_last = float(last.get("diversity_score", 0.0) or 0.0)
+    diversity_retention = (
+        min(1.5, diversity_last / diversity_first) if diversity_first > 0 else 0.0
+    )
+    diversity_floor = min(1.0, diversity_last / 0.30) if diversity_last > 0 else 0.0
+    diversity_component = math.sqrt(max(0.0, diversity_retention) * max(0.0, diversity_floor))
+
+    population_values = [float(s.get("population", 0.0) or 0.0) for s in samples]
+    population_component = _stability_component(population_values)
+    quality_per_generation = population_component * min(1.0, generation_rate / 5.0)
+
+    selection_component = min(2.0, drift_per_generation / TRAIT_DRIFT_SELECTION_PCT)
+    score = (
+        100.0
+        * selection_component
+        * selected_fraction
+        * diversity_component
+        * quality_per_generation
+    )
+
+    return {
+        "benchmark_id": BENCHMARK_ID,
+        "seed": seed,
+        "score": score,
+        "runtime_seconds": runtime_seconds,
+        "metadata": {
+            "frames": FRAMES,
+            "sample_interval": SAMPLE_INTERVAL,
+            "samples": len(samples),
+            "frame_first": first["frame"],
+            "frame_last": last["frame"],
+            "frames_covered": frames_covered,
+            "generation_first": first["max_generation"],
+            "generation_last": last["max_generation"],
+            "generations_advanced": generations_advanced,
+            "generation_rate_per_10k": round(generation_rate, 4),
+            "selection_detected": bool(selected),
+            "selected_trait_count": len(selected),
+            "selected_trait_fraction": round(selected_fraction, 4),
+            "mean_selected_abs_drift_pct": round(mean_selected_abs_drift, 4),
+            "drift_per_generation_pct": round(drift_per_generation, 4),
+            "diversity_first": round(diversity_first, 4),
+            "diversity_last": round(diversity_last, 4),
+            "diversity_delta": round(diversity_last - diversity_first, 4),
+            "diversity_retention": round(diversity_retention, 4),
+            "population_mean": round(sum(population_values) / len(population_values), 2),
+            "population_cv": round(_coefficient_of_variation(population_values), 4),
+            "population_component": round(population_component, 4),
+            "selection_component": round(selection_component, 4),
+            "diversity_component": round(diversity_component, 4),
+            "quality_per_generation": round(quality_per_generation, 4),
+            "trait_drift": drift,
+            "score_formula": (
+                "100 * selection_component * selected_trait_fraction * "
+                "diversity_component * quality_per_generation"
+            ),
+        },
+    }
+
+
+def _sample_world(world: Any, frame: int) -> dict[str, Any]:
+    stats = world.get_stats(include_distributions=False)
+    living = [e for e in world.entities_list if isinstance(e, Fish) and not e.is_dead()]
+    diversity = stats.get("diversity_stats", {})
+    return {
+        "frame": frame,
+        "max_generation": stats.get("max_generation", 0),
+        "population": stats.get("fish_count", 0),
+        "births_total": stats.get("total_births", stats.get("births", 0)),
+        "deaths_total": stats.get("total_deaths", stats.get("deaths", 0)),
+        "diversity_score": diversity.get("diversity_score", 0.0),
+        "traits": compute_trait_means(living),
+    }
+
+
+def _trait_drift(
+    first_traits: dict[str, float], last_traits: dict[str, float]
+) -> dict[str, dict[str, Any]]:
+    drift: dict[str, dict[str, Any]] = {}
+    for trait in EVOLUTION_TRAIT_KEYS:
+        if trait not in first_traits or trait not in last_traits:
+            continue
+        start = float(first_traits[trait])
+        end = float(last_traits[trait])
+        delta = end - start
+        pct = (delta / start * 100.0) if start else 0.0
+        drift[trait] = {
+            "start": round(start, 5),
+            "end": round(end, 5),
+            "delta": round(delta, 5),
+            "pct": round(pct, 2),
+            "selection": abs(pct) >= TRAIT_DRIFT_SELECTION_PCT,
+        }
+    return drift
+
+
+def _stability_component(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    cv = _coefficient_of_variation(values)
+    return 1.0 / (1.0 + cv)
+
+
+def _coefficient_of_variation(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    mean = sum(values) / len(values)
+    if mean <= 0:
+        return 1.0
+    variance = sum((value - mean) ** 2 for value in values) / len(values)
+    return math.sqrt(variance) / mean
+
+
+def _run_fingerprint_pass(
+    seed: int, fingerprint_callback: Callable[[Any, int], None]
+) -> None:
+    config = dict(WORLD_CONFIG)
+    world = WorldRegistry.create_world("tank", seed=seed, config=config)
+    world.reset(seed=seed, config=config)
+    fingerprint_callback(world, 0)
+    for frame in range(1, FRAMES + 1):
+        world.step()
+        fingerprint_callback(world, frame)
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    print(json.dumps(run(args.seed), indent=2))

--- a/docs/EVOLVABILITY.md
+++ b/docs/EVOLVABILITY.md
@@ -145,9 +145,23 @@ A living log so the board doesn't re‑propose dead ends. **Builders: append out
 engine actually getting better. The durable fix is a **frozen, held‑out measure of
 evolvability** — e.g. the population's **selection response** (trait drift under a fixed
 perturbation across held‑out seeds) — that proposals are scored against but may **not**
-modify. This does not exist yet; speccing and building it is itself a top‑tier proposal.
-Until it does, treat any change to the fitness signal as the highest‑leverage *and*
-highest‑risk class of work, kept separate from Layer‑1 changes and justified rigorously.
+modify.
+
+The first frozen assay is now:
+
+```bash
+# Held-out multi-seed ruler (default seeds: 42, 7, 123)
+python tools/run_selection_response_assay.py
+
+# Single-seed benchmark-compatible surface
+python tools/run_bench.py benchmarks/tank/selection_response_10k.py --seed 42
+```
+
+It reports a decomposed score: directional trait drift per generation, sustained
+diversity, and quality-per-generation. Treat it as held out: a PR that edits this assay
+must not claim an improvement from the edited assay in the same change. Changes to the
+fitness signal remain the highest‑leverage *and* highest‑risk class of work, kept
+separate from Layer‑1 changes and justified rigorously.
 
 ---
 

--- a/tests/test_selection_response_assay.py
+++ b/tests/test_selection_response_assay.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from benchmarks.tank.selection_response_10k import score_samples
+from tools.run_selection_response_assay import _aggregate_metadata
+
+
+def test_selection_response_score_rewards_drift_with_retained_diversity():
+    samples = [
+        {
+            "frame": 1000,
+            "max_generation": 1,
+            "population": 30,
+            "diversity_score": 0.40,
+            "traits": {
+                "pursuit_aggression": 0.50,
+                "prediction_skill": 0.50,
+                "hunting_stamina": 0.50,
+                "aggression": 0.50,
+                "speed": 1.00,
+                "size": 1.00,
+            },
+        },
+        {
+            "frame": 10000,
+            "max_generation": 6,
+            "population": 32,
+            "diversity_score": 0.36,
+            "traits": {
+                "pursuit_aggression": 0.60,
+                "prediction_skill": 0.40,
+                "hunting_stamina": 0.58,
+                "aggression": 0.51,
+                "speed": 1.10,
+                "size": 1.00,
+            },
+        },
+    ]
+
+    result = score_samples(samples, seed=42)
+
+    assert result["score"] > 0.0
+    assert result["metadata"]["selection_detected"] is True
+    assert result["metadata"]["selected_trait_count"] == 4
+    assert result["metadata"]["diversity_retention"] == 0.9
+
+
+def test_selection_response_score_is_zero_without_directional_drift():
+    samples = [
+        {
+            "frame": 1000,
+            "max_generation": 1,
+            "population": 30,
+            "diversity_score": 0.40,
+            "traits": {"pursuit_aggression": 0.50, "speed": 1.00},
+        },
+        {
+            "frame": 10000,
+            "max_generation": 6,
+            "population": 31,
+            "diversity_score": 0.40,
+            "traits": {"pursuit_aggression": 0.51, "speed": 1.01},
+        },
+    ]
+
+    result = score_samples(samples, seed=42)
+
+    assert result["score"] == 0.0
+    assert result["metadata"]["selection_detected"] is False
+
+
+def test_multi_seed_aggregate_preserves_decomposition():
+    per_seed = [
+        {
+            "seed": 42,
+            "score": 10.0,
+            "metadata": {
+                "selection_detected": True,
+                "selected_trait_fraction": 0.5,
+                "drift_per_generation_pct": 2.0,
+                "diversity_delta": -0.1,
+                "diversity_retention": 0.8,
+                "quality_per_generation": 0.9,
+                "generation_rate_per_10k": 5.0,
+                "diversity_last": 0.3,
+            },
+        },
+        {
+            "seed": 7,
+            "score": 20.0,
+            "metadata": {
+                "selection_detected": True,
+                "selected_trait_fraction": 1.0,
+                "drift_per_generation_pct": 4.0,
+                "diversity_delta": 0.0,
+                "diversity_retention": 1.0,
+                "quality_per_generation": 0.7,
+                "generation_rate_per_10k": 7.0,
+                "diversity_last": 0.4,
+            },
+        },
+    ]
+
+    metadata = _aggregate_metadata(per_seed)
+
+    assert metadata["mean_score"] == 15.0
+    assert metadata["all_selection_detected"] is True
+    assert metadata["mean_selected_trait_fraction"] == 0.75
+    assert metadata["min_final_diversity"] == 0.3

--- a/tools/run_selection_response_assay.py
+++ b/tools/run_selection_response_assay.py
@@ -1,0 +1,110 @@
+"""Run the frozen multi-seed Tank selection-response assay.
+
+This is the held-out surface for proposal #6: it runs the normal
+``tank/selection_response_10k`` benchmark over the frozen seed set 42/7/123 and
+returns both the aggregate score and the per-seed decomposition. The benchmark
+module itself remains single-seed compatible with ``tools/run_bench.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from benchmarks.tank import selection_response_10k
+from core.solutions.config_hash import compute_config_hash
+
+
+def run_assay(seeds: tuple[int, ...] = selection_response_10k.FROZEN_SEEDS) -> dict[str, Any]:
+    per_seed = []
+    started = time.time()
+    for seed in seeds:
+        result = selection_response_10k.run(seed)
+        result["config_hash"] = compute_config_hash(
+            selection_response_10k.BENCHMARK_ID,
+            seed,
+            selection_response_10k.CONFIG,
+        )
+        per_seed.append(result)
+
+    scores = [float(result["score"]) for result in per_seed]
+    mean_score = sum(scores) / len(scores) if scores else 0.0
+    metadata = _aggregate_metadata(per_seed)
+    return {
+        "assay_id": "tank/frozen_selection_response_10k",
+        "benchmark_id": selection_response_10k.BENCHMARK_ID,
+        "seeds": list(seeds),
+        "score": mean_score,
+        "runtime_seconds": time.time() - started,
+        "metadata": metadata,
+        "per_seed": per_seed,
+    }
+
+
+def _aggregate_metadata(per_seed: list[dict[str, Any]]) -> dict[str, Any]:
+    if not per_seed:
+        return {}
+    metrics = [result.get("metadata", {}) for result in per_seed]
+    return {
+        "frozen_seeds": [result["seed"] for result in per_seed],
+        "mean_score": round(sum(float(result["score"]) for result in per_seed) / len(per_seed), 4),
+        "all_selection_detected": all(bool(m.get("selection_detected")) for m in metrics),
+        "mean_selected_trait_fraction": _mean(metrics, "selected_trait_fraction"),
+        "mean_drift_per_generation_pct": _mean(metrics, "drift_per_generation_pct"),
+        "mean_diversity_delta": _mean(metrics, "diversity_delta"),
+        "mean_diversity_retention": _mean(metrics, "diversity_retention"),
+        "mean_quality_per_generation": _mean(metrics, "quality_per_generation"),
+        "mean_generation_rate_per_10k": _mean(metrics, "generation_rate_per_10k"),
+        "min_final_diversity": min(float(m.get("diversity_last", 0.0) or 0.0) for m in metrics),
+        "score_formula": (
+            "mean of per-seed selection_response_10k scores over frozen seeds 42/7/123"
+        ),
+        "anti_goodhart_note": (
+            "Use this as a held-out decomposition. PRs that edit the assay should not "
+            "claim score wins from the edited assay in the same change."
+        ),
+    }
+
+
+def _mean(items: list[dict[str, Any]], key: str) -> float:
+    values = [float(item[key]) for item in items if isinstance(item.get(key), (int, float))]
+    return round(sum(values) / len(values), 4) if values else 0.0
+
+
+def _parse_seeds(raw: str) -> tuple[int, ...]:
+    seeds = tuple(int(part.strip()) for part in raw.split(",") if part.strip())
+    if not seeds:
+        raise argparse.ArgumentTypeError("at least one seed is required")
+    return seeds
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seeds",
+        type=_parse_seeds,
+        default=selection_response_10k.FROZEN_SEEDS,
+        help="Comma-separated seeds; default is the frozen held-out set 42,7,123",
+    )
+    parser.add_argument("--out", help="Write JSON result to this path")
+    args = parser.parse_args()
+
+    result = run_assay(args.seeds)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=2)
+        print(f"Result written to {args.out}")
+    else:
+        print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the frozen selection-response assay elected by the decision board as proposal #6.

This is a Layer 2 measurement change only. It does not change fish behavior, core config, champions, or the existing `ecosystem_health_10k` scoring surface.

What changed:

- Added `benchmarks/tank/selection_response_10k.py`, a normal `tools/run_bench.py` compatible single-seed benchmark.
- Added `tools/run_selection_response_assay.py`, the held-out multi-seed runner over frozen seeds `42,7,123`.
- Added unit tests for the scoring decomposition and aggregate metadata.
- Updated `docs/EVOLVABILITY.md` with the new assay commands and anti-Goodhart usage rule.

## Why

`ecosystem_health_10k` is trajectory-sensitive and can make one-seed generation churn look like evolvability. This assay reports a decomposed held-out ruler for:

- directional trait drift per generation
- sustained diversity / diversity retention
- quality per generation via population stability and turnover adequacy

The runner preserves the anti-Goodhart rule in metadata: PRs that edit the assay should not claim wins from the edited assay in the same change.

## Results

`py tools/run_selection_response_assay.py --out %TEMP%\selection_response_frozen.json`

Frozen aggregate:

- Score: `41.3732`
- Seeds: `42, 7, 123`
- `all_selection_detected=true`
- `mean_selected_trait_fraction=0.7222`
- `mean_drift_per_generation_pct=3.3957`
- `mean_diversity_delta=+0.0662`
- `mean_diversity_retention=1.2631`
- `mean_quality_per_generation=0.8398`
- `min_final_diversity=0.2645`

Per seed:

| seed | selection_response_10k score | config hash |
| --- | ---: | --- |
| 42 | 45.0954 | `78bd6a9375ae7762` |
| 7 | 42.2583 | `e62651b32d1cdb28` |
| 123 | 36.7658 | `7f25d9ea13606f76` |

Single-seed determinism:

`py tools/run_bench.py benchmarks\tank\selection_response_10k.py --seed 42 --verify-determinism`

- Passed
- Seed 42 score: `45.09540764987502`
- Config hash: `78bd6a9375ae7762`

Existing benchmark trail:

`py tools/run_bench.py benchmarks\tank\ecosystem_health_10k.py --seed 42 --out %TEMP%\ecosystem_health_seed42_for_assay_pr.json`

- Score: `8.382515838972495`
- Config hash: `43b81b3f6651a28a`

`py tools\validate_improvement.py %TEMP%\ecosystem_health_seed42_for_assay_pr.json champions\tank\ecosystem_health_10k.json`

- Refused comparison due config hash mismatch against stored champion `0b6bfb9fd9cdb0b5`.
- No champion metadata changed.

Legacy selection diagnostics:

- `py scripts\diagnose_evolution.py --frames 10000 --seed 42` -> directional selection detected
- `py scripts\diagnose_evolution.py --frames 10000 --seed 7` -> directional selection detected
- `py scripts\diagnose_evolution.py --frames 10000 --seed 123` -> directional selection detected

## Validation

- `py -m pytest tests\test_selection_response_assay.py -q` -> `3 passed`
- `py tools\smoke_gate.py` -> passed, `34 passed`
- `py tools\fast_gate.py` -> passed, `1775 passed, 3 skipped, 157 deselected`
- `py tools\agent_gate.py` -> passed, `575 passed, 100 deselected`
