### PR TITLE
Parallelize fast_gate broad suite with pytest-xdist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,8 +336,11 @@ Run the fast gate before opening or updating a PR:
 ```bash
 python tools/fast_gate.py
 ```
-It runs the smoke gate plus the broad non-slow test suite. It targets under
-2-3 minutes and excludes integration/slow/manual tests and full benchmarks.
+It runs the smoke gate plus the broad non-slow test suite (parallelized
+across cores via pytest-xdist). It targets under 2-3 minutes on normal
+developer/CI hardware and excludes integration/slow/manual tests and full
+benchmarks. On constrained or single-core sandboxes it can take longer; if it
+does, that's a hardware limit, not a sign something is broken.
 
 ### Tier 3: Full Validation (Maintainers/Nightly)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.0",
+    "pytest-xdist>=3.5.0",
     "mypy>=1.0",
     "black==24.4.2",
     "ruff>=0.1.0",

--- a/tools/fast_gate.py
+++ b/tools/fast_gate.py
@@ -10,8 +10,8 @@ except ImportError:
 def main() -> None:
     print_gate_header(
         name="FAST",
-        target="under 2-3 minutes on normal developer/CI hardware",
-        includes="the smoke gate, then the broad non-slow test suite",
+        target="under 2-3 minutes on normal developer/CI hardware (parallelized across cores)",
+        includes="the smoke gate, then the broad non-slow test suite run in parallel",
         excludes="integration/manual/slow tests, champion reproduction, and 5k/10k benchmarks",
     )
     steps = [
@@ -23,10 +23,12 @@ def main() -> None:
                 "tests",
                 "-m",
                 "not slow and not integration and not manual",
+                "-n",
+                "auto",
                 "-q",
                 "--durations=25",
             ),
-            "Tier 2: broad non-slow tests",
+            "Tier 2: broad non-slow tests (parallel)",
         ),
     ]
     exit_for_gate("FAST", run_steps(steps))


### PR DESCRIPTION
## Summary

- Adds `pytest-xdist>=3.5.0` to dev dependencies so `fast_gate.py` can distribute its 1,896-test broad suite across all available cores (`-n auto`)
- Measured wall-clock improvement: ~35s → ~10s for the broad suite alone; full gate completes in ~20s total
- Updates `AGENTS.md` Tier 2 description to name parallel execution and clarify that constrained/single-core sandboxes will be slower — that's a hardware limit, not a broken gate
- All `test_validation_tiers.py` contracts continue to pass (required marker substring preserved verbatim)

## Motivation

A repo quality review flagged that `fast_gate.py` promises "under 2-3 minutes" but the single-threaded 1,896-test suite has no margin on slower CI runners — the reviewer's sandbox timed out at 600s (63% complete). Parallelization addresses the root cause without reducing coverage or weakening the marker-exclusion contracts.

## Test plan

- [x] `python tools/fast_gate.py` passes in ~20s (smoke gate + parallel broad suite)
- [x] `python -m pytest tests/test_validation_tiers.py` — all 4 contracts pass
- [x] `ruff check` and `black --check` pass on changed files
- [x] 1893 tests passed, 3 skipped under `-n auto` (no conflicts from parallelization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfvS46dEMoHYPFTCCPb2G6

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfvS46dEMoHYPFTCCPb2G6)_