### PR TITLE
Stabilize fast gate and tighten champion-update guidance

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -152,6 +152,8 @@ def _get_network_ip() -> str:
 
 def _configure_windows_event_loop(logger: logging.Logger) -> None:
     """Configure asyncio event loop policy on Windows."""
+    if "pytest" in sys.modules:
+        return
     if sys.platform != "win32":
         return
 

--- a/backend/broadcast.py
+++ b/backend/broadcast.py
@@ -428,3 +428,12 @@ def get_active_broadcast_count() -> int:
         Number of running broadcast tasks
     """
     return sum(1 for task in _broadcast_tasks.values() if not task.done())
+
+
+def clear_broadcast_state() -> None:
+    """Cancel any running broadcast tasks and clear global broadcast state (for test isolation)."""
+    for task in list(_broadcast_tasks.values()):
+        if not task.done():
+            task.cancel()
+    _broadcast_tasks.clear()
+    _broadcast_locks.clear()

--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -64,7 +64,7 @@ python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42
 ## What should it avoid?
 
 - **Mixing Layers**: Do not combine Layer 1 behavior optimizations with Layer 2 tooling, documentation, or workflow modifications in a single PR.
-- **Unverified Champion Updates**: Do not update `champions/**/*.json` files unless you have reproduced the benchmark score deterministically and have a valid reason to do so.
+- **Champion File Modifications**: Do not edit `champions/**/*.json` files unless explicitly authorized by a maintainer or task prompt. Unauthorized changes will be rejected.
 - **Breaking Determinism**: Do not use non-deterministic inputs (like system time, global random, or network calls) in simulations or benchmarks.
 - **Placeholder Work**: Do not leave TODOs or generic placeholders in code or documentation.
 
@@ -78,15 +78,8 @@ python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42
    ```bash
    python tools/validate_improvement.py results.json champions/tank/survival_5k.json
    ```
-3. If the change represents a valid improvement, update the champion file:
-   ```bash
-   python tools/validate_improvement.py results.json champions/tank/survival_5k.json --update-champion
-   ```
-4. If a legitimate codebase change (like a bug fix) breaks deterministic outcomes and necessitates updating all champion baselines, run:
-   ```bash
-   python tools/verify_all_champions.py
-   ```
-   And commit the resulting `verify_*.json` outputs as your new baselines.
+3. If the change represents a candidate improvement, report the score, seed, reproduction command, and all metadata in your PR description.
+4. **Do NOT edit the `champions/**/*.json` files directly** unless you are explicitly authorized by a maintainer or task prompt. Maintainers will run the full validation gate and update champions upon merging.
 
 ## What should a PR include?
 
@@ -116,7 +109,7 @@ Your task is to identify and optimize a Layer 1 behavior algorithm or configurat
 4. Modify fish parameters in core/config/fish.py or behavior logic in core/algorithms/composable/.
 5. Validate locally using the agent gate: python tools/agent_gate.py
 6. Before PR, run the fast gate: python tools/fast_gate.py
-7. Compare scores against the champion; update champion metadata only with explicit benchmark evidence and maintainer-approved scope.
+7. Compare scores against the champion; do not edit the champions/**/*.json files unless explicitly authorized by a maintainer or task prompt.
 8. Commit only the Layer 1 changes with a detailed message following the AGENTS.md format.
 Do not modify workflows, CI configurations, or unrelated documentation.
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,3 +121,13 @@ def _force_mutation_invariants_in_tests():
     os.environ["TANK_ENFORCE_MUTATION_INVARIANTS"] = "1"
     yield
     os.environ.pop("TANK_ENFORCE_MUTATION_INVARIANTS", None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_broadcast_globals():
+    """Reset global broadcast tasks and locks between tests to prevent loop pollution."""
+    from backend.broadcast import clear_broadcast_state
+
+    clear_broadcast_state()
+    yield
+    clear_broadcast_state()

--- a/tests/test_docs_agent_onboarding.py
+++ b/tests/test_docs_agent_onboarding.py
@@ -148,3 +148,19 @@ def test_ci_job_names_in_readme_match_workflow_files():
     )
     stale_mentions = sorted(all_readme_job_mentions - actual_jobs)
     assert not stale_mentions, f"README.md mentions stale/nonexistent CI jobs: {stale_mentions}"
+
+
+def test_agent_quickstart_does_not_mention_update_champion():
+    quickstart_path = ROOT / "docs" / "AGENT_QUICKSTART.md"
+    content = quickstart_path.read_text(encoding="utf-8")
+    assert "--update-champion" not in content, (
+        "docs/AGENT_QUICKSTART.md must not instruct agents to use --update-champion. "
+        "Updating champion files is restricted to authorized agents/maintainers."
+    )
+    assert (
+        "verify_all_champions.py" not in content
+    ), "docs/AGENT_QUICKSTART.md must not instruct agents to use verify_all_champions.py."
+    assert (
+        "Do NOT edit the `champions/**/*.json` files directly" in content
+        or "do not edit the champions/**/*.json files" in content
+    )

--- a/tools/tally_proposals.py
+++ b/tools/tally_proposals.py
@@ -33,11 +33,14 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 # Reuse the board client (HTTP + default-world resolution) from the sibling tool.
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from post_commentary import DEFAULT_URL, post_comment, read_comments
+if TYPE_CHECKING:
+    from tools.post_commentary import DEFAULT_URL, post_comment, read_comments
+else:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from post_commentary import DEFAULT_URL, post_comment, read_comments
 
 KEEP_LOOKING = 0  # the standing "adopt nothing yet" candidate
 QUORUM = 3  # distinct voters required before a winner is binding


### PR DESCRIPTION
- Resolve fast gate pytest event loop conflict on Windows by bypassing loop policy modification in tests.

- Resolve broadcast task/lock leakage by adding clear_broadcast_state() and conftest reset fixture.

- Fix mypy import error in tools/tally_proposals.py.

- Restrict unauthorized champion updates in AGENT_QUICKSTART.md.

- Add docs consistency onboarding test in test_docs_agent_onboarding.py.