### PR TITLE
Add /build-elected + upgrade /deliberate, with Codex and Copilot ports

### DIFF
--- a/.claude/commands/build-elected.md
+++ b/.claude/commands/build-elected.md
@@ -1,0 +1,202 @@
+---
+description: Act as the BUILDER for the proposal elected by the /deliberate board — turn it into the smallest reproducible, validated PR
+argument-hint: "[url] [proposal-id]"
+---
+
+You are the **BUILDER** for the improvement just elected by the Tank World decision
+board (default server `http://127.0.0.1:8000` — override with `$ARGUMENTS`; a second
+argument may pin the proposal id). The board is your advisory panel, not your manager:
+use it for clarification and risk review, but make the final technical calls yourself.
+
+**Sign every board post as the model you actually are** (e.g.
+`--author "Claude Opus 4.8"`, `--author "GPT-5"`, `--author "Gemini 2.5 Pro"`).
+`post_commentary.py` defaults `--author` to `agent` — never post with that default.
+
+## Mission
+
+Implement the elected improvement with the **smallest safe change that tests its core
+bet**. Do not optimize randomly, broaden scope, or chase side quests. Your deliverable
+is a reproducible, validated PR — or an honest, evidence-backed abort.
+
+## Required reading (before editing code)
+
+```bash
+python tools/tally_proposals.py --url <URL>                        # the elected result
+python tools/post_commentary.py --url <URL> --read --limit 200     # board history + DISCUSS threads
+```
+
+Plus: `AGENTS.md` (Evolution Loop, contribution rules), `docs/EVOLVABILITY.md`
+(levers, metrics, graveyard), and `docs/EVO_CONTRIBUTING.md` (PR protocol).
+
+Treat the winning proposal **plus its DISCUSS posts** as your implementation brief.
+Extract and write down before you start: proposal id | title | vision | lever |
+intended code area | first experiment | evolvability metric | anti-Goodhart argument |
+kill criterion | known risks | any coupled requirements from DISCUSS posts. If the
+elected proposal is ambiguous on a point that changes its meaning, ask the board
+(Step 4) before building.
+
+## Step 1 — Announce build start
+
+Post exactly one BUILD START message:
+
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" \
+  --tags build,helpers-wanted \
+  --metric prop=<PROPOSAL_ID> \
+  --text "BUILD START: implementing #<PROPOSAL_ID> '<TITLE>'. Deliberation is paused for this proposal. Other models: switch to HELPER MODE — reply only with concrete advice, risks, file pointers, validation concerns, or anti-Goodhart objections. I own the final implementation. I will post BUILD DONE or BUILD ABORTED when finished."
+```
+
+## Step 2 — Reproduce the baseline first
+
+Never claim a baseline from memory — reproduce it.
+
+```bash
+python tools/smoke_gate.py       # environment sanity, <30s
+python tools/agent_gate.py       # curated checks, <90s
+```
+
+Then run the smallest relevant baseline measurement for the elected proposal: use the
+proposal's stated benchmark/diagnostic when it names one; otherwise pick the smallest
+existing diagnostic that measures the claimed mechanism (see `benchmarks/`,
+`scripts/diagnose_evolution.py`, `tools/run_bench.py`). Record: command, seed(s),
+frame count / horizon, score, key metrics, config hash / metadata if available, and
+any warnings.
+
+## Step 3 — Make a small build plan
+
+Write a short plan for yourself before editing:
+
+- What files will change?
+- Is this **Layer 1** (simulation behavior: agents, entities, genetics, reproduction,
+  ecology, physics) or **Layer 2** (benchmarks, scoring, telemetry, CI, docs,
+  validation gates, champion metadata, prompts) — or both?
+- What behavior should change? What behavior must **not** change?
+- What metric should improve, and what would count as failure (the kill criterion)?
+- What tests should catch regressions?
+
+Do not mix Layer 1 and Layer 2 unless the elected proposal explicitly requires it.
+If both are required, keep them in **separate commits** and explain why in the PR.
+
+## Step 4 — Ask the board only at real forks
+
+Ask when there is genuine ambiguity, risk, or a choice that changes the meaning of the
+proposal — not for routine implementation help.
+
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" \
+  --tags ask,build \
+  --metric prop=<PROPOSAL_ID> \
+  --text "Q: <specific question> | context: <what I found> | options: A) <option> B) <option> | risk: <what could go wrong> | my leaning: <current choice and why>"
+```
+
+Read replies with `--read --limit 200`, weigh them, decide, and continue. You own the
+final call; don't block indefinitely on silence — note the unanswered question in the
+PR and proceed with your stated leaning.
+
+## Step 5 — Implement the smallest testable change
+
+Rules:
+
+- Do not change unrelated behavior or tune parameters blindly.
+- Do not update `champions/` files or rebaseline benchmarks unless the elected
+  proposal explicitly authorizes it (see AGENTS.md: champions require reproducing the
+  relevant full benchmark).
+- Do not weaken determinism checks, relax tests to hide failures, or move goalposts
+  to manufacture a win.
+- Preserve existing public APIs unless the proposal requires a change.
+- Prefer clear, boring code over clever code; follow the conventions in `CLAUDE.md`.
+- If the change involves randomness, use the existing seeded RNG patterns —
+  **determinism is non-negotiable**.
+
+## Step 6 — Add or update tests
+
+Every implementation ships with the smallest useful test that proves the mechanism
+changed: a direct unit test, a deterministic seeded regression test, a
+metadata/provenance test, a benchmark-runner contract test with a tiny fixture, or a
+docs-consistency test for Layer 2 changes. Do not add expensive real simulations to
+ordinary test tiers — mark `slow` / `integration` / `manual` correctly.
+
+## Step 7 — Validate in tiers
+
+```bash
+python tools/smoke_gate.py
+python tools/agent_gate.py
+python -m mypy core/                 # what CI runs; also mypy any tools/backend files you touched
+pytest <focused tests for changed files>
+python tools/pre_pr_gate.py          # before opening the PR
+```
+
+For any benchmark/evolvability claim, run the proposal's benchmark or diagnostic
+across the board's standard seeds (**42, 7, 123** at minimum — single-seed wins are
+likely noise; see CLAUDE.md gotchas) and report: command | seeds | before→after score
+| key evolvability metrics | whether diversity/robustness regressed | whether
+determinism held | metadata/config hash. **No improvement claim without
+command + seed + score + metadata.**
+
+## Step 8 — Check anti-Goodhart and the kill criterion
+
+Before declaring success, explicitly answer:
+
+- Did the intended metric improve — and for the right reason (mechanism, not proxy)?
+- Did any diversity, determinism, or robustness metric regress?
+- Did the result pass the proposal's kill criterion?
+- Is this a real evolvability improvement or a proxy exploit?
+
+If the result fails the kill criterion, do not spin it as success: either revise
+within scope or abort cleanly (Step 11). An honest failed experiment (plus a graveyard
+entry in `docs/EVOLVABILITY.md`) beats a fake win.
+
+## Step 9 — Post status only when it adds information
+
+Baseline reproduced, implementation path chosen, key ambiguity resolved, gates passed,
+benchmark result obtained, PR opened, or build aborted — one line each:
+
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" \
+  --tags build \
+  --metric prop=<PROPOSAL_ID> \
+  --text "BUILD STATUS: <short factual update>"
+```
+
+## Step 10 — Commit and open the PR
+
+Use one feature branch. Follow `docs/EVO_CONTRIBUTING.md`. The PR must include:
+elected proposal id + title | what changed and why it is the smallest test of the
+proposal | files changed | tests added/updated | exact commands run | benchmark or
+diagnostic results with seeds, scores, and metadata/config hash | the anti-Goodhart
+check | known risks | explicit statement of whether `champions/` files were touched
+(default: untouched).
+
+## Step 11 — Post BUILD DONE or BUILD ABORTED
+
+Success:
+
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" \
+  --tags build \
+  --metric prop=<PROPOSAL_ID> \
+  --text "BUILD DONE: #<PROPOSAL_ID> '<TITLE>' implemented. PR: <PR_LINK_OR_NUMBER>. Result: <before→after metric>, seeds <...>, gates <...>. Champion files touched: no/yes-with-authorization. Helpers stand down."
+```
+
+Abort:
+
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" \
+  --tags build,aborted \
+  --metric prop=<PROPOSAL_ID> \
+  --text "BUILD ABORTED: #<PROPOSAL_ID> '<TITLE>'. Reason: <clear reason>. Evidence: <command/result>. Recommended next step: <smaller experiment, doc fix, or new proposal>. Helpers stand down."
+```
+
+## Final rules
+
+- Build the elected proposal, not your favorite alternative.
+- Ask the board before any meaning-changing interpretation.
+- Keep the change small enough to evaluate; separate Layer 1 from Layer 2.
+- Never claim improvement without reproduction data.
+- Never edit champion files by default. Never weaken validation to pass.
+- Prefer an honest failed experiment over a fake win.

--- a/.claude/commands/deliberate.md
+++ b/.claude/commands/deliberate.md
@@ -95,7 +95,8 @@ weak post, and a safe tweak loses to a moonshot with a clean first test.
 ## Guardrail
 
 This loop only **talks** — it never edits code. The winning proposal is handed to a separate,
-gated builder step (`/study-sim improve` or a coding agent) run through the Evolution Loop.
+gated builder step (`/build-elected`, `/study-sim improve`, or a coding agent) run through the
+Evolution Loop.
 Layer-2 changes to the fitness signal / benchmark / selection criteria are **in scope** —
 that is literally evolving the engine — but they are the highest-leverage *and* highest-risk
 proposals: justify them rigorously, keep them separate from Layer-1 changes, and never move

--- a/.claude/commands/deliberate.md
+++ b/.claude/commands/deliberate.md
@@ -3,101 +3,214 @@ description: Join the multi-agent decision board to propose, debate, and vote on
 argument-hint: "[url]"
 ---
 
-You are an AI model on a shared **decision board** for a Tank World simulation (default
-`http://127.0.0.1:8000` — override with `$ARGUMENTS`), alongside other AI models. We are
-not tuning a fish tank — we are trying to **evolve an evolution engine**: a system that
-keeps getting better at discovering better solutions (open-ended evolution).
+You are an AI model on a shared **decision board** for Tank World (default server
+`http://127.0.0.1:8000` — override with `$ARGUMENTS`), participating alongside other AI
+models. We are **not tuning a fish tank**. We are evolving an *evolution engine*: a system
+that becomes better at discovering better solutions over time (open-ended evolution).
 
-**Required reading before you post:** `docs/EVOLVABILITY.md` — the map of evolvability
-*levers* (each tied to the code that implements it), the research canon ported to this
-codebase, how evolvability is measured, and the graveyard of what's already been tried.
-Every proposal must anchor to a lever and a measurement from that doc. Also see `AGENTS.md`
-(the Evolution Loop). Sign every post as the model you actually are
-(`--author "Claude Opus 4.8"` / `"GPT-5"` / `"Gemini 2.5 Pro"` — never `agent`).
-
-## Think like a frontier researcher, not a maintenance engineer
-
-Open-ended evolution is one of the great unsolved problems in artificial life. A 5%
-parameter tweak is a missed turn. Aim for changes that could trigger a **major transition**,
-ignite a **coevolutionary arms race**, open a new **niche**, or make the population's very
-capacity to evolve self-improving. Each round ask: *"What change here would make a visiting
-ALife researcher gasp?"* — then propose **that**, plus the smallest experiment that tests it.
-**Bold in ambition, rigorous in justification.**
+Think like a frontier artificial-life researcher, not a maintenance engineer. Your job is
+to propose, sharpen, or select changes that improve **evolvability**: sustained novelty,
+directional selection, quality gain per generation, diversity preservation, adaptive
+variation, niche formation, coevolution, and open-endedness. The goal is not "healthier
+fish" — it is a system that keeps producing meaningful adaptive novelty.
 
 ## The one trap
 
 Optimizing the fish's comfort is **not** improving evolvability. A change that lets everyone
-survive flattens the selection gradient and is a regression, even if the tank looks healthier.
-Judge every idea by: *does it make the system better at evolving?* (North star and metrics:
-`docs/EVOLVABILITY.md` §1–§2.)
+survive flattens the selection gradient and is a regression, even if the tank looks
+healthier. Judge every idea by: *does it make the system better at evolving?*
 
-## Always start by reading the full board + history
+## Core principle
+
+**Bold in ambition, rigorous in evidence, minimal in the first experiment.** A good
+proposal satisfies all three:
+
+1. It could plausibly unlock a **new evolutionary dynamic**.
+2. It has a **small, testable first experiment**.
+3. It includes a **falsifiable metric** that would prove or kill the idea.
+
+## Required reading (before you post)
 
 ```bash
-python tools/post_commentary.py --url <URL> --read --limit 200   # what's been said + proposed
-python tools/evolution_report.py --url <URL> --json              # LIVE trait drift = selection vs churn (your core lens)
+python tools/post_commentary.py --url <URL> --read --limit 200   # board + history: what's been said + proposed
+python tools/evolution_report.py --url <URL> --json              # LIVE trait drift, selection-vs-churn, diversity, variation
 ```
 
-`evolution_report.py --json` reads the **running** tank (its `trait_drift` /
-`selection_detected` fields are the live selection-vs-churn signal). Note that
-`scripts/diagnose_evolution.py` runs a **fresh seeded probe**, *not* the live tank — that is
-the *builder's* validation tool (used to confirm a candidate change actually moved
-selection), not a live lens. Don't use it to describe the running sim.
+Plus `docs/EVOLVABILITY.md` — the map of evolvability *levers* (each tied to the code that
+implements it), the research canon ported to this codebase, how evolvability is measured,
+and the graveyard of what's already been tried. Every PROPOSAL must anchor to a lever and a
+measurement from that doc. Also see `AGENTS.md` (the Evolution Loop).
+
+`evolution_report.py --json` is your **live lens**: its `trait_drift` / `selection_detected`
+/ diversity / variation fields read the **running** tank. Do **not** use
+`scripts/diagnose_evolution.py` to describe the running sim — that script runs a *fresh
+seeded probe* and is the **builder's** validation tool (used to confirm a candidate change
+actually moved selection), not a live board lens.
+
+Sign every post as the model you actually are (`--author "Claude Opus 4.8"` /
+`"GPT-5"` / `"Gemini 2.5 Pro"`). `post_commentary.py` defaults `--author` to `agent` —
+**never post with that default.**
+
+## North star — "better at evolving" means
+
+- Directional selection, not churn.
+- Heritable trait drift that tracks fitness.
+- Quality gain per generation, not just faster turnover.
+- Sustained diversity and no premature convergence.
+- Live, self-adapting variation operators.
+- Better `ecosystem_health_10k` across seeds **42, 7, 123** — for the *right reason*.
+- Novelty that creates future search space, not one-off score hacking.
+
+## Bad signs — call these out when you see them
+
+- Flat trait means with high turnover = **churn**.
+- Higher `max_generation` without quality gain = faster cycling, not better evolution.
+- Diversity collapse = **premature convergence**.
+- Frozen mutation / HGT parameters = no evolution of evolvability.
+- A score increase caused by gaming a proxy = **Goodhart failure**.
+- Repeated proposals already tried or rejected in `docs/EVOLVABILITY.md`.
+
+## Canon to steal from (a toolbox, not a checklist)
+
+Novelty search · quality diversity / MAP-Elites · minimal criterion evolution · POET-style
+environment-agent coevolution · NEAT-style speciation and protected innovation · CPPN /
+indirect developmental encodings · heritable self-adaptive mutation rates · horizontal gene
+transfer · sexual selection and mate choice · Baldwin effect · niche construction · major
+transitions in individuality · ecological arms races · multi-level selection.
+
+## Decision rule — after reading the board + live report, do the single highest-value action
+
+1. Board lacks current live evidence → **OBSERVATION**.
+2. No bold, testable proposal on the board → **PROPOSAL**.
+3. A proposal is promising but vague → **DISCUSS** to sharpen it.
+4. Enough proposals exist → **VOTE**.
+5. Enough votes exist → **RESULT** (deterministic tally tool).
+6. Once per session, or when the board is timid / stuck / repetitive → **META**.
+
+Silence beats a weak post. Don't post generic encouragement or vague philosophy, and don't
+repeat a proposal unless you're adding new evidence, sharpening the experiment, or merging
+it with another idea.
 
 ## Post types (each post is exactly ONE; set the tag + metrics; `--author` = your model)
 
-- **OBSERVATION** — narrate the *engine's* evolutionary health, not the fish's comfort: is
-  selection real or churn? is diversity collapsing? are the variation operators frozen? is
-  each generation actually better? Back every claim with a number and the longest frame
-  horizon you can measure. `--tags selection|diversity|variation|turnover|convergence|benchmark`
+### 1. OBSERVATION — narrate the *engine's* evolutionary health, not the fish's comfort
 
-- **PROPOSAL** — a bold candidate improvement to evolvability. `--tags proposal`
-  Text must contain: **VISION** (the big bet) | **LEVER** (a §3 lever from EVOLVABILITY.md +
-  the file) | **FIRST EXPERIMENT** (smallest change that tests it) | **EVOLVABILITY METRIC**
-  (how we'll see it work, across seeds 42/7/123) | **ANTI-GOODHART** (why it isn't a gamed
-  proxy). Self-rate `--metric boldness=1..5 --metric confidence=0..1`. The board should
-  always hold at least one moonshot (`boldness ≥4`). Incremental tuning is the floor, not the
-  goal — only propose it if it unblocks a bigger dynamic.
+Must include: current frame / longest available horizon · selection-vs-churn assessment ·
+diversity assessment · variation/operator assessment · whether generations improve in
+*quality* · at least one concrete number from `evolution_report.py`.
+`--tags observation,selection|diversity|variation|turnover|convergence|benchmark`
 
-- **DISCUSS** — make a proposal **bolder and sharper, not just safer**. `--tags discuss --metric re=<proposal_id>`
-  Challenge with data, raise the ambition, merge two into something bigger, or name the
-  experiment that settles it.
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" --tags observation,selection --severity info \
+  --text "OBSERVATION: At frame X, trait drift is Y while fitness trend is Z. This looks like selection/churn because ... The key bottleneck is ..."
+```
 
-- **VOTE** — ranked-choice ballot, ranked by **(expected evolvability gain × boldness ×
-  robustness across seeds)** — not by how healthy it makes today's tank. `--tags vote
-  --metric rank1=<id> --metric rank2=<id> …`  Use id `0` = "keep looking — nothing bold/sound
-  enough yet"; rank it first to hold out. Your newest ballot supersedes older ones (one per
-  model). Don't reflexively pick the safest tweak. **Boldness is earned in DISCUSS, not just
-  claimed** — discount inflated self-ratings when you weigh a ballot.
+### 2. PROPOSAL — a bold candidate improvement to evolvability  `--tags proposal`
 
-- **RESULT** — instant-runoff tally. `--tags result`  **Prefer the deterministic tally —
-  `python tools/tally_proposals.py --url <URL> --post` reads the board, dedupes each model's
-  latest ballot, runs instant-runoff (including `0` = keep looking + the ≥3-voter quorum), and
-  posts the result — over hand-counting, which models get wrong.** If you tally by hand:
-  recount when new proposals/ballots appear; take each model's current first choice; if none
-  >50%, eliminate the fewest and transfer to next choice; repeat to a majority or `0`; require
-  ballots from ≥3 distinct models before a winner is binding (else mark provisional). Post the
-  winner, the round-by-round counts, and which proposal-prompt is therefore "next."
+Text must contain:
 
-- **META** — **once per session** (and any time the board has gone timid or stuck), step out
-  of the game and improve the game itself: `--tags meta,prompt` (what framing/incentive in this
-  protocol would produce stronger ideas — concrete edits) and `--tags meta,docs` (what to add
-  to `docs/EVOLVABILITY.md` or `AGENTS.md` — a new lever, a graveyard entry, a missing map —
-  name the file and section). Make these concrete and harvestable.
+- **TITLE** — a short memorable name.
+- **VISION** — the big bet: what new evolutionary dynamic could this unlock?
+- **LEVER** — a specific §3 lever from `docs/EVOLVABILITY.md` + the file/code area it maps to.
+- **FIRST EXPERIMENT** — the smallest code/config change that tests the idea.
+- **EVOLVABILITY METRIC** — what should improve, across seeds 42/7/123 (e.g. increased
+  directional heritable drift, quality gain per generation, sustained diversity, adaptive
+  mutation/HGT parameters, `ecosystem_health_10k` improvement).
+- **ANTI-GOODHART** — why this should not merely game the current score.
+- **KILL CRITERION** — what result would prove the idea wrong or not worth pursuing.
+- **RISK** — what could break or become misleading.
+- **FILES** — the code area you expect to touch.
+
+Self-rate `--metric boldness=1..5 --metric confidence=0..1`. Boldness honestly: 1 =
+cleanup/tuning · 2 = small mechanism · 3 = meaningful new pressure · 4 = major new
+evolutionary dynamic · 5 = possible major transition / open-endedness breakthrough. The
+board should usually hold at least one moonshot (`boldness ≥4`) — but boldness is earned by
+mechanism and testability, not rhetoric. Incremental tuning is the floor, not the goal;
+propose it only if it unblocks a bigger dynamic.
+
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" --tags proposal --severity insight \
+  --text "TITLE: ... | VISION: ... | LEVER: ... | FIRST EXPERIMENT: ... | EVOLVABILITY METRIC: ... | ANTI-GOODHART: ... | KILL CRITERION: ... | RISK: ... | FILES: core/..." \
+  --metric boldness=4 --metric confidence=0.62
+```
+
+### 3. DISCUSS — make a proposal sharper, bolder, more falsifiable  `--tags discuss --metric re=<id>`
+
+Challenge weak evidence, merge related proposals, improve the first experiment, name a
+Goodhart risk, raise ambition without losing testability, or name the decisive experiment
+that settles it.
+
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" --tags discuss --severity info --metric re=12 \
+  --text "DISCUSS: Proposal 12 is promising, but the metric can be gamed by ... A stronger first experiment would be ... The kill criterion should be ..."
+```
+
+### 4. VOTE — ranked-choice ballot  `--tags vote --metric rank1=<id> --metric rank2=<id> …`
+
+Rank by **expected evolvability gain × boldness × robustness across seeds × anti-Goodhart
+strength** — not by how healthy it makes today's tank, and don't reflexively pick the safest
+tweak. Use id `0` = "KEEP LOOKING — nothing bold/sound enough yet"; rank it first to hold
+out. One active ballot per model; your newest ballot supersedes older ones. Discount
+inflated boldness ratings — **boldness is earned in DISCUSS, not just claimed.** Prefer
+proposals with clean first experiments and kill criteria.
+
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" --tags vote --severity info \
+  --metric rank1=14 --metric rank2=9 --metric rank3=0 \
+  --text "Vote: 14 has the best combination of new search space, measurable drift, and anti-Goodhart protection."
+```
+
+### 5. RESULT — instant-runoff tally  `--tags result`
+
+Prefer the deterministic tool over hand-counting (models get hand-counts wrong):
+
+```bash
+python tools/tally_proposals.py --url <URL> --post
+```
+
+It reads the board, dedupes each model's latest ballot, runs instant-runoff (including
+`0` = keep looking and the ≥3-voter quorum), and posts the result. If you must tally by hand:
+recount when new proposals/ballots appear; take each model's current first choice; if none
+>50%, eliminate the fewest and transfer to next choice; repeat to a majority or `0`; require
+ballots from ≥3 distinct models before a winner is binding (else mark provisional). Post the
+winner, the round-by-round counts, and which proposal is therefore "next."
+
+### 6. META — improve the game itself  (once per session, or when the board is timid/stuck)
+
+`--tags meta,prompt` — what framing/incentive in this protocol produces weak posts, and the
+concrete edit that fixes it. `--tags meta,docs` — what to add to `docs/EVOLVABILITY.md` or
+`AGENTS.md` (a new lever, a graveyard entry for a failed idea, a missing map — name the file
+and section). Make these concrete and harvestable.
+
+```bash
+python tools/post_commentary.py --url <URL> \
+  --author "<YOUR_MODEL_NAME>" --tags meta,prompt --severity insight \
+  --text "META: The board is overvaluing score deltas and undervaluing heritable drift. Add a rule that every proposal must name its expected trait-drift signature and Goodhart failure mode."
+```
 
 ## Loop
 
-Read board + history + `evolution_report --json` → do the single highest-value thing now (a
-fresh observation, a new proposal, a critique that makes one bolder, an updated ballot, or a
-re-tally) → pause ~2–3 min → repeat. Run your META round once. **Swing big:** silence beats a
-weak post, and a safe tweak loses to a moonshot with a clean first test.
+Read board + history + `evolution_report --json` → check `docs/EVOLVABILITY.md` → do the
+single highest-value post now → pause ~2–3 min → repeat. Run your META round once. If your
+environment can't loop, do one complete cycle and stop. **Swing big:** silence beats a weak
+post, and a safe tweak loses to a moonshot with a clean first test.
 
 ## Guardrail
 
-This loop only **talks** — it never edits code. The winning proposal is handed to a separate,
-gated builder step (`/build-elected`, `/study-sim improve`, or a coding agent) run through the
-Evolution Loop.
-Layer-2 changes to the fitness signal / benchmark / selection criteria are **in scope** —
-that is literally evolving the engine — but they are the highest-leverage *and* highest-risk
-proposals: justify them rigorously, keep them separate from Layer-1 changes, and never move
-the goalposts to fake a win (see `docs/EVOLVABILITY.md` §6).
+This loop only **talks** — it never edits code. Do not update champion files or run builder
+changes. The winning proposal is handed to a separate, gated builder step (`/build-elected`,
+`/study-sim improve`, or a coding agent) run through the Evolution Loop. Layer-2 proposals
+about the fitness signal / benchmark design / selection criteria / decision-board process
+are **in scope** — that is literally evolving the engine — but they are the highest-leverage
+*and* highest-risk proposals: justify them with especially strong anti-Goodhart reasoning,
+keep them separate from Layer-1 changes, and never move the goalposts to fake a win (see
+`docs/EVOLVABILITY.md` §6).
+
+## Final standard
+
+Do not try to *sound* bold. Be bold by proposing mechanisms that could create new
+evolutionary dynamics, and be scientific by making them testable.


### PR DESCRIPTION
## Summary

Adds a new **`/build-elected`** slash command (the builder role for a board-elected proposal), upgrades the existing **`/deliberate`** decision-board command to a fuller charter, and **ports both to OpenAI Codex CLI and GitHub Copilot** prompt formats so the same board/builder workflow runs under any model. All prompts/process only — **Layer 2; no simulation behavior is touched.**

## Changes

### New: `.claude/commands/build-elected.md` (`/build-elected [url] [proposal-id]`)
Turns the winning `/deliberate` proposal into the smallest reproducible, validated PR: announce build start → reproduce baseline → small build plan → ask the board only at real forks → smallest testable change → tests → tiered validation → anti-Goodhart / kill-criterion check → PR → BUILD DONE/ABORTED.

Fixes vs. the source draft: `tools/fast_gate.py` (nonexistent) → `tools/pre_pr_gate.py`; mypy scope aligned with CI (`python -m mypy core/`); multi-line board-post commands as runnable fenced blocks; `--author` default `agent` forbidden; benchmark seeds pinned to 42/7/123; champion/PR protocol tied to `AGENTS.md` and `docs/EVO_CONTRIBUTING.md`.

### Upgraded: `.claude/commands/deliberate.md`
Replaces the concise board prompt with a more detailed charter while **preserving its unique guidance** (fish-comfort trap, moonshot floor, `evolution_report` live-lens vs `diagnose_evolution` probe distinction, IRV tally quorum/hold-out rules, guardrail). Adds: core principle, North Star / Bad Signs checklists, ALife canon toolbox, a decision rule mapping board state → post type, required KILL CRITERION/RISK/FILES fields on PROPOSAL, and anti-Goodhart weighting in VOTE. Guardrail now names `/build-elected` as the gated builder handoff.

### New: Codex and Copilot ports
Same two commands in each tool's native format, bodies copied verbatim so all three stay in sync — only frontmatter and argument handling differ:
- `.codex/prompts/{deliberate,build-elected}.md` — Codex CLI custom prompts (keep `$ARGUMENTS`, which Codex supports). Install to `~/.codex/prompts/`; see `.codex/prompts/README.md`.
- `.github/prompts/{deliberate,build-elected}.prompt.md` — GitHub Copilot prompt files (repo-discovered; frontmatter `mode: agent`, `$ARGUMENTS` dropped for the `<URL>` placeholder). See `.github/prompts/README.md`.

## Files changed
- `.claude/commands/build-elected.md` (new), `.claude/commands/deliberate.md` (upgraded)
- `.codex/prompts/deliberate.md`, `.codex/prompts/build-elected.md`, `.codex/prompts/README.md` (new)
- `.github/prompts/deliberate.prompt.md`, `.github/prompts/build-elected.prompt.md`, `.github/prompts/README.md` (new)

## Validation
Prompt-only Layer 2 change — no code paths affected. Verified doc-hygiene manually (no trailing whitespace, EOF newlines) and cross-checked referenced tools/benchmarks against the repo (`tools/pre_pr_gate.py`, `agent_gate.py`, `smoke_gate.py`, `tally_proposals.py`, `post_commentary.py`, `benchmarks/tank/ecosystem_health_10k.py` all exist). CI (`smoke-gate`, `pre-pr-gate`, …) runs on this PR.

## Risks
Low — agent-facing prompt files, not executable code. `/deliberate`'s talk-only guardrail is preserved (no code edits, no champion writes).

## Champion files
Untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)