### PR TITLE
Improve selection_response_10k: Evolving Disassortative Mating for Di…

### DIFF
--- a/core/genetics/expression.py
+++ b/core/genetics/expression.py
@@ -161,15 +161,30 @@ def calculate_mate_attraction(
             continue
 
         mate_value = float(get_trait_value(other_trait, default=0.0))
-        score = _normalized_similarity(
+        similarity = _normalized_similarity(
             mate_value,
             desired,
             spec.min_val,
             spec.max_val,
             circular=(trait_name == "color_hue"),
         )
+
+        if trait_name == "size_modifier":
+            p_sim_size = normalized_prefs.get("prefer_similar_size", 0.5)
+            alpha = (p_sim_size - 0.5) * 2.0  # ranges from -1.0 to 1.0
+            weight = abs(alpha)
+            score = similarity if alpha >= 0 else (1.0 - similarity)
+        elif trait_name == "color_hue":
+            p_diff_color = normalized_prefs.get("prefer_different_color", 0.5)
+            beta = (p_diff_color - 0.5) * 2.0  # ranges from -1.0 to 1.0
+            weight = abs(beta)
+            score = (1.0 - similarity) if beta >= 0 else similarity
+        else:
+            score = similarity
+            weight = 1.0
+
         scores.append(score)
-        weights.append(1.0)
+        weights.append(weight)
 
     pattern_weight = normalized_prefs.get("prefer_high_pattern_intensity", 0.5)
     if pattern_weight > 0.0 and has_trait_value(other_physical.pattern_intensity):

--- a/tests/test_genetics_expression.py
+++ b/tests/test_genetics_expression.py
@@ -67,6 +67,73 @@ class TestGenomeExpressionRefactor(unittest.TestCase):
         )
         self.assertAlmostEqual(score, expected)
 
+    def test_disassortative_mating_preferences(self):
+        """Verify that prefer_similar_size and prefer_different_color modulate attraction scores."""
+        from core.genetics.genome import Genome
+
+        # Create identical clones (except preference alleles)
+        g1 = Genome.random()
+        g2 = Genome.random()
+
+        # Make physical traits identical so similarity = 1.0
+        g2.physical = g1.physical
+
+        # Test 1: Assortative Mating for Size (prefer_similar_size = 1.0)
+        g1.behavioral.mate_preferences.value["prefer_similar_size"] = 1.0
+        g1.behavioral.mate_preferences.value["prefer_different_color"] = 0.5  # neutral
+        score_assortative = g1.calculate_mate_attraction(g2)
+
+        # Test 2: Disassortative Mating for Size (prefer_similar_size = 0.0)
+        g1.behavioral.mate_preferences.value["prefer_similar_size"] = 0.0
+        score_disassortative = g1.calculate_mate_attraction(g2)
+
+        # Because g1 and g2 are identical (size similarity is 1.0):
+        # - Assortative (prefer_similar_size = 1.0) gets size similarity = 1.0 with weight 1.0.
+        # - Disassortative (prefer_similar_size = 0.0) gets size similarity = 0.0 with weight 1.0.
+        # So score_assortative should be strictly greater than score_disassortative.
+        self.assertGreater(score_assortative, score_disassortative)
+
+        # Test 3: Assortative Mating for Color (prefer_different_color = 0.0)
+        g1.behavioral.mate_preferences.value["prefer_similar_size"] = 0.5  # neutral
+        g1.behavioral.mate_preferences.value["prefer_different_color"] = 0.0
+        score_color_assortative = g1.calculate_mate_attraction(g2)
+
+        # Test 4: Disassortative Mating for Color (prefer_different_color = 1.0)
+        g1.behavioral.mate_preferences.value["prefer_different_color"] = 1.0
+        score_color_disassortative = g1.calculate_mate_attraction(g2)
+
+        # Because g1 and g2 have identical colors (color similarity is 1.0):
+        # - Assortative (prefer_different_color = 0.0) gets color similarity = 1.0 with weight 1.0.
+        # - Disassortative (prefer_different_color = 1.0) gets color similarity = 0.0 with weight 1.0.
+        # So score_color_assortative should be strictly greater than score_color_disassortative.
+        self.assertGreater(score_color_assortative, score_color_disassortative)
+
+    def test_neutral_preferences_behavior(self):
+        """Verify that when preferences are 0.5, their weights are 0.0 (neutral)."""
+        from core.genetics.genome import Genome
+
+        g1 = Genome.random()
+        g2 = Genome.random()
+
+        # Set physical traits to be identical first
+        g2.physical = g1.physical
+
+        # Default preferences are 0.5
+        g1.behavioral.mate_preferences.value["prefer_similar_size"] = 0.5
+        g1.behavioral.mate_preferences.value["prefer_different_color"] = 0.5
+
+        # Calculate attraction with identical and different size/color
+        # Save original size
+        orig_size = g2.physical.size_modifier.value
+        g2.physical.size_modifier.value = g1.physical.size_modifier.value
+        score_similar = g1.calculate_mate_attraction(g2)
+
+        g2.physical.size_modifier.value = orig_size + 0.5  # different size
+        score_different = g1.calculate_mate_attraction(g2)
+
+        # Since weight of size modifier is 0.0, changing size should not affect attraction score!
+        self.assertAlmostEqual(score_similar, score_different)
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
…versity Maintenance

New score: 50.5734 (previous: 47.1171, +7.34%)
Algorithm: Evolving Disassortative Mating
Seeds: 42, 7, 123
Reproduction: python tools/run_selection_response_assay.py --out results.json

- Activate prefer_similar_size and prefer_different_color mate preference weights in calculate_mate_attraction (core/genetics/expression.py).
- Ensure default preference value of 0.5 resolves to weight=0 (neutral) to allow preferences to drift and respond to selection.
- Add comprehensive unit and regression tests in tests/test_genetics_expression.py to verify assortative, disassortative, and neutral preference scoring behaviors.