### PR TITLE
[codex] Inherit decayed CFR state for poker clones

### DIFF
--- a/core/poker/strategy/composable/strategy.py
+++ b/core/poker/strategy/composable/strategy.py
@@ -717,12 +717,13 @@ class ComposablePokerStrategy(PokerStrategyAlgorithm):
     ) -> "ComposablePokerStrategy":
         """Create a mutated clone (for asexual reproduction).
 
-        CFR learning state is not copied: clones start as fresh learners
-        (CFRInheritanceMode.RESET).
+        CFR learning state is inherited with decay so useful lifetime poker
+        learning can persist through asexual reproduction without freezing
+        stale regrets indefinitely.
         """
         rng = require_rng_param(rng, "__init__")
         regret, strategy_sum, learning_rate = CFRInheritance.inherit(
-            self, self, mode=CFRInheritanceMode.RESET
+            self, self, weight1=1.0, mode=CFRInheritanceMode.BLEND_DECAY
         )
         clone = ComposablePokerStrategy(
             hand_selection=self.hand_selection,

--- a/tests/test_composable_poker.py
+++ b/tests/test_composable_poker.py
@@ -22,6 +22,10 @@ from core.poker.strategy.composable import (
     PositionAwareness,
     ShowdownTendency,
 )
+from core.poker.strategy.composable.definitions import (
+    CFR_INHERITANCE_DECAY,
+    CFR_MIN_VISITS_FOR_INHERITANCE,
+)
 from core.poker.strategy.composable.cfr_decision import CFR_DECISION_MIN_VISITS
 from core.poker.strategy.implementations import crossover_poker_strategies
 
@@ -160,6 +164,36 @@ class TestComposablePokerStrategyMutation:
         # With no mutation and no switching, should have same sub-behaviors
         assert clone.hand_selection == original.hand_selection
         assert clone.betting_style == original.betting_style
+
+    def test_clone_with_mutation_inherits_decayed_cfr_state(self):
+        """Asexual clones keep qualified CFR learning with decay."""
+        rng = random.Random(1)
+        original = ComposablePokerStrategy()
+        info_set = "bucket:turn:button"
+        original.regret[info_set] = {
+            "fold": 10.0,
+            "call": -2.0,
+            "raise_small": 5.0,
+        }
+        original.strategy_sum[info_set] = {
+            "fold": 3.0,
+            "call": 1.0,
+            "raise_small": 2.0,
+        }
+        original.visit_count[info_set] = CFR_MIN_VISITS_FOR_INHERITANCE
+        original.learning_rate = 0.7
+
+        clone = original.clone_with_mutation(
+            mutation_rate=0.0, sub_behavior_switch_rate=0.0, rng=rng
+        )
+
+        assert clone.regret[info_set]["fold"] == pytest.approx(10.0 * CFR_INHERITANCE_DECAY)
+        assert clone.regret[info_set]["call"] == pytest.approx(-2.0 * CFR_INHERITANCE_DECAY)
+        assert clone.strategy_sum[info_set]["raise_small"] == pytest.approx(
+            2.0 * CFR_INHERITANCE_DECAY
+        )
+        assert clone.learning_rate == pytest.approx(original.learning_rate)
+        assert clone.visit_count == {}
 
 
 class TestComposablePokerStrategySerialization:


### PR DESCRIPTION
## Elected Proposal

Proposal: #21, `Poker Dojo Niches`

This PR implements the smallest first experiment agreed in the #22/#42 discussion: before adding external dojo credits or protected niche machinery, make the dominant asexual poker lineage capable of carrying learned CFR state forward.

## What Changed

- Changed `ComposablePokerStrategy.clone_with_mutation()` so asexual clones inherit CFR regret and strategy-sum tables through `CFRInheritanceMode.BLEND_DECAY` with `weight1=1.0`.
- Kept inherited clone `visit_count` reset, matching the existing CFR inheritance design so stale inherited info sets must be re-earned before driving live decisions.
- Added a focused regression test proving qualified CFR state survives cloning with `CFR_INHERITANCE_DECAY` while visit counts reset.

Files changed:

- `core/poker/strategy/composable/strategy.py`
- `tests/test_composable_poker.py`

## Why This Is The Smallest Test

The original #21 vision was a poker skill niche/dojo mechanism. Discussion identified a lower-level blocker: asexual clones were resetting learned CFR tables, preventing lifetime poker learning from persisting across the primary clone lineage. This PR tests that core bet without changing scoring, benchmark goals, champion files, reproduction thresholds, energy rewards, or external benchmark-oracle breeding credits.

## Baseline And Result

Mechanism baseline before change:

```text
parent_info_sets: 1
clone_info_sets: 0
clone_learning_rate: 1.0
clone_regret: {}
```

Mechanism result after change:

```text
parent_info_sets: 1
clone_info_sets: 1
clone_learning_rate: 0.7
clone_regret: {'baseline_state': {'call': -1.6, 'fold': 8.0}}
clone_visit_count: {}
```

Selection-response anti-regression, seed 42:

```text
Before: score 55.92679951842493, config_hash 78bd6a9375ae7762
After:  score 55.92679951842493, config_hash 78bd6a9375ae7762
```

The unchanged selection-response score is expected because `benchmarks/tank/selection_response_10k.py` disables poker. This is anti-regression evidence, not a poker-skill improvement claim.

Attempted full held-out multi-seed assay:

```bash
.\.venv\Scripts\python.exe tools\run_selection_response_assay.py --out results\selection_response_baseline_cfr_reset.json
```

It timed out after 304 seconds before producing an output file, so I used the benchmark-compatible seed-42 surface for this PR.

## Commands Run

```bash
.\.venv\Scripts\python.exe tools\smoke_gate.py
.\.venv\Scripts\python.exe tools\agent_gate.py
.\.venv\Scripts\python.exe tools\run_bench.py benchmarks\tank\selection_response_10k.py --seed 42 --out results\selection_response_seed42_baseline_cfr_reset.json
.\.venv\Scripts\python.exe -m pytest tests\test_composable_poker.py -q
.\.venv\Scripts\python.exe -m mypy core
.\.venv\Scripts\python.exe -m mypy tools backend
.\.venv\Scripts\python.exe tools\run_bench.py benchmarks\tank\selection_response_10k.py --seed 42 --out results\selection_response_seed42_after_asexual_cfr.json
.\.venv\Scripts\python.exe tools\fast_gate.py
```

Validation results:

- Focused test: 28 passed
- Smoke gate: passed, 36 passed
- Agent gate: passed, 575 passed, 100 deselected
- `mypy core`: passed, no issues in 329 source files
- `mypy tools backend`: passed, no issues in 101 source files
- Fast gate: passed, 1887 passed, 3 skipped, 157 deselected

## Anti-Goodhart Check

This change does not alter population scoring, benchmark formulas, champion files, energy accounting, or reproduction thresholds. The only changed behavior is whether already-qualified CFR learning state survives asexual cloning with decay. It can only help poker behavior by preserving learned poker action information; it cannot directly inflate generation count, population stability, or diversity metrics.

## Known Risks

- Inherited CFR regrets may be stale in new contexts. Mitigation: inherited values decay by `CFR_INHERITANCE_DECAY` and clone visit counts reset, so decision-time CFR still requires fresh visits.
- Standard tank benchmarks with poker disabled cannot prove poker improvement. A follow-up should measure poker skill in a poker-enabled run or dedicated poker-evolution assay.
- The board tally was provisional with two voters; however, both votes/discussion converged on this narrow CFR inheritance first experiment.

Champion files touched: no.