### PR TITLE
docs: rewrite README for accuracy and clearer messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,26 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-Tank World is an open-source research framework where AI agents autonomously conduct artificial life experiments and commit their improvements back to the codebase. The simulation runs, collects data, an AI analyzes the results, improves the underlying algorithms, and opens a pull request. CI validates the improvement. If it passes, the change merges and becomes the new baseline for the next cycle.
+Tank World is an open-source research framework where AI agents autonomously conduct artificial life experiments and commit their improvements back to the codebase. A simulation runs, an AI analyzes the telemetry, improves the underlying algorithms, and opens a pull request. CI re-runs the benchmarks to validate the claim. If it passes, the change merges and becomes the new baseline for the next cycle.
 
-The result: a continuously improving evolutionary system where **PRs are mutations, CI is natural selection, and Git history is the phylogenetic tree**.
+The result: a continuously improving evolutionary system where **PRs are mutations, CI is natural selection, and Git history is the phylogenetic tree**. This is not a metaphor — it is the literal mechanism by which the project develops.
 
-> **[Full Vision](docs/VISION.md)** | **[Architecture](docs/ARCHITECTURE.md)** | **[Agent Guide](AGENTS.md)** | **[Roadmap](docs/ROADMAP.md)**
+> **[Full Vision](docs/VISION.md)** | **[Architecture](docs/ARCHITECTURE.md)** | **[Agent Guide](AGENTS.md)** | **[Roadmap](docs/ROADMAP.md)** | **[Evolvability](docs/EVOLVABILITY.md)**
 
 ---
 
 ## Why This Matters
 
-Most AI-assisted development treats the AI as a tool that responds to human requests. Tank World inverts this: the AI is the primary researcher, running experiments 24/7, and the human reviews the results. The framework is designed so that:
+Most AI-assisted development treats the AI as a tool that responds to human requests. Tank World inverts this: the AI is the primary researcher, running experiments continuously, and the human reviews the results. The framework is designed so that:
 
 - **AI agents discover improvements** by analyzing simulation data and proposing code changes
-- **Benchmarks enforce rigor** with deterministic seeds and reproducible results
+- **Benchmarks enforce rigor** with deterministic seeds and independently reproducible results
 - **CI gates prevent regressions** automatically before any merge
 - **Every merged PR raises the floor** for the next agent session
 
 This creates compounding returns. Each improvement is inherited by future agents who build on top of it. Over time, the system gets better at getting better.
+
+The goal is not a comfortable fish tank. It is **evolvability**: a system that keeps producing meaningful adaptive novelty — sustained selection pressure, diversity preservation, niche formation, open-endedness. A change that makes every fish survive flattens the selection gradient and counts as a regression, even if the tank looks healthier. [docs/EVOLVABILITY.md](docs/EVOLVABILITY.md) maps these levers to code and records which ideas have already been tried and buried.
 
 ---
 
@@ -52,7 +54,7 @@ flowchart TB
 
 ### Layer 0: In-World Evolution
 
-Fish compete for survival using 58 parametrizable behavior algorithms. Natural selection optimizes parameters over generations. Better strategies mean more reproduction and longer survival.
+Fish compete for survival using 58 parametrizable behavior algorithms encoded in their genomes. Natural selection tunes parameters and shifts algorithm prevalence over generations. Better strategies mean more reproduction and longer survival.
 
 **Output**: Champion genomes, performance telemetry, population dynamics data.
 
@@ -64,7 +66,7 @@ AI agents run deterministic benchmarks, compare results against the Best Known S
 
 ### Layer 2: Meta-Evolution
 
-AI agents improve the benchmarks, fitness functions, agent instructions, and CI workflows that Layer 1 uses. This is evolution of the evolutionary process itself.
+AI agents improve the benchmarks, fitness functions, agent instructions, and CI workflows that Layer 1 uses. This is evolution of the evolutionary process itself — and it is already running: the agent workflows in this repo (validation gates, decision-board prompts, field guides) were largely written and refined by agents.
 
 **Output**: Better ways of discovering improvements.
 
@@ -92,16 +94,33 @@ A fish tank ecosystem with real evolutionary dynamics:
 - **58 behavior algorithms** across food seeking, predator avoidance, schooling, energy management, territory, and poker strategies
 - **Predator-prey dynamics** with crabs hunting fish
 - **Fractal L-system plants** with genetic evolution and nectar production
-- **Fish poker** where fish play Texas Hold'em against each other and plants for energy
+- **Fish poker** where fish play Texas Hold'em against each other and plants for energy stakes, on a full poker engine
+- **Fish soccer** as a skill minigame with its own training benchmarks and tournaments
 - **Day/night cycles** affecting behavior and visibility
 - **Genetic inheritance** of physical traits, visual traits, behavior algorithms, and mate preferences
-- **Real-time web UI** built with React + FastAPI + WebSocket, rendering at 30 FPS
+- **Multiple worlds**: the same agents, genetics, and energy model render as a fish tank or a Petri dish of microbes
+- **Real-time web UI** built with React 19 + FastAPI + WebSocket, rendering at 30 FPS
 
 The visualization is deliberately engaging. Entertainment drives participation: if people enjoy watching their tank, they'll run longer experiments and contribute more compute.
 
-### AI Oceanographer (Planned)
+### Watch the Watchers: Live Sim Observability
 
-A future narration layer will explain what's happening in plain language, like an AI Jacques Cousteau providing commentary on the evolutionary dynamics unfolding in your tank.
+The UI has an **Insights feed** where AI agents post commentary on the evolutionary dynamics as they unfold — an early, working version of the planned "AI oceanographer" narration layer:
+
+```bash
+# Structured evolution-health report on a running sim (read-only)
+python tools/evolution_report.py --url http://127.0.0.1:8000 --json
+
+# Post an observation to the UI's Insights feed
+python tools/post_commentary.py --url http://127.0.0.1:8000 \
+    --text "Selection on pursuit_aggression: +12% over 40k frames" \
+    --severity insight --tags selection
+
+# Read the feed back
+python tools/post_commentary.py --read --limit 15
+```
+
+The `/observe-sim` and `/study-sim` agent skills drive these tools automatically.
 
 ---
 
@@ -132,15 +151,15 @@ cd frontend && npm ci && cd ..
 
 ### Run the Web UI
 
-You can launch both the FastAPI backend and the Vite React frontend with a single command:
+Launch both the FastAPI backend and the Vite React frontend with a single command:
 
 ```bash
 python start.py
 ```
 
-This will run pre-flight checks, install frontend dependencies if missing, start both servers in parallel with colored output logging, open http://localhost:3000 in your default browser, and cleanly shut down all processes upon pressing `Ctrl+C`.
+This runs pre-flight checks, installs frontend dependencies if missing, starts both servers in parallel with colored log output, opens http://localhost:3000 in your browser, and shuts everything down cleanly on `Ctrl+C`.
 
-*(Alternatively, you can run them in separate terminals: run `python main.py` from the root, and run `cd frontend && npm run dev` to start the frontend).*
+*(Alternatively, run them in separate terminals: `python main.py` from the root for the backend, and `cd frontend && npm run dev` for the frontend.)*
 
 ### Run Headless (10-300x Faster)
 
@@ -164,30 +183,23 @@ python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42 --out results
 ### Run the Demo
 
 ```bash
-# One command: short tank sim + replay + soccer episode + 3k benchmark bundle
+# One command: short tank sim + replay + soccer episode + benchmark bundle
 python tools/demo.py --seed 42
 ```
 
-That creates `runs/demo_<timestamp>/` with:
+That creates `runs/demo_<timestamp>/` with a `manifest.json` (seed, parameters, git metadata, headline scores), a step-level `demo.log`, a human-readable `summary.md`, plus `tank_results.json`, `tank.replay.jsonl`, `soccer_episode.json`, and `benchmark_result.json`.
 
-- `manifest.json` containing seed, parameters, git metadata, and headline scores
-- `demo.log` with step-level execution notes
-- `summary.md` with a quick human-readable recap
-- `tank_results.json` and `tank.replay.jsonl`
-- `soccer_episode.json`
-- `benchmark_result.json`
-
-See [SETUP.md](SETUP.md) for detailed setup instructions and troubleshooting.
+See [SETUP.md](SETUP.md) for detailed setup and troubleshooting.
 
 ---
 
 ## The Evolution Loop
 
-This is the core workflow that makes Tank World a self-improving system:
+This is the core workflow that makes Tank World self-improving:
 
 ```
-1. RUN benchmark with deterministic seed
-2. COMPARE results against Best Known Solutions registry
+1. RUN benchmark with a deterministic seed
+2. COMPARE results against the Best Known Solutions registry
 3. IMPROVE code based on data analysis
 4. VALIDATE with tests and benchmarks
 5. OPEN PR with reproducible evidence
@@ -201,15 +213,17 @@ This is the core workflow that makes Tank World a self-improving system:
 The repository maintains a formal registry of champion solutions:
 
 ```
-benchmarks/          # Evaluation harnesses (deterministic, reproducible)
-  tank/              # Tank benchmarks (for example survival_5k, ecosystem_health_10k)
-  soccer/            # Soccer benchmarks (for example training_3k, training_5k)
-champions/           # Best-known solutions per benchmark
+benchmarks/          # Deterministic, reproducible evaluation harnesses
+  tank/              # survival_5k, ecosystem_health_10k, selection_response_10k
+  soccer/            # training_3k, training_5k
+champions/           # Best-known solution snapshots per benchmark
   tank/              # Current tank champions
   soccer/            # Current soccer champions
 ```
 
-Champion files are benchmark result snapshots. They store the benchmark id, seed, score, metadata payload, and timestamp; when updated through the validation tooling they can also keep a nested `champion` record plus history. Anyone can verify a claimed result by re-running the benchmark and comparing the score and metadata.
+Champion files are benchmark result snapshots: they store the benchmark id, seed, score, metadata payload, and timestamp; when updated through the validation tooling they can also keep a nested `champion` record plus history. Anyone can verify a claimed result by re-running the benchmark and comparing the score and metadata.
+
+The tank suite is intentionally more than a survival timer. `ecosystem_health_10k` rewards generation turnover, while `selection_response_10k` is a frozen assay that measures directional heritable trait response — catching the failure mode where a population churns generations fast but its traits stay flat or collapse. Optimizing for survival alone will not win it.
 
 ### Evolutionary PR Protocol
 
@@ -218,19 +232,35 @@ When you discover an improvement (human or AI):
 1. Run the benchmark: `python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42 --out results.json`
 2. Compare vs champion: `python tools/validate_improvement.py results.json champions/tank/survival_5k.json`
 3. If better, report the command, seed, score, metadata, and code diff in the PR.
-4. Do not edit `champions/**/*.json` or use champion-update tooling unless a maintainer or the task prompt explicitly authorizes that scope.
-5. Open a PR with benchmark evidence; CI re-runs the relevant checks before merge
+4. Do not edit `champions/**/*.json` or use champion-update tooling unless a maintainer or task prompt explicitly authorizes that scope.
+5. Open a PR with benchmark evidence; CI re-runs the relevant checks before merge.
 
 See [docs/EVO_CONTRIBUTING.md](docs/EVO_CONTRIBUTING.md) for the complete protocol.
 
 ---
 
-## AI Code Evolution
+## AI-Driven Development
 
-AI agents can autonomously improve the simulation:
+Tank World is built for AI-first development, and several agent workflows are wired directly into the repo.
+
+### Multi-Model Deliberation Board
+
+Rather than a single agent guessing at the next improvement, Tank World runs a **decision board** where multiple AI models (for example Claude, GPT, and Gemini) propose, debate, and vote on the next evolvability experiment — then a builder agent turns the elected proposal into the smallest reproducible, validated PR.
 
 ```bash
-# 1. Run simulation and export data
+# Join the board: propose, sharpen, and vote on the next evolvability change
+/deliberate
+
+# Build the elected proposal as a minimal, validated PR
+/build-elected
+```
+
+Every proposal must be **bold in ambition, rigorous in evidence, minimal in the first experiment** — a plausible new evolutionary dynamic, a small testable first experiment, and a falsifiable metric that would prove or kill the idea.
+
+### Autonomous Code-Evolution Agent
+
+```bash
+# 1. Run a simulation and export data
 python main.py --headless --max-frames 30000 --export-stats results.json --seed 42
 
 # 2. Install optional AI provider dependencies
@@ -239,58 +269,37 @@ pip install -e .[ai]
 # 3. AI agent analyzes results, identifies underperformers, and improves code
 python scripts/ai_code_evolution_agent.py results.json --provider anthropic --validate
 
-# 4. Run AI tournament to evaluate poker strategies
+# 4. Run an AI tournament to evaluate poker strategies
 python scripts/run_ai_tournament.py --write-back
 ```
 
-The AI code evolution agent currently supports `anthropic` and `openai` providers and expects the matching API key in `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`. It reads simulation data, identifies the worst-performing algorithms, reads their source code, implements improvements, validates with benchmarks, and creates a Git branch with the changes. See [AGENTS.md](AGENTS.md) for the complete AI agent guide.
+The code-evolution agent supports the `anthropic` and `openai` providers and expects the matching API key in `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`. It reads simulation data, identifies the worst-performing algorithms, reads their source, implements improvements, validates with benchmarks, and creates a Git branch. See [AGENTS.md](AGENTS.md) for the complete agent guide.
 
----
+### Getting Started as an Agent
 
-## Agentic Development with Claude Code
+The repository ships infrastructure for productive agentic sessions:
 
-Tank World is designed for AI-first development. The repository includes infrastructure for productive agentic sessions:
-
-- **[CLAUDE.md](CLAUDE.md)**: Project intelligence file loaded automatically by Claude Code
-- **[AGENTS.md](AGENTS.md)**: Comprehensive guide for AI agents entering the evolution loop
-- **[docs/AGENT_FIELD_GUIDE.md](docs/AGENT_FIELD_GUIDE.md)**: Foolproof on-ramp for agents of any capability — decision tree, difficulty-rated starter tasks, and copy-paste recipes
-- **[docs/AGENT_QUICKSTART.md](docs/AGENT_QUICKSTART.md)**: Clear quickstart guide for contributors and agents
-- **Pre-commit hooks**: Automated formatting, linting, and type checking
-- **Deterministic benchmarks**: Reproducible evaluation with fixed seeds
-- **CI validation**: Automated verification of all improvements
-
-To start an agentic development session:
+- **[CLAUDE.md](CLAUDE.md)** — project intelligence, loaded automatically by Claude Code
+- **[AGENTS.md](AGENTS.md)** — comprehensive guide for agents entering the evolution loop
+- **[docs/AGENT_FIELD_GUIDE.md](docs/AGENT_FIELD_GUIDE.md)** — decision tree, difficulty-rated starter tasks, and copy-paste recipes for agents of any capability
+- Deterministic benchmarks, pre-commit hooks, and layered CI gates that catch regressions early
 
 ```bash
-# Install dev tools and hooks
-pip install -e .[dev]
-pre-commit install
-
-# Run the smoke gate to ensure the baseline is healthy
-python tools/smoke_gate.py
-
-# Run local checks with the agent gate
-python tools/agent_gate.py
-
-# Run a baseline benchmark (5k frames is faster for verification)
-python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42
-
-# Make improvements, validate with the pre-PR gate before opening a PR
-python tools/pre_pr_gate.py
-pre-commit run --all-files
+pip install -e .[dev] && pre-commit install
+python tools/smoke_gate.py     # before coding (<30s)
+python tools/agent_gate.py     # before a local commit (<90s)
+python tools/pre_pr_gate.py    # before opening a PR (broad non-slow suite)
 ```
 
 ---
 
 ## Project Structure
 
-Tank World uses a clean, modular architecture designed for extensibility:
-
 ```
 tank/
 |-- main.py                  # CLI entry point (web or headless)
 |-- backend/                 # FastAPI + WebSocket server
-|-- core/                    # Pure Python simulation engine
+|-- core/                    # Pure Python simulation engine (no UI deps)
 |   |-- algorithms/          # 58 behavior algorithms (composable library)
 |   |-- worlds/              # Tank/Petri backends and shared world abstractions
 |   |-- modes/               # Game rulesets (energy models, scoring)
@@ -302,7 +311,7 @@ tank/
 |   |-- simulation/          # Engine orchestration
 |   `-- config/              # Tunable parameters
 |-- frontend/                # React 19 + TypeScript + Vite
-|-- tests/                   # 60+ test files (smoke, core, integration)
+|-- tests/                   # ~200 test files, ~2,000 tests (smoke, core, integration)
 |-- benchmarks/              # Deterministic evaluation harnesses
 |-- champions/               # Best Known Solutions registry
 |-- scripts/                 # AI evolution agent, tournaments, automation
@@ -316,17 +325,17 @@ tank/
 - **Multi-world backend** enabling different world types (Tank, Petri, Soccer)
 - **Interpretable algorithms** over black-box neural networks (behaviors are debuggable)
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for the full technical deep-dive and [docs/adr/](docs/adr/) for architecture decision records.
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full technical deep-dive and [docs/adr/](docs/adr/) for architecture decision records.
 
 ---
 
 ## Testing & Code Quality
 
 ```bash
-# Smoke gate (runs in under 30 seconds)
+# Smoke gate (under 30 seconds)
 python tools/smoke_gate.py
 
-# Agent gate (runs in under 90 seconds, smoke gate + curated checks)
+# Agent gate (under 90 seconds, smoke gate + curated checks)
 python tools/agent_gate.py
 
 # Pre-PR gate (broad non-slow suite; runtime varies by hardware)
@@ -345,7 +354,7 @@ pre-commit run --all-files
 python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42 --verify-determinism
 ```
 
-CI currently runs `smoke-gate`, `pre-pr-gate`, `frontend-ci`, `security-audit`, and `nightly-full` under [`.github/workflows/ci.yml`](.github/workflows/ci.yml), with `verify-champions` and `benchmark-gate` defined separately in [`.github/workflows/bench.yml`](.github/workflows/bench.yml).
+CI runs `smoke-gate`, `pre-pr-gate`, `frontend-ci`, `security-audit`, and `nightly-full` under [`.github/workflows/ci.yml`](.github/workflows/ci.yml), with `verify-champions` and `benchmark-gate` defined separately in [`.github/workflows/bench.yml`](.github/workflows/bench.yml).
 
 ---
 
@@ -358,9 +367,9 @@ CI currently runs `smoke-gate`, `pre-pr-gate`, `frontend-ci`, `security-audit`, 
 | Algorithm parameters | In-world natural selection | `GreedyFoodSeeker` tunes detection radius over generations |
 | Algorithm prevalence | Differential reproduction | `AmbushFeeder` outcompetes `PanicFlee` in low-predator environments |
 | Physical traits | Genetic inheritance + mutation | Speed, size, vision range, metabolism |
-| Poker strategies | Energy stakes selection | Aggressive bluffers vs conservative folders |
-| Visual traits | Mate preference evolution | Color patterns, fin sizes, body shapes |
-| Code itself | AI-driven PR cycle | Agent improves `MirrorMover` with food-seeking fallback |
+| Poker strategies | Energy-stakes selection | Aggressive bluffers vs conservative folders |
+| Visual traits | Mate-preference evolution | Color patterns, fin sizes, body shapes |
+| Code itself | AI-driven PR cycle | Agent improves `MirrorMover` with a food-seeking fallback |
 
 ### Energy Flow
 
@@ -370,13 +379,7 @@ Environment -> Fractal Plants -> Nectar -> Fish -> Predators (Crabs)
                               Poker Games (energy redistribution)
 ```
 
-### Population Dynamics
-
-- Stable population at 7-15 fish with balanced predation
-- Day/night cycles affecting behavior
-- Multiple successful strategies coexisting
-- Carrying capacity prevents overpopulation
-- Algorithm diversity maintained through mutation
+Reproduction is funded by *overflow* energy: fish bank energy earned above their max and spend it on offspring. This is why the healthy ecosystem is a balancing act — burning a well-fed fish's surplus on ball play or poker directly suppresses birth rate and generation turnover, which the health benchmarks penalize.
 
 ---
 
@@ -388,8 +391,8 @@ Environment -> Fractal Plants -> Nectar -> Fish -> Predators (Crabs)
 |-------|------|--------|
 | 0 | Foundation (58 algorithms, headless mode, web UI, basic AI evolution) | Complete |
 | 1 | Evolution Loop MVP (BKS registry, evolutionary PRs, CI validation) | In Progress |
-| 2 | Closed-loop automation (24/7 AI improvement cycles) | Planned |
-| 3 | Meta-evolution (AI improves its own instructions and benchmarks) | Planned |
+| 2 | Closed-loop automation (continuous AI improvement cycles) | Planned |
+| 3 | Meta-evolution (AI improves its own instructions and benchmarks) | In Progress |
 | 4 | Research platform (publishable ALife findings) | Planned |
 | 5 | Distributed compute (entertainment-driven participation) | Planned |
 | 6 | Evolving visualization (AI evolves how research is presented) | Planned |
@@ -418,11 +421,11 @@ See [docs/EVO_CONTRIBUTING.md](docs/EVO_CONTRIBUTING.md) for the evolutionary PR
 |----------|---------|
 | [CLAUDE.md](CLAUDE.md) | Claude Code project intelligence (auto-loaded) |
 | [AGENTS.md](AGENTS.md) | AI agent guide for entering the evolution loop |
-| [docs/AGENT_FIELD_GUIDE.md](docs/AGENT_FIELD_GUIDE.md) | Foolproof, recipe-driven starter-task menu for agents of any capability |
+| [docs/AGENT_FIELD_GUIDE.md](docs/AGENT_FIELD_GUIDE.md) | Recipe-driven starter-task menu for agents of any capability |
 | [SETUP.md](SETUP.md) | Development environment setup |
 | [docs/VISION.md](docs/VISION.md) | Long-term vision and three-layer evolution paradigm |
+| [docs/EVOLVABILITY.md](docs/EVOLVABILITY.md) | Evolvability levers mapped to code, plus the ideas graveyard |
 | [docs/ROADMAP.md](docs/ROADMAP.md) | Development roadmap and milestones |
-| [docs/IMPROVEMENT_PROPOSALS.md](docs/IMPROVEMENT_PROPOSALS.md) | Prioritized engineering backlog with implementation plans |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Technical architecture deep-dive |
 | [docs/EVO_CONTRIBUTING.md](docs/EVO_CONTRIBUTING.md) | Evolutionary PR protocol |
 | [docs/BEHAVIOR_DEVELOPMENT_GUIDE.md](docs/BEHAVIOR_DEVELOPMENT_GUIDE.md) | Creating new behavior algorithms |
@@ -436,7 +439,7 @@ Built with Python, React, TypeScript, FastAPI, NumPy, and a deep appreciation fo
 
 ## License
 
-This project is open source under the [MIT License](LICENSE).
+Open source under the [MIT License](LICENSE).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ pre-commit run --all-files
 python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42 --verify-determinism
 ```
 
-CI runs `smoke-gate`, `pre-pr-gate`, `frontend-ci`, `security-audit`, and `nightly-full` under [`.github/workflows/ci.yml`](.github/workflows/ci.yml), with `verify-champions` and `benchmark-gate` defined separately in [`.github/workflows/bench.yml`](.github/workflows/bench.yml).
+CI currently runs `smoke-gate`, `pre-pr-gate`, `frontend-ci`, `security-audit`, and `nightly-full` under [`.github/workflows/ci.yml`](.github/workflows/ci.yml), with `verify-champions` and `benchmark-gate` defined separately in [`.github/workflows/bench.yml`](.github/workflows/bench.yml).
 
 ---
 


### PR DESCRIPTION
## Summary

Completes a partially-written README rewrite that had been left truncated mid-file (the entire back half — Quick Start, Evolution Loop, Project Structure, Testing, Roadmap — was missing), and folds in accuracy fixes verified against the codebase. The goal was to make the README both accurate and a clearer pitch for what's interesting about the project and where it's headed.

## Accuracy fixes (verified against code)

- **Test-suite size**: corrected "60+ test files" → ~200 test files / ~2,000 tests (actual: 207 files, 2,097 collected).
- **Benchmarks**: previously named only two; now lists all five (tank: `survival_5k`, `ecosystem_health_10k`, `selection_response_10k`; soccer: `training_3k`, `training_5k`) and explains what the `selection_response_10k` evolvability assay measures (directional heritable trait response, not just survival).
- **"AI Oceanographer (Planned)"**: reframed as the *working* Insights commentary feed, driven by `tools/evolution_report.py` / `tools/post_commentary.py` and the `/observe-sim` and `/study-sim` skills — auto-narration remains the planned layer on top.
- Verified every referenced flag, extra, tool path, and doc link resolves (`[ai]` extra, `--verify-determinism`, `--severity`/`--tags`, demo output filenames, all `docs/` links).

## Messaging improvements

- Surfaces the **multi-model deliberation board** (`/deliberate` → `/build-elected`), where multiple AI models propose, debate, and vote on the next evolvability experiment before a builder agent turns the winner into a minimal validated PR — previously unmentioned.
- Leads with **evolvability** as the actual goal (sustained adaptive novelty, selection pressure, diversity) rather than fish comfort, matching `docs/EVOLVABILITY.md` and the deliberation prompts.
- Notes that Layer 2 meta-evolution is already running (agent workflows in the repo were largely written and refined by agents).

## Notes

- Docs-only change; no code touched.
- All 30 code fences are balanced and Mermaid diagrams preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EHXLW7gEiXsp3cKTztUDR

---
_Generated by [Claude Code](https://claude.ai/code/session_011EHXLW7gEiXsp3cKTztUDR)_