### PR TITLE
Fix builtin soccer policies dashing at full power regardless of stamina

### DIFF
--- a/core/code_pool/pool.py
+++ b/core/code_pool/pool.py
@@ -261,8 +261,16 @@ def chase_ball_soccer_policy(observation: dict[str, Any], rng: Any) -> dict[str,
         else:
             turn = max(-1.0, min(1.0, (angle_delta * 1.5) / 3.14159))
 
-        # Dash toward ball if not too close
-        dash = 1.0 if dist > 0.4 else 0.0
+        # Dash toward ball at full power while fresh; ease off once stamina
+        # runs low so a long chase doesn't crash through the RCSS effort
+        # floor (a constant full-power dash costs more stamina than passive
+        # recovery replaces). BotEntity's default_policy_action never hits
+        # this because it throttles power by distance instead.
+        stamina_ratio = float(observation.get("stamina_ratio", 1.0))
+        if dist > 0.4:
+            dash = 1.0 if stamina_ratio > 0.4 else max(0.3, stamina_ratio / 0.4)
+        else:
+            dash = 0.0
 
         # Kick if close to ball
         kick_power = 0.0
@@ -335,7 +343,11 @@ def defensive_soccer_policy(observation: dict[str, Any], rng: Any) -> dict[str, 
         else:
             turn = max(-1.0, min(1.0, (angle_delta * 1.5) / 3.14159))
 
-        dash = 1.0 if dist > 0.5 else 0.0
+        stamina_ratio = float(observation.get("stamina_ratio", 1.0))
+        if dist > 0.5:
+            dash = 1.0 if stamina_ratio > 0.4 else max(0.3, stamina_ratio / 0.4)
+        else:
+            dash = 0.0
 
         # Kick away if close to ball
         ball_rel = observation.get("ball_relative_pos", {})
@@ -406,7 +418,11 @@ def striker_soccer_policy(observation: dict[str, Any], rng: Any) -> dict[str, An
         else:
             turn = max(-1.0, min(1.0, (angle_delta * 1.5) / 3.14159))
 
-        dash = 1.0 if dist > 0.4 else 0.0
+        stamina_ratio = float(observation.get("stamina_ratio", 1.0))
+        if dist > 0.4:
+            dash = 1.0 if stamina_ratio > 0.4 else max(0.3, stamina_ratio / 0.4)
+        else:
+            dash = 0.0
 
         # Shoot on goal if close to ball
         kick_power = 0.0

--- a/core/minigames/soccer/policy_adapter.py
+++ b/core/minigames/soccer/policy_adapter.py
@@ -59,6 +59,7 @@ def build_observation(
         "self_angle": player.body_angle,  # Radians [-pi, pi]
         "neck_angle": player.neck_angle,  # Radians relative to body
         "stamina": player.stamina,
+        "stamina_ratio": (player.stamina / config.stamina_max) if config.stamina_max > 0 else 1.0,
         "recovery": player.recovery,
         "effort": player.effort,
         "team": player.team,


### PR DESCRIPTION
Fish on the soccer field were visibly slower than BotEntity opponents over the course of a match. Root cause: chase_ball_soccer_policy, striker_soccer_policy, and defensive_soccer_policy commanded an unconditional full-power dash (dash=1.0) whenever not within ~0.4-0.5m of their target. A sustained full-power dash costs more RCSS stamina per cycle (100) than passive recovery replaces (45), so fish run themselves into the engine's effort-degradation floor (effort -> 0.6), which directly caps cruising speed (~40% slower once degraded).

BotEntity opponents never hit this because they have no genome, so they always fall back to default_policy_action(), which throttles dash power by distance (power = min(100, dist*5)) and incidentally never taxes stamina.

Fix: the three builtin soccer policies now read the new "stamina_ratio" observation field (added in policy_adapter.py's build_observation) and ease off dash power once stamina drops below 40%, instead of always commanding full power. Full aggression is preserved while fresh.

Verified:
- tests/test_soccer_*.py (139 tests) and the agent-gate suite (575 tests) pass unchanged.
- Manual SoccerMatch probe: striker_soccer_policy's stamina no longer collapses (8000 -> 5850 vs previously 8000 -> 22.5 over one 5-minute match), and fish now win more decisively against bots instead of fading late.
- benchmarks/soccer/training_5k.py --seed 42: 12.638 -> 13.687 benchmarks/soccer/training_3k.py --seed 42: 8.817 -> 11.897 (both builtin-policy baselines improve; champions/soccer/*.json are now stale and would need a refresh via validate_improvement.py if this is to be tracked as a formal benchmark improvement)