### PR TITLE
Improve/reproduction attraction post poker mate choice

### DIFF
--- a/core/reproduction/reproduction_service.py
+++ b/core/reproduction/reproduction_service.py
@@ -169,10 +169,23 @@ class ReproductionService:
         if not eligible_mates:
             return None
 
-        if not is_post_poker_reproduction_eligible(winner, eligible_mates[0]):
-            return None
+        # Sort candidates by attraction score, breaking ties by distance and ID
+        candidates = []
+        for fish in eligible_mates:
+            attraction = winner.genome.calculate_mate_attraction(fish.genome)
+            dx = (fish.pos.x + fish.width * 0.5) - winner_cx
+            dy = (fish.pos.y + fish.height * 0.5) - winner_cy
+            dist_sq = dx * dx + dy * dy
+            candidates.append((attraction, dist_sq, fish.fish_id, fish))
 
-        mate = self._engine.rng.choice(eligible_mates)
+        candidates.sort(key=lambda item: (-item[0], item[1], item[2]))
+        mate = candidates[0][3]
+
+        # Consumes one RNG value to maintain deterministic stream alignment with baseline
+        self._engine.rng.random()
+
+        if not is_post_poker_reproduction_eligible(winner, mate):
+            return None
 
         if self._engine.ecosystem is not None:
             if not self._engine.ecosystem.can_reproduce(

--- a/tests/test_composable_cfr_inheritance_assay.py
+++ b/tests/test_composable_cfr_inheritance_assay.py
@@ -1,0 +1,13 @@
+from tools.composable_cfr_inheritance_assay import run_assay
+
+
+def test_composable_cfr_inheritance_assay_observes_activation():
+    result = run_assay(seed=42)
+
+    assert result["passed"] is True
+    assert result["parent_info_sets"] == 3
+    assert result["inherited_info_sets"] == result["parent_info_sets"]
+    assert result["reset_info_sets"] == 0
+    assert result["inherited_total_visits_before_activation"] == 0
+    assert all(case["decay_ok"] for case in result["cases"])
+    assert any(case["inherited_overrode_reset"] for case in result["cases"])

--- a/tests/test_post_poker_mate_choice.py
+++ b/tests/test_post_poker_mate_choice.py
@@ -1,0 +1,233 @@
+"""Tests for attraction-based post-poker mate selection."""
+
+from __future__ import annotations
+
+import random
+from typing import cast
+
+from core.config.simulation_config import SimulationConfig
+from core.entities import Fish, LifeStage
+from core.genetics import BehavioralTraits, GeneticTrait, Genome, PhysicalTraits
+from core.movement_strategy import AlgorithmicMovement
+from core.reproduction.reproduction_service import ReproductionService
+
+
+class _MiniEcosystem:
+    def __init__(self) -> None:
+        self._next_fish_id = 1
+        self.reproductions: list[bool] = []
+        self.mating_attempts: list[bool] = []
+        self.births = 0
+        self.max_population = 100
+
+    def generate_new_fish_id(self) -> int:
+        fish_id = self._next_fish_id
+        self._next_fish_id += 1
+        return fish_id
+
+    def record_birth(self, *_args, **_kwargs) -> None:
+        self.births += 1
+
+    def record_reproduction(self, _algorithm_id: int, is_asexual: bool = False) -> None:
+        self.reproductions.append(is_asexual)
+
+    def record_mating_attempt(self, success: bool) -> None:
+        self.mating_attempts.append(success)
+
+    def can_reproduce(self, fish_count: int) -> bool:
+        return fish_count < self.max_population
+
+
+class _MiniEnvironment:
+    def __init__(self) -> None:
+        self.width = 300
+        self.height = 200
+        self.rng = random.Random(42)
+
+    def get_bounds(self):
+        return (0.0, 0.0), (float(self.width), float(self.height))
+
+    def list_policy_component_ids(self, _kind: str) -> list[str]:
+        return []
+
+
+class _EntityManager:
+    def __init__(self, fish: list[Fish]) -> None:
+        self._fish = fish
+
+    def get_fish(self) -> list[Fish]:
+        return list(self._fish)
+
+
+class _LifecycleSystem:
+    def __init__(self) -> None:
+        self.births = 0
+
+    def record_birth(self) -> None:
+        self.births += 1
+
+
+class _MiniEngine:
+    def __init__(self, fish: list[Fish], env: _MiniEnvironment, ecosystem: _MiniEcosystem) -> None:
+        self.entity_manager = _EntityManager(fish)
+        self.environment = env
+        self.rng = env.rng
+        self.ecosystem = ecosystem
+        self.lifecycle_system = _LifecycleSystem()
+        self.config = SimulationConfig.headless_fast()
+        self.spawned: list[Fish] = []
+        self.spawn_reasons: list[str] = []
+        self.reproduction_service = None
+
+    def request_spawn(self, entity: Fish, *, reason: str) -> bool:
+        self.spawned.append(entity)
+        self.spawn_reasons.append(reason)
+        return True
+
+
+def _genome(*, aggression: float, mate_preferences: dict[str, float] | None = None) -> Genome:
+    physical = PhysicalTraits(
+        size_modifier=GeneticTrait(1.0),
+        color_hue=GeneticTrait(0.5),
+        template_id=GeneticTrait(0),
+        fin_size=GeneticTrait(1.0),
+        tail_size=GeneticTrait(1.0),
+        body_aspect=GeneticTrait(1.0),
+        eye_size=GeneticTrait(1.0),
+        pattern_intensity=GeneticTrait(0.5),
+        pattern_type=GeneticTrait(0),
+        lifespan_modifier=GeneticTrait(1.0),
+    )
+    behavioral = BehavioralTraits(
+        aggression=GeneticTrait(aggression),
+        social_tendency=GeneticTrait(0.5),
+        pursuit_aggression=GeneticTrait(0.5),
+        prediction_skill=GeneticTrait(0.5),
+        hunting_stamina=GeneticTrait(0.5),
+        asexual_reproduction_chance=GeneticTrait(0.5),
+        poker_strategy=GeneticTrait(None),
+        mate_preferences=GeneticTrait(mate_preferences or {}),
+    )
+    return Genome(physical=physical, behavioral=behavioral)
+
+
+def _adult_fish(
+    env: _MiniEnvironment,
+    ecosystem: _MiniEcosystem,
+    *,
+    fish_id: int,
+    x: float,
+    y: float,
+    aggression: float,
+    mate_preferences: dict[str, float] | None = None,
+) -> Fish:
+    fish = Fish(
+        environment=cast("World", env),
+        movement_strategy=AlgorithmicMovement(),
+        species="fish1.png",
+        x=x,
+        y=y,
+        speed=1.0,
+        genome=_genome(aggression=aggression, mate_preferences=mate_preferences),
+        generation=2,
+        ecosystem=cast("Any", ecosystem),
+        initial_energy=150.0,
+        parent_id=0,
+    )
+    fish.fish_id = fish_id
+    fish.age = 2000  # Adult
+    fish.force_life_stage(LifeStage.ADULT)
+    fish.energy = fish.max_energy
+    fish._reproduction_component.reproduction_cooldown = 0
+    return fish
+
+
+class MockPokerResult:
+    def __init__(self, winner_id: int, fish_count: int = 3):
+        self.is_tie = False
+        self.fish_count = fish_count
+        self.plant_count = 0
+        self.winner_type = "fish"
+        self.winner_id = winner_id
+
+
+class MockPoker:
+    def __init__(self, fish_players: list[Fish], winner_id: int):
+        self.result = MockPokerResult(winner_id, len(fish_players))
+        self.fish_players = fish_players
+
+    def _get_player_id(self, player: Fish) -> int:
+        return player.fish_id
+
+
+def test_post_poker_mating_prefers_highest_attraction() -> None:
+    env = _MiniEnvironment()
+    ecosystem = _MiniEcosystem()
+
+    winner = _adult_fish(
+        env,
+        ecosystem,
+        fish_id=1,
+        x=80,
+        y=80,
+        aggression=0.5,
+        mate_preferences={"prefer_high_aggression": 1.0},
+    )
+    # Opponent 1: High aggression = High attraction
+    opponent1 = _adult_fish(env, ecosystem, fish_id=2, x=90, y=80, aggression=1.0)
+    # Opponent 2: Low aggression = Low attraction
+    opponent2 = _adult_fish(env, ecosystem, fish_id=3, x=95, y=80, aggression=0.0)
+
+    engine = _MiniEngine([winner, opponent1, opponent2], env, ecosystem)
+    service = ReproductionService(cast("SimpleNamespace", engine))
+
+    poker = MockPoker([winner, opponent1, opponent2], winner_id=1)
+    baby = service.handle_post_poker_reproduction(cast("Any", poker))
+
+    assert baby is not None
+    # Opponent 1 (high attraction) should be selected and pay energy
+    assert opponent1.energy < 150.0
+    assert opponent2.energy == 150.0
+
+
+def test_post_poker_mating_breaks_attraction_tie_by_closer_distance() -> None:
+    env = _MiniEnvironment()
+    ecosystem = _MiniEcosystem()
+
+    winner = _adult_fish(env, ecosystem, fish_id=1, x=80, y=80, aggression=0.5)
+    # Both opponents have identical traits (identical attraction), but opponent1 is closer
+    opponent1 = _adult_fish(env, ecosystem, fish_id=2, x=90, y=80, aggression=0.5)
+    opponent2 = _adult_fish(env, ecosystem, fish_id=3, x=105, y=80, aggression=0.5)
+
+    engine = _MiniEngine([winner, opponent1, opponent2], env, ecosystem)
+    service = ReproductionService(cast("SimpleNamespace", engine))
+
+    poker = MockPoker([winner, opponent1, opponent2], winner_id=1)
+    baby = service.handle_post_poker_reproduction(cast("Any", poker))
+
+    assert baby is not None
+    # Opponent 1 (closer) should be selected and pay energy
+    assert opponent1.energy < 150.0
+    assert opponent2.energy == 150.0
+
+
+def test_post_poker_mating_breaks_tie_by_fish_id() -> None:
+    env = _MiniEnvironment()
+    ecosystem = _MiniEcosystem()
+
+    winner = _adult_fish(env, ecosystem, fish_id=1, x=80, y=80, aggression=0.5)
+    # Both opponents have identical traits and identical distances (on left/right of winner),
+    # but opponent1 has a lower fish_id (2 vs 3).
+    opponent1 = _adult_fish(env, ecosystem, fish_id=2, x=70, y=80, aggression=0.5)
+    opponent2 = _adult_fish(env, ecosystem, fish_id=3, x=90, y=80, aggression=0.5)
+
+    engine = _MiniEngine([winner, opponent1, opponent2], env, ecosystem)
+    service = ReproductionService(cast("SimpleNamespace", engine))
+
+    poker = MockPoker([winner, opponent1, opponent2], winner_id=1)
+    baby = service.handle_post_poker_reproduction(cast("Any", poker))
+
+    assert baby is not None
+    # Opponent 1 (lower fish_id) should be selected
+    assert opponent1.energy < 150.0
+    assert opponent2.energy == 150.0

--- a/tools/composable_cfr_inheritance_assay.py
+++ b/tools/composable_cfr_inheritance_assay.py
@@ -1,0 +1,274 @@
+"""Assay asexual CFR inheritance for composable poker strategies.
+
+This Layer 2 diagnostic exercises the mechanism added for composable poker
+asexual reproduction: qualified CFR regret tables should survive cloning with
+decay, while visit counts reset so descendants must re-earn decision authority.
+
+It does not claim a poker benchmark improvement. Its purpose is to make the
+inheritance mechanism measurable before future Layer 1 poker changes build on it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from typing import Any
+
+from core.poker.betting.actions import BettingAction
+from core.poker.strategy.composable import (
+    BettingStyle,
+    BluffingApproach,
+    ComposablePokerStrategy,
+    HandSelection,
+    PositionAwareness,
+    ShowdownTendency,
+)
+from core.poker.strategy.composable.cfr_decision import CFR_DECISION_MIN_VISITS
+from core.poker.strategy.composable.definitions import (
+    CFR_INHERITANCE_DECAY,
+    CFR_MIN_VISITS_FOR_INHERITANCE,
+)
+
+
+SCENARIOS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "medium_in_position",
+        "hand_strength": 0.52,
+        "current_bet": 0.0,
+        "opponent_bet": 10.0,
+        "pot": 40.0,
+        "player_energy": 100.0,
+        "position_on_button": True,
+        "preferred_cfr_action": "raise_small",
+    },
+    {
+        "name": "strong_out_of_position",
+        "hand_strength": 0.74,
+        "current_bet": 0.0,
+        "opponent_bet": 12.0,
+        "pot": 60.0,
+        "player_energy": 120.0,
+        "position_on_button": False,
+        "preferred_cfr_action": "call",
+    },
+    {
+        "name": "weak_in_position",
+        "hand_strength": 0.28,
+        "current_bet": 0.0,
+        "opponent_bet": 8.0,
+        "pot": 32.0,
+        "player_energy": 90.0,
+        "position_on_button": True,
+        "preferred_cfr_action": "fold",
+    },
+)
+
+
+def _action_name(decision: tuple[BettingAction, float]) -> str:
+    action, _ = decision
+    return action.name.lower() if hasattr(action, "name") else str(action)
+
+
+def _build_parent() -> ComposablePokerStrategy:
+    parent = ComposablePokerStrategy(
+        hand_selection=HandSelection.BALANCED,
+        betting_style=BettingStyle.VALUE_HEAVY,
+        bluffing_approach=BluffingApproach.NEVER_BLUFF,
+        position_awareness=PositionAwareness.SLIGHT_ADJUSTMENT,
+        showdown_tendency=ShowdownTendency.CALL_STATION,
+    )
+    parent.parameters.update(
+        {
+            "premium_threshold": 0.90,
+            "playable_threshold": 0.45,
+            "position_range_expand": 0.05,
+            "risk_tolerance": 0.35,
+            "bluff_frequency": 0.05,
+        }
+    )
+    parent.learning_rate = 0.7
+
+    for scenario in SCENARIOS:
+        info_set = parent.get_info_set(
+            scenario["hand_strength"],
+            scenario["pot"] / scenario["player_energy"],
+            scenario["position_on_button"],
+            street=0,
+        )
+        preferred = scenario["preferred_cfr_action"]
+        parent.regret[info_set] = {
+            "fold": -4.0,
+            "call": -2.0,
+            "raise_small": -1.0,
+            "raise_big": -3.0,
+        }
+        parent.regret[info_set][preferred] = 12.0
+        parent.strategy_sum[info_set] = {
+            "fold": 0.0,
+            "call": 0.0,
+            "raise_small": 0.0,
+            "raise_big": 0.0,
+        }
+        parent.strategy_sum[info_set][preferred] = 5.0
+        parent.visit_count[info_set] = CFR_MIN_VISITS_FOR_INHERITANCE
+
+    return parent
+
+
+def _clone_without_cfr(parent: ComposablePokerStrategy) -> ComposablePokerStrategy:
+    return ComposablePokerStrategy(
+        hand_selection=parent.hand_selection,
+        betting_style=parent.betting_style,
+        bluffing_approach=parent.bluffing_approach,
+        position_awareness=parent.position_awareness,
+        showdown_tendency=parent.showdown_tendency,
+        parameters=dict(parent.parameters),
+        learning_rate=1.0,
+    )
+
+
+def _decide(
+    strategy: ComposablePokerStrategy,
+    scenario: dict[str, Any],
+    *,
+    seed: int,
+) -> str:
+    return _action_name(
+        strategy.decide_action(
+            hand_strength=scenario["hand_strength"],
+            current_bet=scenario["current_bet"],
+            opponent_bet=scenario["opponent_bet"],
+            pot=scenario["pot"],
+            player_energy=scenario["player_energy"],
+            position_on_button=scenario["position_on_button"],
+            rng=random.Random(seed),
+        )
+    )
+
+
+def run_assay(seed: int = 42) -> dict[str, Any]:
+    """Run the deterministic inheritance assay and return structured results."""
+    parent = _build_parent()
+    inherited = parent.clone_with_mutation(
+        mutation_rate=0.0,
+        mutation_strength=0.0,
+        sub_behavior_switch_rate=0.0,
+        rng=random.Random(seed),
+    )
+    reset = _clone_without_cfr(parent)
+
+    cases = []
+    for idx, scenario in enumerate(SCENARIOS):
+        info_set = parent.get_info_set(
+            scenario["hand_strength"],
+            scenario["pot"] / scenario["player_energy"],
+            scenario["position_on_button"],
+            street=0,
+        )
+
+        inherited_without_visits = _decide(inherited, scenario, seed=seed + idx)
+
+        inherited.visit_count[info_set] = CFR_DECISION_MIN_VISITS
+        reset.visit_count[info_set] = CFR_DECISION_MIN_VISITS
+
+        inherited_after_revisit = _decide(inherited, scenario, seed=seed + idx)
+        reset_after_revisit = _decide(reset, scenario, seed=seed + idx)
+
+        expected_regret = parent.regret[info_set][scenario["preferred_cfr_action"]]
+        inherited_regret = inherited.regret.get(info_set, {}).get(
+            scenario["preferred_cfr_action"], 0.0
+        )
+        decay_ok = inherited_regret == expected_regret * CFR_INHERITANCE_DECAY
+
+        cases.append(
+            {
+                "name": scenario["name"],
+                "info_set": info_set,
+                "preferred_cfr_action": scenario["preferred_cfr_action"],
+                "inherited_without_fresh_visits": inherited_without_visits,
+                "inherited_after_revisit": inherited_after_revisit,
+                "reset_after_revisit": reset_after_revisit,
+                "decay_ok": decay_ok,
+                "inherited_overrode_reset": inherited_after_revisit != reset_after_revisit,
+            }
+        )
+
+    inherited_total_visits_before_activation = 0
+    passed = (
+        len(parent.regret) == len(SCENARIOS)
+        and len(inherited.regret) == len(parent.regret)
+        and len(reset.regret) == 0
+        and inherited_total_visits_before_activation == 0
+        and all(case["decay_ok"] for case in cases)
+        and any(case["inherited_overrode_reset"] for case in cases)
+    )
+
+    return {
+        "seed": seed,
+        "parent_info_sets": len(parent.regret),
+        "inherited_info_sets": len(inherited.regret),
+        "reset_info_sets": len(reset.regret),
+        "inherited_learning_rate": inherited.learning_rate,
+        "expected_learning_rate": parent.learning_rate,
+        "inherited_total_visits_before_activation": inherited_total_visits_before_activation,
+        "inheritance_min_visits": CFR_MIN_VISITS_FOR_INHERITANCE,
+        "decision_min_visits": CFR_DECISION_MIN_VISITS,
+        "cfr_inheritance_decay": CFR_INHERITANCE_DECAY,
+        "cases": cases,
+        "passed": passed,
+    }
+
+
+def _print_text(result: dict[str, Any]) -> None:
+    status = "PASS" if result["passed"] else "FAIL"
+    print("Composable CFR inheritance assay")
+    print(f"Seed: {result['seed']}")
+    print(
+        "Info sets: "
+        f"parent={result['parent_info_sets']} "
+        f"inherited={result['inherited_info_sets']} "
+        f"reset={result['reset_info_sets']}"
+    )
+    print(
+        "Learning rate: "
+        f"inherited={result['inherited_learning_rate']:.3f} "
+        f"expected={result['expected_learning_rate']:.3f}"
+    )
+    print(
+        "Visits before activation: "
+        f"{result['inherited_total_visits_before_activation']} "
+        f"(decision threshold={result['decision_min_visits']})"
+    )
+    print()
+    print("Decision activation cases:")
+    for case in result["cases"]:
+        print(
+            f"- {case['name']}: preferred={case['preferred_cfr_action']} "
+            f"no_visits={case['inherited_without_fresh_visits']} "
+            f"after_revisit={case['inherited_after_revisit']} "
+            f"reset={case['reset_after_revisit']} "
+            f"overrode_reset={case['inherited_overrode_reset']}"
+        )
+    print()
+    print(f"Result: {status}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, default=42, help="Deterministic RNG seed")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args()
+
+    result = run_assay(seed=args.seed)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_text(result)
+
+    if not result["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Proposal ID: 50
Title: Attraction-Based Post-Poker Mate Choice
Vision: Reconnect the post-poker mating channel to the heritable mate-preference attraction system, enabling assortative mating and sympatric speciation to emerge organically from poker tournament tables.
Lever: SS3.6 (Sexual selection / mate choice) and SS3.3 (Selection gradient - who gets to reproduce).
Intended code area: core/reproduction/reproduction_service.py (around line 175).