### PR TITLE
[codex] Measure strong baseline in quick poker benchmark

### DIFF
--- a/core/poker/evaluation/benchmark_suite.py
+++ b/core/poker/evaluation/benchmark_suite.py
@@ -229,11 +229,9 @@ class ComprehensiveBenchmarkConfig:
         return {b.strategy_id: b.weight for b in BASELINE_OPPONENTS}
 
 
-# Quick benchmark config for frequent evaluation
-# Increased sample size for better statistical accuracy:
-# - 100 hands × 10 duplicate sets = 2000 hands per baseline (was 500)
-# - Added missing weak baselines for balanced coverage
-# - Increased fish sample from 5 to 8
+# Quick benchmark config for frequent live evaluation.
+# Keep one baseline from every reported difficulty tier so confidence metrics
+# reflect measured play instead of falling back to neutral defaults.
 QUICK_BENCHMARK_CONFIG = ComprehensiveBenchmarkConfig(
     fish_vs_baselines=SubTournamentConfig(
         category=BenchmarkCategory.FISH_VS_BASELINES,
@@ -244,6 +242,7 @@ QUICK_BENCHMARK_CONFIG = ComprehensiveBenchmarkConfig(
             "random",
             "loose_passive",
             "tight_aggressive",
+            "balanced",
             "gto_expert",
         ],
     ),

--- a/tests/test_poker_benchmark_uncertainty.py
+++ b/tests/test_poker_benchmark_uncertainty.py
@@ -5,13 +5,35 @@ import math
 from types import SimpleNamespace
 
 from core.poker.evaluation import comprehensive_benchmark
-from core.poker.evaluation.benchmark_suite import ComprehensiveBenchmarkConfig
+from core.poker.evaluation.benchmark_suite import (
+    BASELINE_OPPONENTS,
+    QUICK_BENCHMARK_CONFIG,
+    BaselineDifficulty,
+    ComprehensiveBenchmarkConfig,
+)
 from core.poker.evaluation.comprehensive_benchmark import FishBenchmarkResult
 from core.poker.evaluation.evolution_benchmark_tracker import EvolutionBenchmarkTracker
 
 
 class _StubFish:
     poker_stats = None
+
+
+def test_quick_benchmark_covers_reported_confidence_tiers():
+    selected = set(QUICK_BENCHMARK_CONFIG.fish_vs_baselines.baseline_opponents)
+    by_difficulty = {
+        difficulty: {
+            opponent.strategy_id
+            for opponent in BASELINE_OPPONENTS
+            if opponent.difficulty is difficulty
+        }
+        for difficulty in BaselineDifficulty
+    }
+
+    assert selected & by_difficulty[BaselineDifficulty.WEAK]
+    assert selected & by_difficulty[BaselineDifficulty.MODERATE]
+    assert selected & by_difficulty[BaselineDifficulty.STRONG]
+    assert selected & by_difficulty[BaselineDifficulty.EXPERT]
 
 
 def test_population_benchmark_populates_bb100_uncertainty(monkeypatch):


### PR DESCRIPTION
## What changed

Adds the `balanced` opponent to the quick poker evolution benchmark so the live `confidence_vs_strong` / `vs strong` metric is measured instead of defaulting to neutral. Also adds a regression test that the quick benchmark covers each reported confidence tier: weak, moderate, strong, and expert.

## Layer

- [x] Layer 2 (benchmark / test coverage - does not change fish behavior logic)

## Why

The live benchmark chart showed `conf vs Strong` pinned at 50%. The root cause was that `QUICK_BENCHMARK_CONFIG` did not include any strong-tier baseline (`balanced` or `maniac`), while the strong confidence metric is computed only from those baselines. With no data, the metric falls back to `0.5` and cannot guide selection.

Existing local benchmark history confirmed the issue: 12 snapshots over frames `1801 -> 300435`, generations `0 -> 143`, Elo `1233.4 -> 1260.3`, but `confStrong=0.5 -> 0.5` and `vsStrong=0.0 -> 0.0`.

## Proof

Commands run:

```bash
.\.venv\Scripts\python.exe tools\smoke_gate.py
.\.venv\Scripts\python.exe -m pytest tests\test_poker_benchmark_uncertainty.py -q
.\.venv\Scripts\python.exe tools\agent_gate.py
.\.venv\Scripts\python.exe tools\fast_gate.py
```

Results:

- Smoke gate passed: 36 passed
- Focused poker benchmark uncertainty tests passed: 3 passed
- Agent gate passed: 575 passed, 100 deselected
- Fast gate passed: 1886 passed, 3 skipped, 157 deselected

## Notes

This does not rewrite existing exported history. Old snapshots collected before this change will remain flat at 50% for strong; new quick benchmark snapshots will include real `balanced` baseline measurements.