### PR TITLE
Size soccer rewards to skill so tournaments select better players

### DIFF
--- a/backend/runner/commands/soccer.py
+++ b/backend/runner/commands/soccer.py
@@ -95,8 +95,8 @@ class SoccerCommands:
 
         if "reward_mode" in data:
             mode = str(data["reward_mode"]).strip().lower()
-            if mode not in {"pot_payout", "refill_to_max"}:
-                errors.append("reward_mode must be 'pot_payout' or 'refill_to_max'")
+            if mode not in {"pot_payout", "refill_to_max", "shaped_pot"}:
+                errors.append("reward_mode must be 'pot_payout', 'refill_to_max', or 'shaped_pot'")
             else:
                 soccer_cfg.reward_mode = mode
 

--- a/core/config/soccer.py
+++ b/core/config/soccer.py
@@ -27,9 +27,42 @@ SOCCER_LEAGUE_COOLDOWN_MATCHES = 2
 SOCCER_LEAGUE_ALLOW_REPEAT_WITHIN_MATCH = False
 SOCCER_LEAGUE_SELECTION_STRATEGY = "stratified"
 
+# ---------------------------------------------------------------------------
+# Reward architecture (single source of truth for soccer energy rewards).
+#
+# Soccer mirrors poker's economy: a competition whose reward is (a) proportional
+# to skill and (b) largely self-funded, so it feeds the reproduction economy
+# without acting as an unbounded energy faucet. Two surfaces read these:
+#   * SoccerSystem   - in-tank "practice" ball: sparse per-event energy.
+#   * league rewards - the tournament pot + shaped bonuses (see rewards.py).
+# The same shaped-reward function is used by the training benchmark's fitness,
+# so Layer-0 (tank selection) and Layer-1 (benchmark) optimize one objective.
+# ---------------------------------------------------------------------------
+
+# In-tank practice ball (SoccerSystem). Sparse events only, not per-frame.
+SOCCER_KICK_REWARD_ENERGY = 2.0  # Reward for a purposeful kick.
+SOCCER_GOAL_REWARD_ENERGY = 50.0  # Reward for scoring (dominant skill signal).
+
+# Shaped-reward weights: dense, per-contribution learning signal derived from
+# match telemetry. Keep in sync with the benchmark fitness (match_runner.py uses
+# calculate_shaped_bonuses with these same defaults).
+SOCCER_SHAPED_PROGRESS_WEIGHT = 0.5  # Energy per meter of ball progress toward goal.
+SOCCER_SHAPED_TOUCH_WEIGHT = 0.2  # Energy per ball touch.
+SOCCER_SHAPED_SHOT_WEIGHT = 1.0  # Energy per shot on target.
+SOCCER_SHAPED_PER_PLAYER_CAP = 10.0  # Cap on any single player's shaped bonus.
+SOCCER_SHAPED_TEAM_BONUS_CAP = 20.0  # Cap on shaped bonus summed across a team.
+
 # Reward model defaults.
-SOCCER_LEAGUE_ENTRY_FEE_ENERGY = 0.0
-SOCCER_LEAGUE_REWARD_MODE = "refill_to_max"
+# Entry fee mirrors the poker ante (POKER_ANTE_AMOUNT): every participant has
+# skin in the game, so the pot is real and losing a match costs energy. This
+# turns the tournament into a redistribution of energy toward skilled players
+# (selection pressure) instead of a flat handout to whoever wins.
+SOCCER_LEAGUE_ENTRY_FEE_ENERGY = 5.0
+# shaped_pot: winners split the (self-funded) pot AND all players receive
+# telemetry-shaped bonuses, so reward tracks contribution and margin rather
+# than the mere fact of being on the winning side (the old refill_to_max
+# rewarded a 1-0 fluke identically to a 10-0 rout and injected free energy).
+SOCCER_LEAGUE_REWARD_MODE = "shaped_pot"
 SOCCER_LEAGUE_REWARD_MULTIPLIER = 1.0
 
 # Reproduction reward defaults.

--- a/core/minigames/soccer/league_runtime.py
+++ b/core/minigames/soccer/league_runtime.py
@@ -234,6 +234,15 @@ class SoccerLeagueRuntime:
         collect_team_participants(home_team, "home", home_participants)
         collect_team_participants(away_team, "away", away_participants)
 
+        # Drop participants that cannot afford the entry fee. create_soccer_match_*
+        # raises if a fee is unaffordable, so filtering here keeps a nonzero fee from
+        # crashing the league tick. Bots report a zero-energy delta and never pay, so
+        # they pass the affordability check unconditionally.
+        entry_fee = float(getattr(self.config, "entry_fee_energy", 0.0) or 0.0)
+        if entry_fee > 0:
+            home_participants = [p for p in home_participants if self._can_afford_fee(p, entry_fee)]
+            away_participants = [p for p in away_participants if self._can_afford_fee(p, entry_fee)]
+
         # Balance teams to ensure equal numbers (and thus even total for evaluator)
         common_count = min(len(home_participants), len(away_participants))
         if common_count < 1:
@@ -268,6 +277,15 @@ class SoccerLeagueRuntime:
         self._active_match = setup.match
         self._active_setup = setup
         self._current_league_match = league_match
+
+    @staticmethod
+    def _can_afford_fee(entity: Any, entry_fee: float) -> bool:
+        """Whether an entity can pay the entry fee (mirrors evaluator's guard)."""
+        from core.minigames.soccer.selection import get_entity_energy
+
+        if not hasattr(entity, "modify_energy"):
+            return False
+        return get_entity_energy(entity) > entry_fee
 
     def _finalize_active_match(self, teams: dict[str, Any]) -> None:
         if self._active_match is None or self._active_setup is None:

--- a/core/minigames/soccer/rewards.py
+++ b/core/minigames/soccer/rewards.py
@@ -13,6 +13,13 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
+from core.config.soccer import (
+    SOCCER_SHAPED_PER_PLAYER_CAP,
+    SOCCER_SHAPED_PROGRESS_WEIGHT,
+    SOCCER_SHAPED_SHOT_WEIGHT,
+    SOCCER_SHAPED_TEAM_BONUS_CAP,
+    SOCCER_SHAPED_TOUCH_WEIGHT,
+)
 from core.minigames.soccer.selection import get_entity_id
 
 if TYPE_CHECKING:
@@ -104,10 +111,10 @@ def apply_soccer_rewards(
 def calculate_shaped_bonuses(
     telemetry: SoccerTelemetry,
     *,
-    progress_weight: float = 0.5,
-    touch_weight: float = 0.2,
-    shot_weight: float = 1.0,
-    max_bonus_per_player: float = 10.0,
+    progress_weight: float = SOCCER_SHAPED_PROGRESS_WEIGHT,
+    touch_weight: float = SOCCER_SHAPED_TOUCH_WEIGHT,
+    shot_weight: float = SOCCER_SHAPED_SHOT_WEIGHT,
+    max_bonus_per_player: float = SOCCER_SHAPED_PER_PLAYER_CAP,
 ) -> dict[str, float]:
     """Calculate shaped bonuses from telemetry for evolution fitness.
 
@@ -164,10 +171,10 @@ def apply_shaped_soccer_rewards(
     *,
     entry_fees: Mapping[int, float] | None = None,
     reward_multiplier: float = 1.0,
-    shaped_bonus_cap: float = 20.0,
-    progress_weight: float = 0.5,
-    touch_weight: float = 0.2,
-    shot_weight: float = 1.0,
+    shaped_bonus_cap: float = SOCCER_SHAPED_TEAM_BONUS_CAP,
+    progress_weight: float = SOCCER_SHAPED_PROGRESS_WEIGHT,
+    touch_weight: float = SOCCER_SHAPED_TOUCH_WEIGHT,
+    shot_weight: float = SOCCER_SHAPED_SHOT_WEIGHT,
     reward_source: str = "soccer_shaped",
     draw_refund_source: str = "soccer_draw_refund",
 ) -> dict[str, float]:

--- a/core/systems/soccer_system.py
+++ b/core/systems/soccer_system.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from core.config.soccer import SOCCER_GOAL_REWARD_ENERGY, SOCCER_KICK_REWARD_ENERGY
 from core.energy.energy_utils import apply_energy_delta
 from core.systems.base import BaseSystem, SystemResult
 
@@ -178,12 +179,16 @@ class SoccerSystem(BaseSystem):
             # Award small energy reward for kicking via proper channel
             # Fish implements modify_energy(), no fallback needed
             try:
-                apply_energy_delta(kicker, 2.0, source="soccer_kick")
+                apply_energy_delta(kicker, SOCCER_KICK_REWARD_ENERGY, source="soccer_kick")
             except AttributeError:
                 pass
 
             # Set visual effect for HUD display
-            kicker.soccer_effect_state = {"type": "kick", "amount": 2.0, "timer": 10}  # type: ignore[attr-defined]
+            kicker.soccer_effect_state = {  # type: ignore[attr-defined]
+                "type": "kick",
+                "amount": SOCCER_KICK_REWARD_ENERGY,
+                "timer": 10,
+            }
 
     def _handle_goal_scored(self, goal_event) -> None:
         """Handle a goal being scored and award energy.
@@ -216,7 +221,7 @@ class SoccerSystem(BaseSystem):
             if fish.fish_id == goal_event.scorer_id:
                 # Award big energy reward for scoring via proper channel
                 # Fish implements modify_energy(), no fallback needed
-                reward = 50.0
+                reward = SOCCER_GOAL_REWARD_ENERGY
                 try:
                     apply_energy_delta(fish, reward, source="soccer_goal")
                 except AttributeError:

--- a/tests/test_soccer_league_runtime.py
+++ b/tests/test_soccer_league_runtime.py
@@ -230,6 +230,50 @@ def test_smoke_league_produces_match_outcome():
     assert match_completed, "Expected at least one match outcome within 50 frames"
 
 
+def test_default_config_is_self_funded_and_shaped():
+    """The shipped league defaults reward skill via a self-funded shaped pot."""
+    config = SoccerConfig()
+    assert config.reward_mode == "shaped_pot"
+    assert config.entry_fee_energy > 0.0
+
+
+def test_entry_fee_filters_unaffordable_participants_without_crashing():
+    """A nonzero entry fee must not raise when some rostered fish are too poor.
+
+    Poor fish are dropped before match creation; the match still forms and
+    completes from the affording fish, and the league records an outcome.
+    """
+    config = SoccerConfig(
+        enabled=True,
+        match_every_frames=1,
+        duration_frames=10,
+        team_size=0,
+        num_players=6,  # derives team_size = 3
+        entry_fee_energy=5.0,
+        reward_mode="shaped_pot",
+        cycles_per_frame=1,
+    )
+    runtime = SoccerLeagueRuntime(config)
+
+    # 6 wealthy fish (can afford the fee) + 4 broke fish (cannot).
+    wealthy = [DummyFish(i, 100.0) for i in range(6)]
+    broke = [DummyFish(100 + i, 1.0) for i in range(4)]
+    world = DummyWorld(wealthy + broke)
+
+    match_completed = False
+    for cycle in range(50):
+        # Must never raise even though broke fish are on the roster.
+        runtime.tick(world, seed_base=42, cycle=cycle)
+        if runtime.drain_events():
+            match_completed = True
+            break
+
+    assert match_completed, "Expected a match to complete despite unaffordable fish on roster"
+    # Broke fish never paid the fee (they were filtered out before match creation).
+    for fish in broke:
+        assert fish.energy == 1.0
+
+
 def test_leaderboard_sorting(base_config):
     """Test leaderboard is sorted by Points then GD."""
     runtime = SoccerLeagueRuntime(base_config)


### PR DESCRIPTION
The soccer economy had three disjoint reward surfaces with the tournament (league) one decoupled from skill: the league defaulted to refill_to_max with a zero entry fee, so any winning team was topped up to max energy regardless of margin or contribution — a flat, skill-blind energy faucet that paid a 1-0 fluke identically to a 10-0 rout. Meanwhile the training benchmark's fitness already rewarded goals, possession, and telemetry-shaped contribution. Layer-0 tank selection and Layer-1 benchmark fitness were thus optimizing different objectives.

Align them on poker's model (a self-funded, zero-sum competition whose reward tracks skill and feeds the reproduction economy):

- League default reward_mode -> shaped_pot: winners split a self-funded pot AND all players receive telemetry-shaped bonuses (ball progress, touches, shots), so reward tracks contribution and margin, not just being on the winning side. The shaped-reward function is the same one the benchmark fitness uses, unifying the two objectives.
- Add a modest league entry fee (mirrors POKER_ANTE_AMOUNT) so the pot is real and losing costs energy: the tournament redistributes energy toward skilled players instead of handing out free energy.
- Harden league_runtime._start_match to drop participants that cannot afford the entry fee before match creation, so a nonzero fee never raises during a tick; bots (zero-energy delta) always pass.
- Centralize all soccer reward magnitudes (kick/goal/shaped weights and caps) in core/config/soccer.py as the single source of truth; wire SoccerSystem and rewards.py to them. Values are unchanged, so the in-tank practice ball and the soccer benchmark score are byte-for-byte identical (training_5k determinism verified: 13.6867 on both trees).
- Accept 'shaped_pot' in the backend set_soccer_league_config validator, which previously rejected the mode that is now the default.

The league is disabled in every guarded tank benchmark (ecosystem_health, survival) and the soccer benchmark uses the match runner, not the league, so no champion is affected.


Claude-Session: https://claude.ai/code/session_01E36aRbk3qKrTVzEFunt9YA