### PR TITLE
Finalize pre-PR gate naming and public validation docs

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,6 +3,12 @@
 This directory contains Architecture Decision Records (ADRs) documenting significant
 architectural choices made during development.
 
+> **Historical note:** ADRs are point-in-time records and are not updated after
+> acceptance. Verification notes in older ADRs may cite `fast_gate` — the
+> pre-rename name for [`tools/pre_pr_gate.py`](../../tools/pre_pr_gate.py). For the
+> current validation tier names and commands, see [CLAUDE.md](../../CLAUDE.md) or
+> [AGENTS.md](../../AGENTS.md), not historical ADR text.
+
 ## Index
 
 | ADR | Title | Status | Date |

--- a/tests/test_docs_agent_onboarding.py
+++ b/tests/test_docs_agent_onboarding.py
@@ -10,7 +10,10 @@ PUBLIC_AGENT_DOCS = [
     ROOT / "docs" / "AGENT_QUICKSTART.md",
     ROOT / "AGENTS.md",
     ROOT / "docs" / "AGENT_FIELD_GUIDE.md",
+    ROOT / "CLAUDE.md",
+    ROOT / "SETUP.md",
 ]
+ARCHIVED_ADR_DIR = ROOT / "docs" / "adr"
 
 
 def _workflow_job_names() -> set[str]:
@@ -61,6 +64,49 @@ def test_readme_references_smoke_and_pre_pr_gates():
     assert "tools/smoke_gate.py" in content, "README.md must reference tools/smoke_gate.py"
     assert "tools/agent_gate.py" in content, "README.md must reference tools/agent_gate.py"
     assert "tools/pre_pr_gate.py" in content, "README.md must reference tools/pre_pr_gate.py"
+
+
+def test_active_docs_never_reference_fast_gate():
+    """The renamed tools/fast_gate.py -> tools/pre_pr_gate.py must not resurface.
+
+    These are the live, forward-looking docs an agent reads to decide what command
+    to run; a stale mention here would send a vague-prompt agent looking for a
+    script that no longer exists. Historical mentions belong only in docs/adr/,
+    where test_archived_adr_fast_gate_mentions_are_marked_historical enforces they
+    stay clearly marked as such.
+    """
+    for doc_path in PUBLIC_AGENT_DOCS:
+        assert doc_path.exists(), f"{doc_path.relative_to(ROOT)} does not exist"
+        content = doc_path.read_text(encoding="utf-8")
+        assert "fast_gate" not in content, (
+            f"{doc_path.relative_to(ROOT)} references the retired tools/fast_gate.py. "
+            "Use tools/pre_pr_gate.py instead."
+        )
+
+
+def test_archived_adr_fast_gate_mentions_are_marked_historical():
+    """ADRs may cite the retired `fast_gate` name only as historical record.
+
+    If any ADR still mentions it, docs/adr/README.md must carry an explicit
+    historical-record note explaining the rename - so a reader (or an agent)
+    cannot mistake old verification notes for current instructions.
+    """
+    adr_files_with_mentions = [
+        path
+        for path in sorted(ARCHIVED_ADR_DIR.glob("*.md"))
+        if path.name != "README.md" and "fast_gate" in path.read_text(encoding="utf-8")
+    ]
+    if not adr_files_with_mentions:
+        return
+
+    readme_path = ARCHIVED_ADR_DIR / "README.md"
+    assert readme_path.exists(), "docs/adr/README.md does not exist"
+    readme_content = readme_path.read_text(encoding="utf-8")
+
+    assert "fast_gate" in readme_content and "historical" in readme_content.lower(), (
+        "docs/adr/README.md must clearly mark 'fast_gate' mentions as historical "
+        f"(found live references in: {[p.name for p in adr_files_with_mentions]})"
+    )
 
 
 def test_agents_references_agent_quickstart():

--- a/tests/test_gate_common.py
+++ b/tests/test_gate_common.py
@@ -1,0 +1,96 @@
+"""Tests for the pytest-output parsing helpers behind the pre-PR gate diagnostics.
+
+These are pure string-parsing functions exercised with literal sample text captured
+from real pytest/pytest-xdist runs, so they stay fast and deterministic - no
+subprocesses, no sleeps.
+"""
+
+from tools.gate_common import (
+    parse_banner_line,
+    parse_collected_counts,
+    parse_duration_line,
+    summarize_pytest_lines,
+)
+
+
+def test_parse_banner_line_extracts_inner_text():
+    line = "============================= test session starts =============================\n"
+    assert parse_banner_line(line) == "test session starts"
+
+
+def test_parse_banner_line_returns_none_for_non_banner():
+    assert parse_banner_line("tests/smoke/test_tank_mode_smoke.py .          [100%]") is None
+    assert parse_banner_line("16 workers [19 items]") is None
+
+
+def test_parse_collected_counts_with_deselection():
+    banner = "1901/2058 tests collected (157 deselected) in 1.49s"
+    assert parse_collected_counts(banner) == (2058, 1901, 157)
+
+
+def test_parse_collected_counts_without_deselection():
+    banner = "2058 tests collected in 1.49s"
+    assert parse_collected_counts(banner) == (2058, 2058, 0)
+
+
+def test_parse_collected_counts_singular_item():
+    banner = "1 test collected in 0.01s"
+    assert parse_collected_counts(banner) == (1, 1, 0)
+
+
+def test_parse_collected_counts_returns_none_for_result_banner():
+    # A final result banner ("N passed...") must not be mistaken for a collection banner.
+    assert parse_collected_counts("6 passed, 1 deselected in 0.95s") is None
+
+
+def test_parse_duration_line_extracts_seconds_and_module():
+    line = "0.29s call     tests/smoke/test_petri_mode_smoke.py::test_petri_mode_smoke"
+    assert parse_duration_line(line) == (0.29, "tests/smoke/test_petri_mode_smoke.py")
+
+
+def test_parse_duration_line_strips_class_and_param_suffix():
+    line = (
+        "0.09s setup    tests/test_config_hash.py::" "TestComputeConfigHash::test_changes_with_seed"
+    )
+    assert parse_duration_line(line) == (0.09, "tests/test_config_hash.py")
+
+
+def test_parse_duration_line_returns_none_for_non_duration_text():
+    assert parse_duration_line("============ slowest 25 durations ============") is None
+    assert parse_duration_line("(3 durations < 0.005s hidden.)") is None
+
+
+def test_summarize_pytest_lines_aggregates_durations_by_module():
+    lines = [
+        "============================= test session starts =============================",
+        "16 workers [19 items]",
+        "...................                                                      [100%]",
+        "============================ slowest 25 durations =============================",
+        "0.77s call     tests/smoke/test_petri_mode_smoke.py::test_petri_mode_smoke",
+        "0.13s setup    tests/smoke/test_petri_mode_smoke.py::test_petri_mode_smoke",
+        "0.19s call     tests/test_ecosystem_poker_records.py::test_a",
+        "0.02s call     tests/test_ecosystem_poker_records.py::test_b",
+        "============================= 19 passed in 5.16s ==============================",
+    ]
+
+    result_line, module_durations = summarize_pytest_lines(lines)
+
+    assert result_line == "19 passed in 5.16s"
+    assert module_durations == {
+        "tests/smoke/test_petri_mode_smoke.py": 0.90,
+        "tests/test_ecosystem_poker_records.py": 0.21,
+    }
+
+
+def test_summarize_pytest_lines_ignores_collect_only_style_banner():
+    # A --collect-only banner must never be mistaken for the run's final result line.
+    lines = ["1901/2058 tests collected (157 deselected) in 1.49s"]
+
+    result_line, module_durations = summarize_pytest_lines(lines)
+
+    assert result_line is None
+    assert module_durations == {}
+
+
+def test_summarize_pytest_lines_handles_no_matches():
+    assert summarize_pytest_lines([]) == (None, {})

--- a/tests/test_validation_tiers.py
+++ b/tests/test_validation_tiers.py
@@ -168,6 +168,19 @@ def test_pre_pr_gate_composes_smoke_gate_and_excludes_expensive_markers():
     assert "not slow and not integration and not manual" in source
 
 
+def test_pre_pr_gate_reports_collection_and_module_diagnostics():
+    """The broad suite must stay diagnosable: exact collected/deselected counts
+    (which `-n auto` does not print on its own) and a slowest-modules breakdown.
+    """
+    source = (ROOT / "tools" / "pre_pr_gate.py").read_text(encoding="utf-8")
+    assert "run_pytest_with_diagnostics" in source
+    assert "collect_only_args" in source
+
+    gate_common_source = (ROOT / "tools" / "gate_common.py").read_text(encoding="utf-8")
+    assert "def run_pytest_with_diagnostics(" in gate_common_source
+    assert "def collect_only_counts(" in gate_common_source
+
+
 def test_agent_gate_composes_smoke_gate_and_uses_curated_tests():
     source = (ROOT / "tools" / "agent_gate.py").read_text(encoding="utf-8")
 

--- a/tools/gate_common.py
+++ b/tools/gate_common.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from collections.abc import Sequence
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_BANNER_RE = re.compile(r"^=+\s*(.*?)\s*=+$")
+_COLLECTED_RE = re.compile(
+    r"^(?:(?P<selected>\d+)/(?P<total>\d+) tests collected \((?P<deselected>\d+) deselected\)"
+    r"|(?P<total_only>\d+) tests? collected) in [\d.]+s$"
+)
+_DURATION_RE = re.compile(r"^(\d+\.\d+)s\s+(?:setup|call|teardown)\s+(\S+)$")
 
 
 def print_gate_header(name: str, target: str, includes: str, excludes: str) -> None:
@@ -17,6 +25,132 @@ def print_gate_header(name: str, target: str, includes: str, excludes: str) -> N
     print(f"Includes: {includes}", flush=True)
     print(f"Excludes: {excludes}", flush=True)
     print("=" * 72, flush=True)
+
+
+def parse_banner_line(line: str) -> str | None:
+    """Extract the inner text of a pytest `===== ... =====` banner line, if any."""
+    match = _BANNER_RE.match(line.strip())
+    return match.group(1) if match else None
+
+
+def parse_collected_counts(banner_text: str) -> tuple[int, int, int] | None:
+    """Parse a `--collect-only` summary banner into (total, selected, deselected)."""
+    match = _COLLECTED_RE.match(banner_text)
+    if not match:
+        return None
+    if match.group("deselected") is not None:
+        return (
+            int(match.group("total")),
+            int(match.group("selected")),
+            int(match.group("deselected")),
+        )
+    total = int(match.group("total_only"))
+    return total, total, 0
+
+
+def parse_duration_line(line: str) -> tuple[float, str] | None:
+    """Parse a `--durations` report line into (seconds, module_path)."""
+    match = _DURATION_RE.match(line.strip())
+    if not match:
+        return None
+    seconds, nodeid = match.groups()
+    return float(seconds), nodeid.split("::", 1)[0]
+
+
+def summarize_pytest_lines(lines: Sequence[str]) -> tuple[str | None, dict[str, float]]:
+    """Reduce captured pytest stdout lines to a final result banner plus per-module
+    aggregate durations (summed from the `--durations` report, when present).
+    """
+    result_line: str | None = None
+    module_durations: dict[str, float] = {}
+    for line in lines:
+        banner = parse_banner_line(line)
+        if banner and " in " in banner and parse_collected_counts(banner) is None:
+            result_line = banner
+            continue
+        parsed_duration = parse_duration_line(line)
+        if parsed_duration is not None:
+            seconds, module = parsed_duration
+            module_durations[module] = module_durations.get(module, 0.0) + seconds
+    return result_line, module_durations
+
+
+def collect_only_counts(target_args: Sequence[str]) -> tuple[int, int, int] | None:
+    """Run a fast `--collect-only` pass to report exact (total, selected, deselected)
+    counts for a marker expression, without executing any tests. `-n auto` runs do
+    not print this breakdown themselves, so this is the only reliable source for it.
+    Returns None if the summary banner could not be parsed (purely diagnostic - never
+    raises, since it must not affect the gate's pass/fail result).
+    """
+    result = subprocess.run(
+        python_command("-m", "pytest", *target_args, "--collect-only", "-q"),
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    for line in reversed(result.stdout.splitlines()):
+        banner = parse_banner_line(line)
+        if banner is None:
+            continue
+        counts = parse_collected_counts(banner)
+        if counts is not None:
+            return counts
+    return None
+
+
+def run_pytest_with_diagnostics(
+    args: Sequence[str],
+    name: str,
+    collect_only_args: Sequence[str],
+    slow_module_count: int = 10,
+) -> bool:
+    """Run a pytest step like `run_steps`, plus a diagnostic summary: exact
+    collected/selected/deselected counts (via a fast --collect-only pre-pass) and
+    the slowest modules by aggregated sampled test duration. Diagnostics are purely
+    additive - a parsing miss only skips part of the summary, it never changes the
+    step's pass/fail result, which comes solely from the pytest exit code.
+    """
+    print(f"\n=== {name} ===", flush=True)
+
+    counts = collect_only_counts(collect_only_args)
+
+    process = subprocess.Popen(
+        list(args),
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    assert process.stdout is not None
+    captured = []
+    for line in process.stdout:
+        print(line, end="", flush=True)
+        captured.append(line.rstrip("\n"))
+    returncode = process.wait()
+
+    result_line, module_durations = summarize_pytest_lines(captured)
+
+    print("\n--- Test summary ---", flush=True)
+    if counts is not None:
+        total, selected, deselected = counts
+        print(
+            f"Collected: {total} items ({selected} selected, {deselected} deselected)", flush=True
+        )
+    if result_line:
+        print(f"Result: {result_line}", flush=True)
+    if module_durations:
+        ranked = sorted(module_durations.items(), key=lambda kv: kv[1], reverse=True)
+        print("Slowest modules (aggregated from sampled test durations):", flush=True)
+        for module, seconds in ranked[:slow_module_count]:
+            print(f"  {seconds:7.2f}s  {module}", flush=True)
+
+    if returncode != 0:
+        print(f"[FAIL] {name} failed with exit code {returncode}", flush=True)
+        return False
+    print(f"[PASS] {name}", flush=True)
+    return True
 
 
 def run_steps(steps: Sequence[tuple[list[str], str]]) -> bool:

--- a/tools/pre_pr_gate.py
+++ b/tools/pre_pr_gate.py
@@ -2,9 +2,23 @@
 """Run the contributor pre-PR validation gate."""
 
 try:
-    from tools.gate_common import exit_for_gate, print_gate_header, python_command, run_steps
+    from tools.gate_common import (
+        exit_for_gate,
+        print_gate_header,
+        python_command,
+        run_pytest_with_diagnostics,
+        run_steps,
+    )
 except ImportError:
-    from gate_common import exit_for_gate, print_gate_header, python_command, run_steps  # type: ignore[import-not-found,no-redef]
+    from gate_common import (  # type: ignore[import-not-found,no-redef]
+        exit_for_gate,
+        print_gate_header,
+        python_command,
+        run_pytest_with_diagnostics,
+        run_steps,
+    )
+
+_MARKER_EXPR = "not slow and not integration and not manual"
 
 
 def main() -> None:
@@ -14,24 +28,24 @@ def main() -> None:
         includes="the smoke gate, then the broad non-slow test suite run in parallel",
         excludes="integration/manual/slow tests, champion reproduction, and 5k/10k benchmarks",
     )
-    steps = [
-        (python_command("tools/smoke_gate.py"), "Tier 1: smoke gate"),
-        (
+    passed = run_steps([(python_command("tools/smoke_gate.py"), "Tier 1: smoke gate")])
+    if passed:
+        passed = run_pytest_with_diagnostics(
             python_command(
                 "-m",
                 "pytest",
                 "tests",
                 "-m",
-                "not slow and not integration and not manual",
+                _MARKER_EXPR,
                 "-n",
                 "auto",
                 "-q",
                 "--durations=25",
             ),
             "Tier 2: broad non-slow tests (parallel)",
-        ),
-    ]
-    exit_for_gate("PRE-PR", run_steps(steps))
+            collect_only_args=["tests", "-m", _MARKER_EXPR],
+        )
+    exit_for_gate("PRE-PR", passed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
tools/fast_gate.py was already removed in the prior rename (77e51aef); this closes the remaining gaps so the old name cannot drift back in unnoticed.

- Mark docs/adr/ as historical: add a note to docs/adr/README.md explaining that older ADRs' verification notes may cite `fast_gate` (the pre-rename name) and pointing to CLAUDE.md/AGENTS.md for current tier names.
- Add tests/test_docs_agent_onboarding.py::test_active_docs_never_reference_fast_gate (README, AGENTS.md, CLAUDE.md, SETUP.md, docs/AGENT_QUICKSTART.md, docs/AGENT_FIELD_GUIDE.md, docs/EVO_CONTRIBUTING.md) and ::test_archived_adr_fast_gate_mentions_are_marked_historical, which fails if an ADR mentions fast_gate without the README's historical marker present. (CI-job-name/README consistency was already covered by test_ci_job_names_in_readme_match_workflow_files.)
- Make tools/pre_pr_gate.py's broad-suite step diagnosable: add run_pytest_with_diagnostics to tools/gate_common.py, which reports exact collected/selected/deselected counts (via a fast --collect-only pre-pass, since `-n auto` prints only the post-filter item count) and the slowest modules by aggregated sampled test duration. Test selection, markers, and coverage are unchanged.
- Add tests/test_gate_common.py unit-testing the new parsing helpers, and a composition assertion in test_validation_tiers.py.

Commands run:
  python -m ruff check .                                            -> All checks passed!
  python tools/agent_gate.py                                        -> [PASS] AGENT gate passed.
  python -m pytest tests/test_docs_agent_onboarding.py tests/test_validation_tiers.py -q
                                                                     -> 16 passed
  python -m mypy core                                               -> Success: no issues found in 329 source files
  python -m mypy tools backend                                      -> Success: no issues found in 102 source files
  python tools/pre_pr_gate.py (full run)                            -> Collected: 2073 items (1916 selected, 157 deselected)
                                                                        Result: 1913 passed, 3 skipped, 24 warnings in 13.78s