### PR TITLE
Add phenotype legibility trait cues to tank/dish rendering

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -154,13 +154,17 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
                     const worldType = worldTypePropRef.current || 'tank';
 
                     // Determine effective view mode:
-                    // - Tank mode: ALWAYS use 'side' view (fish in rectangular tank)
-                    // - Petri mode: ALWAYS use 'topdown' view (microbes in circular dish)
-                    // This prevents the confusing case of microbes in a rectangle.
+                    // - Tank mode: respects the caller's viewMode prop, which defaults to
+                    //   'side' (fish in rectangular tank) but is selectable to 'topdown'
+                    //   (genome-driven microbe rendering, see docs/EVOLVABILITY.md sec 3.5)
+                    //   via the existing side/topdown override - opt-in only, so the
+                    //   out-of-box experience is unchanged.
+                    // - Petri/Soccer mode: ALWAYS use 'topdown' view (microbes in circular
+                    //   dish). This prevents the confusing case of microbes forced into a
+                    //   rectangle if a stale 'side' value ever reaches this branch.
                     let effectiveViewMode: 'side' | 'topdown';
                     if (worldType === 'tank') {
-                        // Tank mode = side view only (fish in rectangle)
-                        effectiveViewMode = 'side';
+                        effectiveViewMode = viewModeRef.current === 'topdown' ? 'topdown' : 'side';
                     } else {
                         // Petri/Soccer = topdown view
                         effectiveViewMode = 'topdown';

--- a/frontend/src/renderers/petri/PetriTopDownRenderer.ts
+++ b/frontend/src/renderers/petri/PetriTopDownRenderer.ts
@@ -59,6 +59,7 @@ interface PetriEntity {
     vel_y?: number;
     energy?: number;
     food_type?: string;
+    generation?: number;
     genome_data?: FishGenomeData;
     plant_genome_data?: PlantGenomeData;  // For plant fractal rendering
     perimeter_angle?: number;  // Angle from center for plants on perimeter
@@ -162,6 +163,7 @@ function buildPetriScene(snapshot: PetriSceneSnapshot): PetriScene {
                 vel_y: e.vel_y,
                 energy: e.energy,
                 food_type: e.food_type,
+                generation: e.generation,
                 genome_data: e.genome_data,
                 plant_genome_data: e.type === 'plant' ? e.genome : undefined,
                 size_multiplier: e.size_multiplier,
@@ -692,11 +694,13 @@ export class PetriTopDownRenderer implements Renderer {
             this.drawWobblyBlob(ctx, r, rand, wobble);
         }
 
-        // Outer membrane gradient
+        // Outer membrane gradient. Lineage depth: older generations read slightly
+        // more saturated/vivid.
+        const genSatBoost = this.clamp((entity.generation ?? 0) / 25, 0, 1) * 18;
         const membrane = ctx.createRadialGradient(r * 0.25, -r * 0.25, r * 0.1, 0, 0, r * 1.1);
-        membrane.addColorStop(0, `hsla(${hueDeg}, 70%, 62%, 0.95)`);
-        membrane.addColorStop(0.6, `hsla(${hueDeg}, 60%, 48%, 0.88)`);
-        membrane.addColorStop(1, `hsla(${(hueDeg + 20) % 360}, 55%, 34%, 0.85)`);
+        membrane.addColorStop(0, `hsla(${hueDeg}, ${70 + genSatBoost}%, 62%, 0.95)`);
+        membrane.addColorStop(0.6, `hsla(${hueDeg}, ${60 + genSatBoost}%, 48%, 0.88)`);
+        membrane.addColorStop(1, `hsla(${(hueDeg + 20) % 360}, ${55 + genSatBoost}%, 34%, 0.85)`);
         ctx.fillStyle = membrane;
         ctx.fill();
 
@@ -826,6 +830,98 @@ export class PetriTopDownRenderer implements Renderer {
         else this.drawWobblyBlob(ctx, r, rand, wobble * 0.8);
         ctx.stroke();
 
+        this.drawTraitCues(ctx, entity, r, hueDeg, rand);
+
+        ctx.restore();
+    }
+
+    /**
+     * Phenotype legibility cues for traits selection is currently acting on but
+     * that have no other visual presence (docs/EVOLVABILITY.md sec 3.5). Appended
+     * after the existing membrane/pattern/cilia/tail draws above so it consumes
+     * only the tail end of the seeded rand() sequence and leaves today's organisms
+     * looking exactly as before. Read-only: reacts to genome_data, never mutates it.
+     * Mirrors TankTopDownRenderer.ts's drawTraitCues.
+     */
+    private drawTraitCues(
+        ctx: CanvasRenderingContext2D,
+        entity: PetriEntity,
+        r: number,
+        hueDeg: number,
+        rand: () => number
+    ) {
+        const genome = entity.genome_data;
+
+        // Aggression -> outer glow aura, red-shifted with intensity
+        const aggression = this.clamp(genome?.aggression ?? 0, 0, 1);
+        if (aggression > 0.05) {
+            const auraHue = hueDeg * (1 - aggression);
+            const auraR = r * (1.15 + aggression * 0.35);
+            ctx.save();
+            ctx.globalAlpha = 0.15 + aggression * 0.35;
+            const auraGrad = ctx.createRadialGradient(0, 0, r * 0.9, 0, 0, auraR);
+            auraGrad.addColorStop(0, `hsla(${auraHue}, 90%, 55%, 0.55)`);
+            auraGrad.addColorStop(1, `hsla(${auraHue}, 90%, 50%, 0)`);
+            ctx.fillStyle = auraGrad;
+            ctx.beginPath();
+            ctx.arc(0, 0, auraR, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
+        }
+
+        // Prediction_skill -> forward sensory cone (narrower & longer as skill rises)
+        const predictionSkill = this.clamp(genome?.prediction_skill ?? 0, 0, 1);
+        if (predictionSkill > 0.05) {
+            const coneLen = r * (0.8 + predictionSkill * 2.2);
+            const coneHalfAngle = 0.55 - predictionSkill * 0.28;
+            ctx.save();
+            ctx.globalAlpha = 0.1 + predictionSkill * 0.22;
+            const coneGrad = ctx.createLinearGradient(r * 0.9, 0, r * 0.9 + coneLen, 0);
+            coneGrad.addColorStop(0, `hsla(${(hueDeg + 200) % 360}, 80%, 75%, 0.8)`);
+            coneGrad.addColorStop(1, `hsla(${(hueDeg + 200) % 360}, 80%, 75%, 0)`);
+            ctx.fillStyle = coneGrad;
+            ctx.beginPath();
+            ctx.moveTo(r * 0.9, 0);
+            ctx.lineTo(r * 0.9 + coneLen, -Math.sin(coneHalfAngle) * coneLen);
+            ctx.lineTo(r * 0.9 + coneLen, Math.sin(coneHalfAngle) * coneLen);
+            ctx.closePath();
+            ctx.fill();
+            ctx.restore();
+        }
+
+        // Hunting_stamina -> trailing bubble stream behind the organism
+        const huntingStamina = this.clamp(genome?.hunting_stamina ?? 0, 0, 1);
+        if (huntingStamina > 0.05) {
+            const bubbleCount = Math.floor(huntingStamina * 5);
+            ctx.save();
+            ctx.globalAlpha = 0.35;
+            ctx.fillStyle = `hsla(${(hueDeg + 190) % 360}, 40%, 85%, 0.7)`;
+            for (let i = 0; i < bubbleCount; i++) {
+                const t = (i + 1) / (bubbleCount + 1);
+                const bx = -r * (1.3 + t * 2.1) + (rand() - 0.5) * r * 0.3;
+                const by = (rand() - 0.5) * r * 0.7 * (1 + t);
+                const br = r * (0.06 + rand() * 0.05) * (1 - t * 0.4);
+                ctx.beginPath();
+                ctx.arc(bx, by, br, 0, Math.PI * 2);
+                ctx.fill();
+            }
+            ctx.restore();
+        }
+
+        // Food-approach family: a dashed ring at a fixed per-strategy hue, independent
+        // of the individual's own color_hue (which stays the mate-choice signal).
+        const FOOD_APPROACH_FAMILY_HUES = [200, 130, 20, 280, 50, 320];
+        const foodApproach = genome?.behavior?.food_approach ?? 0;
+        const familyHue = FOOD_APPROACH_FAMILY_HUES[foodApproach % FOOD_APPROACH_FAMILY_HUES.length];
+        ctx.save();
+        ctx.globalAlpha = 0.5;
+        ctx.strokeStyle = `hsla(${familyHue}, 75%, 65%, 0.9)`;
+        ctx.lineWidth = Math.max(1, r * 0.045);
+        ctx.setLineDash([r * 0.18, r * 0.12]);
+        ctx.beginPath();
+        ctx.arc(0, 0, r * 1.08, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
         ctx.restore();
     }
 

--- a/frontend/src/renderers/tank/TankTopDownRenderer.ts
+++ b/frontend/src/renderers/tank/TankTopDownRenderer.ts
@@ -944,10 +944,12 @@ export class TankTopDownRenderer implements Renderer {
             this.drawWobblyBlob(ctx, r, rand, wobble);
         }
 
+        // Lineage depth: older generations read slightly more saturated/vivid.
+        const genSatBoost = this.clamp((entity.generation ?? 0) / 25, 0, 1) * 18;
         const membrane = ctx.createRadialGradient(r * 0.25, -r * 0.25, r * 0.1, 0, 0, r * 1.1);
-        membrane.addColorStop(0, `hsla(${hueDeg}, 70%, 62%, 0.95)`);
-        membrane.addColorStop(0.6, `hsla(${hueDeg}, 60%, 48%, 0.88)`);
-        membrane.addColorStop(1, `hsla(${(hueDeg + 20) % 360}, 55%, 34%, 0.85)`);
+        membrane.addColorStop(0, `hsla(${hueDeg}, ${70 + genSatBoost}%, 62%, 0.95)`);
+        membrane.addColorStop(0.6, `hsla(${hueDeg}, ${60 + genSatBoost}%, 48%, 0.88)`);
+        membrane.addColorStop(1, `hsla(${(hueDeg + 20) % 360}, ${55 + genSatBoost}%, 34%, 0.85)`);
         ctx.fillStyle = membrane;
         ctx.fill();
 
@@ -1076,6 +1078,97 @@ export class TankTopDownRenderer implements Renderer {
         else this.drawWobblyBlob(ctx, r, rand, wobble * 0.8);
         ctx.stroke();
 
+        this.drawTraitCues(ctx, entity, r, hueDeg, rand);
+
+        ctx.restore();
+    }
+
+    /**
+     * Phenotype legibility cues for traits selection is currently acting on but
+     * that have no other visual presence (docs/EVOLVABILITY.md sec 3.5). Appended
+     * after the existing membrane/pattern/cilia/tail draws above so it consumes
+     * only the tail end of the seeded rand() sequence and leaves today's fish
+     * looking exactly as before. Read-only: reacts to genome_data, never mutates it.
+     */
+    private drawTraitCues(
+        ctx: CanvasRenderingContext2D,
+        entity: TankEntity,
+        r: number,
+        hueDeg: number,
+        rand: () => number
+    ) {
+        const genome = entity.genome_data;
+
+        // Aggression -> outer glow aura, red-shifted with intensity
+        const aggression = this.clamp(genome?.aggression ?? 0, 0, 1);
+        if (aggression > 0.05) {
+            const auraHue = hueDeg * (1 - aggression);
+            const auraR = r * (1.15 + aggression * 0.35);
+            ctx.save();
+            ctx.globalAlpha = 0.15 + aggression * 0.35;
+            const auraGrad = ctx.createRadialGradient(0, 0, r * 0.9, 0, 0, auraR);
+            auraGrad.addColorStop(0, `hsla(${auraHue}, 90%, 55%, 0.55)`);
+            auraGrad.addColorStop(1, `hsla(${auraHue}, 90%, 50%, 0)`);
+            ctx.fillStyle = auraGrad;
+            ctx.beginPath();
+            ctx.arc(0, 0, auraR, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
+        }
+
+        // Prediction_skill -> forward sensory cone (narrower & longer as skill rises)
+        const predictionSkill = this.clamp(genome?.prediction_skill ?? 0, 0, 1);
+        if (predictionSkill > 0.05) {
+            const coneLen = r * (0.8 + predictionSkill * 2.2);
+            const coneHalfAngle = 0.55 - predictionSkill * 0.28;
+            ctx.save();
+            ctx.globalAlpha = 0.1 + predictionSkill * 0.22;
+            const coneGrad = ctx.createLinearGradient(r * 0.9, 0, r * 0.9 + coneLen, 0);
+            coneGrad.addColorStop(0, `hsla(${(hueDeg + 200) % 360}, 80%, 75%, 0.8)`);
+            coneGrad.addColorStop(1, `hsla(${(hueDeg + 200) % 360}, 80%, 75%, 0)`);
+            ctx.fillStyle = coneGrad;
+            ctx.beginPath();
+            ctx.moveTo(r * 0.9, 0);
+            ctx.lineTo(r * 0.9 + coneLen, -Math.sin(coneHalfAngle) * coneLen);
+            ctx.lineTo(r * 0.9 + coneLen, Math.sin(coneHalfAngle) * coneLen);
+            ctx.closePath();
+            ctx.fill();
+            ctx.restore();
+        }
+
+        // Hunting_stamina -> trailing bubble stream behind the fish
+        const huntingStamina = this.clamp(genome?.hunting_stamina ?? 0, 0, 1);
+        if (huntingStamina > 0.05) {
+            const bubbleCount = Math.floor(huntingStamina * 5);
+            ctx.save();
+            ctx.globalAlpha = 0.35;
+            ctx.fillStyle = `hsla(${(hueDeg + 190) % 360}, 40%, 85%, 0.7)`;
+            for (let i = 0; i < bubbleCount; i++) {
+                const t = (i + 1) / (bubbleCount + 1);
+                const bx = -r * (1.3 + t * 2.1) + (rand() - 0.5) * r * 0.3;
+                const by = (rand() - 0.5) * r * 0.7 * (1 + t);
+                const br = r * (0.06 + rand() * 0.05) * (1 - t * 0.4);
+                ctx.beginPath();
+                ctx.arc(bx, by, br, 0, Math.PI * 2);
+                ctx.fill();
+            }
+            ctx.restore();
+        }
+
+        // Food-approach family: a dashed ring at a fixed per-strategy hue, independent
+        // of the individual's own color_hue (which stays the mate-choice signal).
+        const FOOD_APPROACH_FAMILY_HUES = [200, 130, 20, 280, 50, 320];
+        const foodApproach = genome?.behavior?.food_approach ?? 0;
+        const familyHue = FOOD_APPROACH_FAMILY_HUES[foodApproach % FOOD_APPROACH_FAMILY_HUES.length];
+        ctx.save();
+        ctx.globalAlpha = 0.5;
+        ctx.strokeStyle = `hsla(${familyHue}, 75%, 65%, 0.9)`;
+        ctx.lineWidth = Math.max(1, r * 0.045);
+        ctx.setLineDash([r * 0.18, r * 0.12]);
+        ctx.beginPath();
+        ctx.arc(0, 0, r * 1.08, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
         ctx.restore();
     }
 

--- a/frontend/src/renderers/tank/tankScene.test.ts
+++ b/frontend/src/renderers/tank/tankScene.test.ts
@@ -39,4 +39,35 @@ describe('buildTankScene', () => {
         const scene = buildTankScene({});
         expect(scene.entities).toHaveLength(0);
     });
+
+    it('should pass through generation and behavioral genome_data fields unchanged', () => {
+        // docs/EVOLVABILITY.md sec 3.5 phenotype legibility: TankTopDownRenderer's
+        // trait cues (aggression/prediction_skill/hunting_stamina/food_approach) read
+        // these straight from genome_data, so the scene builder must not drop or
+        // reshape them on the way from the raw snapshot to the TankEntity.
+        const genome_data = {
+            speed: 1, size: 1, color_hue: 0.5, template_id: 0, fin_size: 1, tail_size: 1,
+            body_aspect: 1, eye_size: 1, pattern_intensity: 0.5, pattern_type: 0,
+            aggression: 0.8, pursuit_aggression: 0.4, hunting_stamina: 0.6, prediction_skill: 0.3,
+            behavior: { food_approach: 2 },
+        };
+        const snapshot = {
+            entities: [
+                { id: 1, type: 'fish', x: 0, y: 0, width: 20, height: 20, generation: 7, genome_data },
+            ],
+        };
+
+        const scene = buildTankScene(snapshot);
+        const fish = scene.entities.find(e => e.id === 1);
+
+        expect(fish?.generation).toBe(7);
+        expect(fish?.genome_data).toEqual(genome_data);
+    });
+
+    it('should default generation to undefined when the snapshot omits it', () => {
+        const scene = buildTankScene({
+            entities: [{ id: 1, type: 'fish', x: 0, y: 0, width: 20, height: 20 }],
+        });
+        expect(scene.entities.find(e => e.id === 1)?.generation).toBeUndefined();
+    });
 });

--- a/frontend/src/renderers/tank/tankScene.ts
+++ b/frontend/src/renderers/tank/tankScene.ts
@@ -21,6 +21,7 @@ export interface TankEntity {
     energy?: number;
     food_type?: string;
     plant_type?: number;
+    generation?: number;
     genome_data?: FishGenomeData;
     plant_genome?: EntityData['genome'];
     size_multiplier?: number;
@@ -86,6 +87,7 @@ export function buildTankScene(snapshot: TankSceneSnapshot): TankScene {
                 energy: e.energy,
                 food_type: e.food_type,
                 plant_type: e.plant_type,
+                generation: e.generation,
                 genome_data: e.genome_data,
                 plant_genome: e.genome,
                 size_multiplier: e.size_multiplier,

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -14,6 +14,16 @@ export interface FishGenomeData {
     eye_size: number;
     pattern_intensity: number;
     pattern_type: number;
+    // Behavioral traits (heritable; see docs/EVOLVABILITY.md sec 3.5 phenotype legibility).
+    // Already present in the wire payload via Genome.to_dict() - optional here since
+    // fish without a resolved genome (or older cached snapshots) may omit them.
+    aggression?: number;
+    pursuit_aggression?: number;
+    hunting_stamina?: number;
+    prediction_skill?: number;
+    behavior?: {
+        food_approach?: number;
+    };
 }
 
 /**


### PR DESCRIPTION
Expose aggression, hunting_stamina, prediction_skill, and food_approach - already present in the live snapshot payload via Genome.to_dict() but never rendered - as deterministic visual cues in the topdown microbe renderer: a red-shifted glow aura for aggression, a forward sensory cone for prediction_skill, a trailing bubble stream for hunting_stamina, a dashed family ring for food_approach, and generation-linked membrane saturation. Cues are appended after the existing membrane/pattern/cilia/tail draws so today's fish keep their exact current look (no shift in the shared seeded rand() sequence).

Also fixes Canvas.tsx, which hardcoded the Tank world to side-view only and silently discarded the view-mode prop, making the topdown renderer (and these new cues) unreachable there even via the existing toggle. Petri stays topdown-only as before; Tank's default is still side-view, now selectable to topdown via the same override mechanism.

Zero touches to core/genetics, core/evolution, core/reproduction, or any config/benchmark - purely additive frontend rendering of genes already on the wire. agent_gate.py and pre_pr_gate.py pass clean; 45/45 frontend tests pass (2 added covering the new genome_data fields' passthrough). Verified live in-browser on both Tank and Petri worlds.

Evolved via /deliberate: proposal 2 (Claude Sonnet 5) merged with proposal 5 "Bioluminescent Phenotype Mapping Layer" (Gemini 3.5 Flash), sharpened through discussions 6/8/13/14, decided by unanimous ranked-choice vote (result #12, 3/3 first-round).