### PR TITLE
Rename fast_gate → pre_pr_gate for honest scope naming

### DIFF
--- a/.claude/commands/study-sim.md
+++ b/.claude/commands/study-sim.md
@@ -50,7 +50,7 @@ hand-wave a fix:
    (e.g. `scripts/diagnose_food_seeking.py`, `scripts/diagnose_evolution.py`).
 2. Make the **smallest** change. Keep Layer 1 (algorithm/config in `core/`)
    separate from any Layer 2 change (this tool, benchmarks, telemetry, gates).
-3. `python tools/smoke_gate.py`, then `python tools/fast_gate.py`.
+3. `python tools/smoke_gate.py`, then `python tools/pre_pr_gate.py`.
 4. Benchmark the candidate and compare against `champions/`. The
    evolution-quality benchmark is `benchmarks/tank/ecosystem_health_10k.py`;
    confirm trait drift actually moved with `scripts/diagnose_evolution.py`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         TANK_ENFORCE_MUTATION_INVARIANTS: "1"
       run: python tools/smoke_gate.py
 
-  fast-gate:
+  pre-pr-gate:
     runs-on: ubuntu-latest
     needs: smoke-gate
     steps:
@@ -51,10 +51,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-    - name: Run named fast gate
+    - name: Run named pre-PR gate
       env:
         TANK_ENFORCE_MUTATION_INVARIANTS: "1"
-      run: python tools/fast_gate.py
+      run: python tools/pre_pr_gate.py
     - name: Type check with mypy
       run: python -m mypy core/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ python main.py --headless --max-frames 30000 --stats-interval 10000 --export-sta
 python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42
 
 # 5. Identify what needs improvement, make changes, run the agent gate, commit
-#    Run the fast gate before opening a PR
+#    Run the pre-PR gate before opening a PR
 ```
 
 ---
@@ -135,7 +135,7 @@ python tools/evolution_report.py --history evolution_journal.jsonl
 When the human asks you to *act* on the findings, drive the top-ranked
 recommendation through the normal **Evolution Loop** (do not hand-wave a fix):
 reproduce it with the named diagnostic, make the smallest change, run the smoke
-then fast gate, benchmark the candidate against the `champions/` registry
+then pre-PR gate, benchmark the candidate against the `champions/` registry
 (`ecosystem_health_10k` is the evolution-quality benchmark), and only claim an
 improvement with a reproduction command, seed, score, and metadata. Keep Layer 1
 (algorithm/config) changes separate from any Layer 2 change to the report tool,
@@ -330,17 +330,16 @@ python tools/agent_gate.py
 ```
 It runs the smoke gate plus a curated correctness suite of architecture, energy, genetics, and protocol tests. It targets under 90 seconds.
 
-### Tier 2: Fast Gate (Before PR)
+### Tier 2: Pre-PR Gate (Before PR)
 
-Run the fast gate before opening or updating a PR:
+Run the pre-PR gate before opening or updating a PR:
 ```bash
-python tools/fast_gate.py
+python tools/pre_pr_gate.py
 ```
 It runs the smoke gate plus the broad non-slow test suite (parallelized
-across cores via pytest-xdist). It targets under 2-3 minutes on normal
-developer/CI hardware and excludes integration/slow/manual tests and full
-benchmarks. On constrained or single-core sandboxes it can take longer; if it
-does, that's a hardware limit, not a sign something is broken.
+across cores via pytest-xdist). Runtime varies by hardware — typically a
+few minutes on multi-core CI, longer on constrained or single-core sandboxes.
+It excludes integration/slow/manual tests and full benchmarks.
 
 ### Tier 3: Full Validation (Maintainers/Nightly)
 
@@ -353,7 +352,7 @@ for nightly or explicit maintainer use, not routine agent iteration.
 
 ### Run Full Benchmarks (Only for Candidate Improvements)
 
-Only run full benchmarks after you have confirmed that the fast gate passes and you have a candidate algorithm/config improvement:
+Only run full benchmarks after you have confirmed that the pre-PR gate passes and you have a candidate algorithm/config improvement:
 ```bash
 # Run benchmark
 python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42
@@ -443,7 +442,7 @@ Tank World has built-in support for Claude Code agentic development:
 3. Run a benchmark to understand current baseline
 4. Analyze results and identify improvement targets
 5. Make changes and run `python tools/agent_gate.py` before local commit
-6. Run `python tools/fast_gate.py` before PR
+6. Run `python tools/pre_pr_gate.py` before PR
 7. Commit with clear metrics in the message
 
 ### What Claude Code Can Do Here
@@ -586,13 +585,13 @@ Workflow:
 2. Run baseline: python main.py --headless --max-frames 30000 --export-stats results.json --seed 42
 3. Analyze: Review results.json for underperformers
 4. Improve: Modify relevant code in core/
-5. Validate: Run agent gate (python tools/agent_gate.py) before local commit, then fast gate (python tools/fast_gate.py) before PR; run full benchmarks only for a candidate improvement
+5. Validate: Run agent gate (python tools/agent_gate.py) before local commit, then pre-PR gate (python tools/pre_pr_gate.py) before PR; run full benchmarks only for a candidate improvement
 6. Commit: Clear message with metrics and reproduction command
 7. Push: git push -u origin [branch]
 
 Rules:
 - Always use deterministic seeds
-- Run the agent gate (python tools/agent_gate.py) before committing, and the fast gate (python tools/fast_gate.py) before opening a PR
+- Run the agent gate (python tools/agent_gate.py) before committing, and the pre-PR gate (python tools/pre_pr_gate.py) before opening a PR
 - Never claim benchmark improvement without reproduction command, seed, score, and metadata
 - Layer 2 changes (benchmarks, CI, scoring, prompts, gates, champion metadata) must be separate from Layer 1 improvements
 - One focused improvement per PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ python tools/smoke_gate.py
 python tools/agent_gate.py
 
 # Run before PR (smoke gate + broad non-slow tests)
-python tools/fast_gate.py
+python tools/pre_pr_gate.py
 
 # Run full validation only for nightly or explicit maintainer review
 python tools/full_gate.py
@@ -124,10 +124,10 @@ Local validation tiers:
 
 1. **Smoke Gate**: `python tools/smoke_gate.py` before coding
 2. **Agent Gate**: `python tools/agent_gate.py` before local commit
-3. **Fast Gate**: `python tools/fast_gate.py` before PR
+3. **Pre-PR Gate**: `python tools/pre_pr_gate.py` before PR
 4. **Full Gate**: `python tools/full_gate.py` only for maintainers/nightly/full validation
 
-Public CI jobs are named `smoke-gate`, `fast-gate`, `frontend-ci`, and
+Public CI jobs are named `smoke-gate`, `pre-pr-gate`, `frontend-ci`, and
 `nightly-full` in `ci.yml`, plus `verify-champions` and `benchmark-gate` in
 `bench.yml`. Benchmark CI verifies champions and runs full determinism checks
 nightly or when a maintainer dispatches it explicitly.
@@ -140,7 +140,7 @@ The standard evolution loop:
 2. **Baseline**: Run `python main.py --headless --max-frames 30000 --export-stats results.json --seed 42`
 3. **Evaluate**: Check `results.json` for underperforming algorithms (high starvation rate, low reproduction)
 4. **Improve**: Modify code in `core/algorithms/` or `core/config/`
-5. **Validate**: Run `python tools/agent_gate.py` before local commit, and `python tools/fast_gate.py` before PR
+5. **Validate**: Run `python tools/agent_gate.py` before local commit, and `python tools/pre_pr_gate.py` before PR
 6. **Benchmark**: Run full benchmarks only after a candidate improvement exists
 7. **Compare**: Compare candidate results against the `champions/` registry
 8. **Commit**: Clear message with metrics, reproduction command, and evidence

--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ python tools/agent_gate.py
 # Run a baseline benchmark (5k frames is faster for verification)
 python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42
 
-# Make improvements, validate with the fast gate before opening a PR
-python tools/fast_gate.py
+# Make improvements, validate with the pre-PR gate before opening a PR
+python tools/pre_pr_gate.py
 pre-commit run --all-files
 ```
 
@@ -329,8 +329,8 @@ python tools/smoke_gate.py
 # Agent gate (runs in under 90 seconds, smoke gate + curated checks)
 python tools/agent_gate.py
 
-# Fast gate (pre-PR check, runs in under 3 minutes)
-python tools/fast_gate.py
+# Pre-PR gate (broad non-slow suite; runtime varies by hardware)
+python tools/pre_pr_gate.py
 
 # Full validation gate (nightly/maintainers only)
 python tools/full_gate.py
@@ -345,7 +345,7 @@ pre-commit run --all-files
 python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42 --verify-determinism
 ```
 
-CI currently runs `smoke-gate`, `fast-gate`, `frontend-ci`, and `nightly-full` under [`.github/workflows/ci.yml`](.github/workflows/ci.yml), with `verify-champions` and `benchmark-gate` defined separately in [`.github/workflows/bench.yml`](.github/workflows/bench.yml).
+CI currently runs `smoke-gate`, `pre-pr-gate`, `frontend-ci`, and `nightly-full` under [`.github/workflows/ci.yml`](.github/workflows/ci.yml), with `verify-champions` and `benchmark-gate` defined separately in [`.github/workflows/bench.yml`](.github/workflows/bench.yml).
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -14,8 +14,8 @@ python tools/smoke_gate.py
 # 3. Use the agent gate for local validation (under 90 seconds)
 python tools/agent_gate.py
 
-# 4. Use the fast gate before submitting a PR (under 3 minutes)
-python tools/fast_gate.py
+# 4. Use the pre-PR gate before submitting a PR (under 3 minutes)
+python tools/pre_pr_gate.py
 ```
 
 For detailed setup or troubleshooting, follow the normal setup paths below.

--- a/docs/AGENT_FIELD_GUIDE.md
+++ b/docs/AGENT_FIELD_GUIDE.md
@@ -55,7 +55,7 @@ specialization of it. Memorize the shape:
 2. PICK     one task from the menu in §4       # exactly one, the smallest that helps
 3. CHANGE   edit the files the recipe names    # nothing the recipe didn't mention
 4. RUN      python tools/agent_gate.py        # local validation gate (under 90s)
-5. PROVE    python tools/fast_gate.py          # did I keep it healthy?
+5. PROVE    python tools/pre_pr_gate.py          # did I keep it healthy?
 6. WRITE    a clear commit + PR (§6 template)  # what, why, and the proof
 7. STOP     one focused change per PR           # resist doing "just one more thing"
 ```
@@ -152,10 +152,10 @@ your diff touches only the lines needed for the fix.
 2. Write a small, fast, deterministic test. Copy the style of a neighboring test
    file. No network, no sleeps, no global random — pass seeds explicitly.
 3. Run just your test: `pytest tests/path/to/your_test.py -v`.
-4. Run `python tools/fast_gate.py` to confirm the whole non-slow suite is green.
+4. Run `python tools/pre_pr_gate.py` to confirm the whole non-slow suite is green.
 
 **Done-check:** Your test passes, it fails if you deliberately break the thing
-it tests (try it, then revert), and `fast_gate` is green.
+it tests (try it, then revert), and `pre_pr_gate` is green.
 
 ---
 
@@ -187,10 +187,10 @@ it tests (try it, then revert), and `fast_gate` is green.
    ```bash
    python tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 42 --out eco.json
    ```
-6. Run `python tools/fast_gate.py`.
+6. Run `python tools/pre_pr_gate.py`.
 
 **Done-check:** `after.score > before.score` on `survival_5k`, no meaningful
-regression on `ecosystem_health_10k`, `fast_gate` green, and your PR quotes both
+regression on `ecosystem_health_10k`, `pre_pr_gate` green, and your PR quotes both
 numbers and the exact reproduction commands.
 
 > ⚠️ Do **not** edit `champions/tank/survival_5k.json` to record your new score.
@@ -221,9 +221,9 @@ the composable framework in `core/algorithms/composable/` (`behavior.py`,
    crash inside `execute`.
 4. Prove it the same way as T3: baseline benchmark → change → re-benchmark →
    compare scores, check a second benchmark for regressions.
-5. Run `python tools/fast_gate.py`.
+5. Run `python tools/pre_pr_gate.py`.
 
-**Done-check:** Measurable benchmark improvement with no regression, `fast_gate`
+**Done-check:** Measurable benchmark improvement with no regression, `pre_pr_gate`
 green, and the algorithm still handles edge cases (no food visible, critical
 energy) without erroring.
 
@@ -248,10 +248,10 @@ energy) without erroring.
    already prints unless that's the fix.
 3. Run the script before and after to confirm it still works and now does the
    new thing.
-4. Run `python tools/fast_gate.py`.
+4. Run `python tools/pre_pr_gate.py`.
 
 **Done-check:** The tool runs cleanly, does the new helpful thing, breaks
-nothing else, and `fast_gate` is green.
+nothing else, and `pre_pr_gate` is green.
 
 ---
 
@@ -301,7 +301,7 @@ changed* and *how do I know it's safe*. Give them both. Copy this template:
 
 ## Proof
 <for Layer 1: before/after scores + the exact reproduction commands and seed>
-<for Layer 2: confirmation that smoke_gate / agent_gate / fast_gate pass>
+<for Layer 2: confirmation that smoke_gate / agent_gate / pre_pr_gate pass>
 
 Reproduction:
     python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42
@@ -310,7 +310,7 @@ Before: <score>
 After:  <score>
 
 ## No regressions
-<which other benchmark(s) you checked, and that fast_gate is green>
+<which other benchmark(s) you checked, and that pre_pr_gate is green>
 ```
 
 **Commit message** — same idea, compressed. State the change, the numbers, the
@@ -318,7 +318,7 @@ seed, and the reproduction command. Avoid vague messages like "improved stuff."
 
 Before you commit, run the self-check:
 
-- [ ] `python tools/agent_gate.py` and `python tools/fast_gate.py` are green.
+- [ ] `python tools/agent_gate.py` and `python tools/pre_pr_gate.py` are green.
 - [ ] My diff is **one focused change** (Rule 1).
 - [ ] I did **not** touch `champions/**` by hand (Rule 3).
 - [ ] I added **no** non-determinism (Rule 2).

--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -35,9 +35,9 @@ pre-commit install
   ```bash
   python tools/agent_gate.py
   ```
-* **Fast Gate (Pre-PR Check)**: Runs the smoke gate plus all non-slow unit tests. Runs in under 3 minutes.
+* **Pre-PR Gate**: Runs the smoke gate plus all non-slow unit tests (parallelized). Runtime varies by hardware.
   ```bash
-  python tools/fast_gate.py
+  python tools/pre_pr_gate.py
   ```
 * **Full Gate (Nightly/Maintainers only)**: Runs everything, including integration/slow tests and strict champion reproduction. Do not run this for routine local iterations.
   ```bash
@@ -87,7 +87,7 @@ A PR title must describe the improvement clearly. The description must include:
 1. **Summary**: What was changed and why.
 2. **Benchmark Results**: Before and after scores.
 3. **Reproduction Command**: The exact command and seed used to reproduce the score.
-4. **Validation Evidence**: Confirmation that `python tools/agent_gate.py` and `python tools/fast_gate.py` pass.
+4. **Validation Evidence**: Confirmation that `python tools/agent_gate.py` and `python tools/pre_pr_gate.py` pass.
 5. **No Regressions**: Evidence that other active benchmarks were not degraded.
 
 ---
@@ -108,7 +108,7 @@ Your task is to identify and optimize a Layer 1 behavior algorithm or configurat
 3. Run a baseline benchmark: python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42
 4. Modify fish parameters in core/config/fish.py or behavior logic in core/algorithms/composable/.
 5. Validate locally using the agent gate: python tools/agent_gate.py
-6. Before PR, run the fast gate: python tools/fast_gate.py
+6. Before PR, run the pre-PR gate: python tools/pre_pr_gate.py
 7. Compare scores against the champion; do not edit the champions/**/*.json files unless explicitly authorized by a maintainer or task prompt.
 8. Commit only the Layer 1 changes with a detailed message following the AGENTS.md format.
 Do not modify workflows, CI configurations, or unrelated documentation.
@@ -122,7 +122,7 @@ Your task is to improve documentation, testing, or benchmark usability.
 2. Run the smoke gate: python tools/smoke_gate.py
 3. Propose/implement edits to documentation, test harnesses under tests/, or tools in tools/.
 4. Run the agent gate: python tools/agent_gate.py
-5. Before PR, run the fast gate: python tools/fast_gate.py
+5. Before PR, run the pre-PR gate: python tools/pre_pr_gate.py
 6. Verify changes do not introduce type errors or lint failures.
 7. Commit only Layer 2 changes.
 Do not modify fish behaviors, game rules, physics, or champion scores.

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -226,7 +226,7 @@ algorithm-count bug is exactly the failure this prevents.
   trajectories). 25 new tests in tests/core/test_parameter_registry.py.
 
 - **Theme 2 (all): god files split into focused collaborators.** Five splits,
-  each behavior-preserving (full fast gate matches baseline; champions
+  each behavior-preserving (full pre-PR gate matches baseline; champions
   reproduce exactly): `core/simulation/engine.py` 951→~700 (PhaseExecutor,
   MutationExecutor, FrameAggregator, engine_setup, headless_runner);
   `core/ecosystem.py` 995→622 (telemetry router, poker outcome recorder,

--- a/docs/REPLAY.md
+++ b/docs/REPLAY.md
@@ -42,7 +42,7 @@ Fingerprints are computed over a canonicalized snapshot:
 
 The repo includes a small golden replay fixture used as a determinism regression test:
 - `tests/fixtures/replays/tank_petri_seed42_v2.jsonl` (includes a tank → petri mode switch)
-- `tests/test_replay_golden.py` (runs in the CI fast gate)
+- `tests/test_replay_golden.py` (runs in the CI pre-PR gate)
 
 If an *intentional* behavior change breaks the golden replay, regenerate the
 fixture with `backend.replay.record_file` (same seed/steps/switch plan) and

--- a/docs/examples/ui_trends_worker_task.md
+++ b/docs/examples/ui_trends_worker_task.md
@@ -17,7 +17,7 @@
 > the population is improving at poker and soccer over time. Do not change any
 > simulation behavior, RNG consumption, or benchmark scoring — this is a Layer 2
 > (tooling/UI) change and must be a separate PR from any algorithm work. Run
-> `python tools/smoke_gate.py` before coding and `python tools/fast_gate.py`
+> `python tools/smoke_gate.py` before coding and `python tools/pre_pr_gate.py`
 > plus `cd frontend && npm run lint && npm run build` before pushing.
 
 ---
@@ -165,7 +165,7 @@ export function TankTrendsTab({ history }: TankTrendsTabProps) {
 - [ ] Empty/fresh world shows the empty state, not a crash or blank panel.
 - [ ] Reconnect mid-run does not duplicate or reorder samples (delta resync
       happens every 90 frames — see `backend/runner/state_publisher.py`).
-- [ ] `python tools/fast_gate.py` passes; `cd frontend && npm run lint && npm run build` pass.
+- [ ] `python tools/pre_pr_gate.py` passes; `cd frontend && npm run lint && npm run build` pass.
 - [ ] No UI_SPEC violations: tokens only, dashboard-card pattern, panel toggle
       added with `aria-pressed`.
 - [ ] PR contains only Layer 2 changes (no `core/algorithms/`, `core/config/`,

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,7 +35,7 @@ Quick sanity checks to verify basic functionality:
 python tools/smoke_gate.py
 
 # Before PR: smoke gate plus broad non-slow suite
-python tools/fast_gate.py
+python tools/pre_pr_gate.py
 
 # Nightly or explicit maintainer validation
 python tools/full_gate.py

--- a/tests/test_benchmark_integrity.py
+++ b/tests/test_benchmark_integrity.py
@@ -5,7 +5,7 @@ score reproduces within tolerance. If run_bench.py, a benchmark, or core config
 changes in a way that breaks champion reproducibility, this fails loudly
 instead of leaving the champions registry silently stale.
 
-Marked slow: runs in the nightly gate, not the fast gate.
+Marked slow: runs in the nightly gate, not the pre-PR gate.
 """
 
 import glob

--- a/tests/test_docs_agent_onboarding.py
+++ b/tests/test_docs_agent_onboarding.py
@@ -54,13 +54,13 @@ def _markdown_section(content: str, heading: str) -> str:
     return content[start:next_heading]
 
 
-def test_readme_references_smoke_and_fast_gates():
+def test_readme_references_smoke_and_pre_pr_gates():
     readme_path = ROOT / "README.md"
     assert readme_path.exists(), "README.md does not exist"
     content = readme_path.read_text(encoding="utf-8")
     assert "tools/smoke_gate.py" in content, "README.md must reference tools/smoke_gate.py"
     assert "tools/agent_gate.py" in content, "README.md must reference tools/agent_gate.py"
-    assert "tools/fast_gate.py" in content, "README.md must reference tools/fast_gate.py"
+    assert "tools/pre_pr_gate.py" in content, "README.md must reference tools/pre_pr_gate.py"
 
 
 def test_agents_references_agent_quickstart():
@@ -73,12 +73,12 @@ def test_agents_references_agent_quickstart():
     assert "tools/agent_gate.py" in content, "AGENTS.md must reference tools/agent_gate.py"
 
 
-def test_vague_prompt_guidance_starts_with_smoke_gate_not_fast_gate():
+def test_vague_prompt_guidance_starts_with_smoke_gate_not_pre_pr_gate():
     agents_path = ROOT / "AGENTS.md"
     content = agents_path.read_text(encoding="utf-8")
     section = _markdown_section(content, "If you were given a vague prompt")
 
-    gate_commands = re.findall(r"python tools/(?:smoke|agent|fast|full)_gate\.py", section)
+    gate_commands = re.findall(r"python tools/(?:smoke|agent|pre_pr|full)_gate\.py", section)
 
     assert gate_commands, "AGENTS.md vague-prompt section must name a validation gate"
     assert (

--- a/tests/test_validation_tiers.py
+++ b/tests/test_validation_tiers.py
@@ -161,8 +161,8 @@ def test_run_bench_contract_tests_do_not_import_real_benchmarks():
     assert "benchmarks/soccer/" not in source.replace("\\", "/")
 
 
-def test_fast_gate_composes_smoke_gate_and_excludes_expensive_markers():
-    source = (ROOT / "tools" / "fast_gate.py").read_text(encoding="utf-8")
+def test_pre_pr_gate_composes_smoke_gate_and_excludes_expensive_markers():
+    source = (ROOT / "tools" / "pre_pr_gate.py").read_text(encoding="utf-8")
 
     assert "tools/smoke_gate.py" in source
     assert "not slow and not integration and not manual" in source
@@ -180,7 +180,7 @@ def test_agent_gate_composes_smoke_gate_and_uses_curated_tests():
 def test_no_unmarked_expensive_simulation_loops():
     """Ensure ordinary tests cannot accidentally grow into real simulations.
 
-    The fast gate should include cheap unit and contract coverage. Tests that run
+    The pre-PR gate should include cheap unit and contract coverage. Tests that run
     long simulation loops, invoke real benchmarks in subprocesses, sleep for long
     periods, or run headless commands with large frame counts belong behind the
     slow/integration/manual markers.

--- a/tools/agent_gate.py
+++ b/tools/agent_gate.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Run the under-90-second curated agent gate.
 
-This sits between the smoke gate and the fast gate:
-  smoke (under 30s) -> agent (under 90s) -> fast (under 3 min) -> full (nightly)
+This sits between the smoke gate and the pre-PR gate:
+  smoke (under 30s) -> agent (under 90s) -> pre-PR (broad suite) -> full (nightly)
 
 Use agent gate before a local commit. It runs the smoke gate first, then a
 curated set of architecture, determinism, energy, genetics, protocol, and
 import-boundary tests - broader than smoke, but much cheaper than the full
-non-slow suite that the fast gate runs.
+non-slow suite that the pre-PR gate runs.
 """
 
 try:

--- a/tools/full_gate.py
+++ b/tools/full_gate.py
@@ -11,11 +11,11 @@ def main() -> None:
     print_gate_header(
         name="FULL",
         target="unbounded; nightly or explicit maintainer use only",
-        includes="fast gate, integration/slow tests, and strict champion reproduction",
+        includes="pre-PR gate, integration/slow tests, and strict champion reproduction",
         excludes="manual tests",
     )
     steps = [
-        (python_command("tools/fast_gate.py"), "Tier 2: fast gate"),
+        (python_command("tools/pre_pr_gate.py"), "Tier 2: pre-PR gate"),
         (
             python_command(
                 "-m",

--- a/tools/pre_pr_gate.py
+++ b/tools/pre_pr_gate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the contributor pre-PR fast gate."""
+"""Run the contributor pre-PR validation gate."""
 
 try:
     from tools.gate_common import exit_for_gate, print_gate_header, python_command, run_steps
@@ -9,8 +9,8 @@ except ImportError:
 
 def main() -> None:
     print_gate_header(
-        name="FAST",
-        target="under 2-3 minutes on normal developer/CI hardware (parallelized across cores)",
+        name="PRE-PR",
+        target="varies by hardware; typically under 3 minutes on multi-core CI, longer on constrained sandboxes",
         includes="the smoke gate, then the broad non-slow test suite run in parallel",
         excludes="integration/manual/slow tests, champion reproduction, and 5k/10k benchmarks",
     )
@@ -31,7 +31,7 @@ def main() -> None:
             "Tier 2: broad non-slow tests (parallel)",
         ),
     ]
-    exit_for_gate("FAST", run_steps(steps))
+    exit_for_gate("PRE-PR", run_steps(steps))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Renames `tools/fast_gate.py` → `tools/pre_pr_gate.py`
- Renames CI job `fast-gate` → `pre-pr-gate` in `.github/workflows/ci.yml`
- Updates all forward-looking references across docs, tests, and tooling (18 files); historical ADRs left as-is
- Updates `test_validation_tiers.py` and `test_docs_agent_onboarding.py` to reference the new file name and updated regex patterns

## Motivation

The broad non-slow suite (~1,900 tests) cannot reliably finish "under 2-3 minutes" on constrained or single-core runners — the name "fast gate" sets expectations the suite can't meet in all environments. Renaming to `pre_pr_gate` describes the role (run before opening a PR) without implying a speed guarantee that only holds on multi-core hardware.

This follows the reviewer's suggestion: *"stop trying to make a 1,900-test suite be 'fast.' Make the naming honest."*

## Test plan

- [x] `python tools/smoke_gate.py` — 36 passed (includes validation-tiers and docs-onboarding contracts)
- [x] `python tools/pre_pr_gate.py` — 1893 passed, 3 skipped in ~13s
- [x] `ruff check` passes on all changed files
- [x] No stale `fast_gate` references remain outside historical ADRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfvS46dEMoHYPFTCCPb2G6

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfvS46dEMoHYPFTCCPb2G6)_