### PR TITLE
[codex] Implement protected innovation niches

### DIFF
--- a/core/agents/components/reproduction_component.py
+++ b/core/agents/components/reproduction_component.py
@@ -107,7 +107,13 @@ class ReproductionComponent:
         self.overflow_energy_bank -= used
         return used
 
-    def can_reproduce(self, life_stage: "LifeStage", energy: float, max_energy: float) -> bool:
+    def can_reproduce(
+        self,
+        life_stage: "LifeStage",
+        energy: float,
+        max_energy: float,
+        mutation_context: "ReproductionMutationContext | None" = None,
+    ) -> bool:
         """Check if fish can reproduce.
 
         Fish must have 90% of their max energy to reproduce - proving they are successful
@@ -123,7 +129,10 @@ class ReproductionComponent:
         """
         from core.entities.base import LifeStage
 
-        min_energy_for_reproduction = max_energy * self.REPRODUCTION_ENERGY_PERCENTAGE
+        threshold = self.REPRODUCTION_ENERGY_PERCENTAGE
+        if mutation_context is not None:
+            threshold = mutation_context.protected_reproduction_ratio(threshold)
+        min_energy_for_reproduction = max_energy * threshold
         return (
             life_stage == LifeStage.ADULT
             and energy >= min_energy_for_reproduction
@@ -135,17 +144,21 @@ class ReproductionComponent:
         life_stage: "LifeStage",
         energy: float,
         max_energy: float,
+        mutation_context: "ReproductionMutationContext | None" = None,
     ) -> bool:
         """Check if the fish can trigger asexual reproduction.
 
         Asexual reproduction requires higher energy than sexual reproduction,
         as the parent must fund the entire offspring alone.
         """
-        if not self.can_reproduce(life_stage, energy, max_energy):
+        if not self.can_reproduce(life_stage, energy, max_energy, mutation_context):
             return False
 
         # Asexual reproduction requires 95% energy (slightly less than 100%)
-        return energy >= max_energy * self.ASEXUAL_REPRODUCTION_THRESHOLD
+        threshold = self.ASEXUAL_REPRODUCTION_THRESHOLD
+        if mutation_context is not None:
+            threshold = mutation_context.protected_reproduction_ratio(threshold)
+        return energy >= max_energy * threshold
 
     def trigger_asexual_reproduction(
         self,

--- a/core/genetics/reproduction.py
+++ b/core/genetics/reproduction.py
@@ -11,6 +11,7 @@ DIVERSITY_DANGER_FLOOR = 0.12
 DIVERSITY_RECOVERY_FLOOR = 0.25
 DEFAULT_SUB_BEHAVIOR_SWITCH_RATE = 0.08
 DANGER_SUB_BEHAVIOR_SWITCH_RATE = 0.16
+PROTECTED_NICHE_REPRODUCTION_DISCOUNT = 0.10
 
 
 @dataclass(frozen=True)
@@ -69,6 +70,17 @@ class ReproductionMutationContext:
         if self.diversity_score < DIVERSITY_DANGER_FLOOR:
             return DANGER_SUB_BEHAVIOR_SWITCH_RATE
         return base_rate
+
+    def protected_reproduction_ratio(self, base_ratio: float) -> float:
+        """Return a niche-protected reproduction threshold ratio.
+
+        Protection is deliberately modest: it gives underrepresented parents a
+        small chance to reproduce before the dominant niche crowds them out,
+        without making reproduction free or flattening selection globally.
+        """
+        if not self.preserve_parent_lineage:
+            return base_ratio
+        return max(0.0, base_ratio * (1.0 - PROTECTED_NICHE_REPRODUCTION_DISCOUNT))
 
 
 @dataclass(frozen=True)

--- a/core/reproduction/asexual_factory.py
+++ b/core/reproduction/asexual_factory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from core.energy.energy_utils import apply_energy_delta
 from core.util.stable_hash import stable_algorithm_id
@@ -108,6 +108,7 @@ def create_asexual_offspring(
         initial_energy=baby_initial_energy,
         parent_id=fish.fish_id,
     )
+    cast(Any, baby).protected_niche_birth = mutation_context.preserve_parent_lineage
 
     composable = fish.genome.behavioral.behavior
     if composable is not None and composable.value is not None:

--- a/core/reproduction/mutation_controller.py
+++ b/core/reproduction/mutation_controller.py
@@ -21,6 +21,8 @@ class DiversityMutationController:
     SAMPLE_INTERVAL_FRAMES = 500
     STALL_WINDOW_FRAMES = 10_000
     UNDERREPRESENTED_LINEAGE_SHARE = 0.15
+    UNDERREPRESENTED_GENETIC_NICHE_SHARE = 0.20
+    GENETIC_NICHE_RADIUS = 0.30
 
     def __init__(
         self,
@@ -92,15 +94,36 @@ class DiversityMutationController:
             if behavior_id is not None:
                 counts[behavior_id] = counts.get(behavior_id, 0) + 1
 
-        if len(counts) <= 1:
-            return False
+        population = len(fish_list)
+        if len(counts) > 1:
+            for parent in parents:
+                behavior_id = self._behavior_id_for(parent)
+                if behavior_id is None:
+                    continue
+                if counts.get(behavior_id, 0) / population <= self.UNDERREPRESENTED_LINEAGE_SHARE:
+                    return True
+        return self._preserve_genetically_isolated_parent(parents, fish_list)
+
+    def _preserve_genetically_isolated_parent(
+        self,
+        parents: tuple[Fish, ...],
+        fish_list: list[Fish],
+    ) -> bool:
+        from core.genetics.diversity import genetic_distance
 
         population = len(fish_list)
+        if population < 4:
+            return False
+
+        max_neighbors = max(1, int(population * self.UNDERREPRESENTED_GENETIC_NICHE_SHARE))
         for parent in parents:
-            behavior_id = self._behavior_id_for(parent)
-            if behavior_id is None:
-                continue
-            if counts.get(behavior_id, 0) / population <= self.UNDERREPRESENTED_LINEAGE_SHARE:
+            neighbor_count = 0
+            for fish in fish_list:
+                if genetic_distance(parent.genome, fish.genome) <= self.GENETIC_NICHE_RADIUS:
+                    neighbor_count += 1
+                    if neighbor_count > max_neighbors:
+                        break
+            if neighbor_count <= max_neighbors:
                 return True
         return False
 

--- a/core/reproduction/reproduction_service.py
+++ b/core/reproduction/reproduction_service.py
@@ -72,7 +72,6 @@ class ReproductionService:
         self._mutation_controller.record_diversity_sample(frame)
 
         fish_count = len(fish_list)
-
         proximity = self._handle_proximity_mating(fish_list, fish_count)
         fish_count += proximity
 
@@ -221,7 +220,6 @@ class ReproductionService:
             required_credits
         ):
             return None
-
         mutation_context = self._mutation_context_for_parents(winner_fish)
         baby = self.create_asexual_offspring(winner_fish, mutation_context=mutation_context)
         if baby is None:
@@ -284,7 +282,6 @@ class ReproductionService:
                 required_credits
             ):
                 continue
-
             mutation_context = self._mutation_context_for_parents(fish)
             baby = self.maybe_create_banked_offspring(fish, mutation_context=mutation_context)
             if baby is None:
@@ -319,8 +316,12 @@ class ReproductionService:
             life_stage = fish.life_stage
             if life_stage is None:
                 continue
+            mutation_context = self._mutation_context_for_parents(fish)
             if not fish._reproduction_component.can_asexually_reproduce(
-                life_stage, fish.energy, fish.max_energy
+                life_stage,
+                fish.energy,
+                fish.max_energy,
+                mutation_context,
             ):
                 continue
 
@@ -328,7 +329,6 @@ class ReproductionService:
             asexual_trait = fish.genome.behavioral.asexual_reproduction_chance.value
             rng = fish.environment.rng
             if rng.random() < asexual_trait:
-                mutation_context = self._mutation_context_for_parents(fish)
                 try:
                     baby = fish._create_asexual_offspring(mutation_context=mutation_context)
                 except TypeError:

--- a/core/reproduction/sexual_factory.py
+++ b/core/reproduction/sexual_factory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from core.energy.energy_utils import apply_energy_delta
 from core.util.stable_hash import stable_algorithm_id
@@ -162,6 +162,7 @@ def create_standard_mating_offspring(
         initial_energy=parent_contrib + mate_contrib,
         parent_id=parent.fish_id,
     )
+    cast(Any, baby).protected_niche_birth = mutation_context.preserve_parent_lineage
 
     _record_successful_mating(parent)
     parent.visual_state.set_birth_effect(60)
@@ -247,6 +248,7 @@ def create_post_poker_offspring(
         initial_energy=total_contrib,
         parent_id=winner.fish_id,
     )
+    cast(Any, baby).protected_niche_birth = mutation_context.preserve_parent_lineage
 
     _record_successful_mating(winner)
     winner.visual_state.set_birth_effect(60)

--- a/tests/test_diversity_mutation_controller.py
+++ b/tests/test_diversity_mutation_controller.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import random
+from types import SimpleNamespace
+
+from core.genetics import Genome
+from core.reproduction.mutation_controller import DiversityMutationController
+
+
+def _same_behavior_genome(seed: int) -> Genome:
+    genome = Genome.random(use_algorithm=False, rng=random.Random(seed))
+    genome.behavioral.behavior = None
+    return genome
+
+
+def test_genetic_outlier_gets_lineage_preservation_without_behavior_id() -> None:
+    common = _same_behavior_genome(1)
+    outlier = _same_behavior_genome(2)
+
+    common.physical.size_modifier.value = 0.5
+    common.physical.fin_size.value = 0.5
+    common.physical.tail_size.value = 0.5
+    common.behavioral.aggression.value = 0.0
+    common.behavioral.pursuit_aggression.value = 0.0
+    common.behavioral.hunting_stamina.value = 0.0
+    common.invalidate_caches()
+
+    outlier.physical.size_modifier.value = 2.0
+    outlier.physical.fin_size.value = 2.0
+    outlier.physical.tail_size.value = 2.0
+    outlier.behavioral.aggression.value = 1.0
+    outlier.behavioral.pursuit_aggression.value = 1.0
+    outlier.behavioral.hunting_stamina.value = 1.0
+    outlier.invalidate_caches()
+
+    crowd = [SimpleNamespace(genome=common) for _ in range(5)]
+    rare_parent = SimpleNamespace(genome=outlier)
+    fish = [*crowd, rare_parent]
+    controller = DiversityMutationController(
+        diversity_score_provider=lambda: 0.18,
+        fish_provider=lambda: fish,
+    )
+
+    context = controller.context_for_parents(rare_parent)
+
+    assert context.preserve_parent_lineage
+
+
+def test_crowded_genetic_niche_does_not_get_lineage_preservation() -> None:
+    common = _same_behavior_genome(3)
+    fish = [SimpleNamespace(genome=common) for _ in range(6)]
+    controller = DiversityMutationController(
+        diversity_score_provider=lambda: 0.18,
+        fish_provider=lambda: fish,
+    )
+
+    context = controller.context_for_parents(fish[0])
+
+    assert not context.preserve_parent_lineage

--- a/tests/test_proximity_mating.py
+++ b/tests/test_proximity_mating.py
@@ -12,7 +12,7 @@ from core.config.fish import (
 )
 from core.config.simulation_config import SimulationConfig
 from core.entities import Fish, LifeStage
-from core.genetics import Genome
+from core.genetics import Genome, ReproductionMutationContext
 from core.movement_strategy import AlgorithmicMovement
 from core.reproduction.reproduction_service import ReproductionService
 from core.world import World
@@ -172,3 +172,21 @@ def test_proximity_mating_requires_local_parent_energy() -> None:
 
     assert stats.proximity_sexual == 0
     assert engine.spawned == []
+
+
+def test_protected_niche_context_can_unlock_trait_asexual_reproduction() -> None:
+    env = _MiniEnvironment()
+    ecosystem = _MiniEcosystem()
+    parent = _adult_fish(env, ecosystem, x=80, y=80, energy_ratio=0.86)
+    engine = _MiniEngine([parent], env)
+    service = ReproductionService(cast("SimpleNamespace", engine))
+
+    service._mutation_controller.context_for_parents = (  # type: ignore[method-assign]
+        lambda *_parents: ReproductionMutationContext(preserve_parent_lineage=True)
+    )
+
+    stats = service.update_frame(1)
+
+    assert stats.trait_asexual == 1
+    assert len(engine.spawned) == 1
+    assert engine.spawned[0].protected_niche_birth

--- a/tests/test_reproduction_params.py
+++ b/tests/test_reproduction_params.py
@@ -2,6 +2,8 @@ import random
 
 import pytest
 
+from core.agents.components.reproduction_component import ReproductionComponent
+from core.entities import LifeStage
 from core.genetics import Genome, ReproductionMutationContext, ReproductionParams
 from core.genetics.reproduction import DANGER_SUB_BEHAVIOR_SWITCH_RATE
 
@@ -73,3 +75,21 @@ def test_danger_zone_escalates_behavior_switch_rate_only_when_active() -> None:
 
     assert inactive.sub_behavior_switch_rate(0.08) == pytest.approx(0.08)
     assert active.sub_behavior_switch_rate(0.08) == pytest.approx(DANGER_SUB_BEHAVIOR_SWITCH_RATE)
+
+
+def test_protected_lineage_gets_modest_asexual_energy_relief() -> None:
+    component = ReproductionComponent()
+    protected = ReproductionMutationContext(preserve_parent_lineage=True)
+
+    assert not component.can_asexually_reproduce(LifeStage.ADULT, 86.0, 100.0)
+    assert component.can_asexually_reproduce(LifeStage.ADULT, 86.0, 100.0, protected)
+
+
+def test_protected_lineage_still_requires_adult_and_cooldown() -> None:
+    component = ReproductionComponent()
+    protected = ReproductionMutationContext(preserve_parent_lineage=True)
+
+    assert not component.can_asexually_reproduce(LifeStage.BABY, 100.0, 100.0, protected)
+
+    component.reproduction_cooldown = 1
+    assert not component.can_asexually_reproduce(LifeStage.ADULT, 100.0, 100.0, protected)


### PR DESCRIPTION
## Summary
- Implements proposal #10, Protected Innovation Niches, as a small Layer 1 experiment.
- Reuses `DiversityMutationController` lineage preservation, extends it to continuous genetic outliers, and applies a modest protected-lineage asexual reproduction threshold discount.
- Tags protected offspring for diagnostics without changing benchmarks, food config, champion files, or scoring.

## Why This Is Small
The change does not add a new selection system or global energy bonus. It extends the existing `preserve_parent_lineage` signal and consumes it only in the trait-asexual reproduction eligibility path.

## Validation
- `py -3 tools/smoke_gate.py` passed.
- `py -3 tools/agent_gate.py` passed.
- `py -3 -m mypy core` passed.
- `py -3 -m mypy tools backend` passed.
- `py -3 tools/fast_gate.py` passed: 1898 passed, 3 skipped.
- Focused tests passed: `tests/test_reproduction_params.py`, `tests/test_diversity_mutation_controller.py`, `tests/test_proximity_mating.py`, god-class guardrail.

## Benchmark Evidence
Baseline reproduced before changes:
- `py -3 tools/run_bench.py benchmarks/tank/selection_response_10k.py --seed 42`
- score 33.4473, config_hash `78bd6a9375ae7762`, diversity_delta -0.0108, drift_per_generation_pct 2.3826.

After changes:
- same command, seed 42: score 59.3567, config_hash `78bd6a9375ae7762`, diversity_delta +0.0709, drift_per_generation_pct 3.0958.
- `py -3 tools/run_selection_response_assay.py`: post-change seeds 42/7/123 mean score 47.1171, all_selection_detected true, mean_diversity_delta +0.0525, min_final_diversity 0.2708.

Note: the full three-seed baseline timed out before code changes, so only seed 42 has direct before/after evidence. The three-seed assay is reported as post-change robustness, not a full multi-seed improvement claim.

## Anti-Goodhart Check
This does not edit the held-out assay, benchmark scoring, champion metadata, food economy, or global reproduction thresholds. Protection is local to underrepresented/genetically isolated parents and still requires adulthood, cooldown readiness, and substantial energy.

Champion files touched: no.