### PR TITLE
meta: shard the pre-PR gate into named, individually runnable slices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,15 @@ across cores via pytest-xdist). Runtime varies by hardware — typically a
 few minutes on multi-core CI, longer on constrained or single-core sandboxes.
 It excludes integration/slow/manual tests and full benchmarks.
 
+The broad suite is split into named shards (`worlds`, `evolution`,
+`backend_tools`, `core` — see `tools/pre_pr_shards.py`) that exactly
+partition the suite. The default run executes all of them; to isolate or
+re-run one failing slice:
+```bash
+python tools/pre_pr_gate.py --list-shards        # shard names and sizes
+python tools/pre_pr_gate.py --shard evolution    # smoke gate + one shard
+```
+
 ### Tier 3: Full Validation (Maintainers/Nightly)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ python tools/agent_gate.py
 
 # Pre-PR gate (broad non-slow suite; runtime varies by hardware)
 python tools/pre_pr_gate.py
+python tools/pre_pr_gate.py --shard core   # re-run one shard (worlds/evolution/backend_tools/core)
 
 # Full validation gate (nightly/maintainers only)
 python tools/full_gate.py

--- a/docs/AGENT_FIELD_GUIDE.md
+++ b/docs/AGENT_FIELD_GUIDE.md
@@ -153,6 +153,8 @@ your diff touches only the lines needed for the fix.
    file. No network, no sleeps, no global random — pass seeds explicitly.
 3. Run just your test: `pytest tests/path/to/your_test.py -v`.
 4. Run `python tools/pre_pr_gate.py` to confirm the whole non-slow suite is green.
+   If one shard fails, re-run just that slice with
+   `python tools/pre_pr_gate.py --shard <worlds|evolution|backend_tools|core>`.
 
 **Done-check:** Your test passes, it fails if you deliberately break the thing
 it tests (try it, then revert), and `pre_pr_gate` is green.

--- a/docs/AGENT_QUICKSTART.md
+++ b/docs/AGENT_QUICKSTART.md
@@ -35,9 +35,10 @@ pre-commit install
   ```bash
   python tools/agent_gate.py
   ```
-* **Pre-PR Gate**: Runs the smoke gate plus all non-slow unit tests (parallelized). Runtime varies by hardware.
+* **Pre-PR Gate**: Runs the smoke gate plus all non-slow unit tests (parallelized). Runtime varies by hardware. The suite runs as named shards (`worlds`, `evolution`, `backend_tools`, `core`); use `--shard NAME` to isolate or re-run one failing slice.
   ```bash
   python tools/pre_pr_gate.py
+  python tools/pre_pr_gate.py --shard evolution   # one shard only
   ```
 * **Full Gate (Nightly/Maintainers only)**: Runs everything, including integration/slow tests and strict champion reproduction. Do not run this for routine local iterations.
   ```bash

--- a/tests/test_pre_pr_shards.py
+++ b/tests/test_pre_pr_shards.py
@@ -1,0 +1,74 @@
+"""Partition invariants for the pre-PR gate's test shards."""
+
+from pathlib import Path
+
+from tools.pre_pr_shards import (
+    REMAINDER_SHARD,
+    SHARD_PREFIXES,
+    assign_shard,
+    discover_test_files,
+    resolve_shards,
+    shard_names,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_shards_exactly_partition_discovered_test_files():
+    """Every discovered test file lands in exactly one shard, none are dropped."""
+    shards = resolve_shards()
+    all_assigned = [test_file for files in shards.values() for test_file in files]
+    assert sorted(all_assigned) == discover_test_files()
+    assert len(all_assigned) == len(set(all_assigned))
+
+
+def test_every_shard_is_nonempty():
+    """An empty shard means dead prefixes; prune them instead of running no-ops."""
+    for name, files in resolve_shards().items():
+        assert files, f"shard '{name}' matched no test files"
+
+
+def test_remainder_shard_is_last_and_prefix_free():
+    """The remainder shard catches unmatched files, so it must not define prefixes
+    and must run last (new test files fall into it automatically)."""
+    assert REMAINDER_SHARD not in SHARD_PREFIXES
+    assert shard_names()[-1] == REMAINDER_SHARD
+
+
+def test_shard_prefixes_only_match_real_files():
+    """Every prefix must match at least one discovered file; stale prefixes rot."""
+    discovered = discover_test_files()
+    for shard, prefixes in SHARD_PREFIXES.items():
+        for prefix in prefixes:
+            assert any(
+                test_file.startswith(prefix) for test_file in discovered
+            ), f"shard '{shard}' prefix '{prefix}' matches no test files"
+
+
+def test_discovery_matches_pytest_python_files_convention():
+    """Shard discovery must mirror pytest collection (python_files = test_*.py
+    under tests/). If pyproject.toml widens that pattern, widen discovery too."""
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'python_files = ["test_*.py"]' in pyproject
+    assert 'testpaths = ["tests"]' in pyproject
+
+    for test_file in discover_test_files():
+        assert test_file.startswith("tests/")
+        assert Path(test_file).name.startswith("test_")
+
+
+def test_assignment_is_first_match_wins_and_deterministic():
+    shards = resolve_shards()
+    for name, files in shards.items():
+        assert files == sorted(files)
+        for test_file in files:
+            assert assign_shard(test_file) == name
+
+
+def test_pre_pr_gate_orchestrates_shards():
+    """The gate must run every shard by default and expose single-shard reruns."""
+    source = (ROOT / "tools" / "pre_pr_gate.py").read_text(encoding="utf-8")
+    assert "resolve_shards" in source
+    assert "shard_names" in source
+    assert "--shard" in source
+    assert "--list-shards" in source

--- a/tools/pre_pr_gate.py
+++ b/tools/pre_pr_gate.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
-"""Run the contributor pre-PR validation gate."""
+"""Run the contributor pre-PR validation gate.
+
+The broad non-slow suite is split into named shards (see tools/pre_pr_shards.py)
+so failures are easy to isolate and cheap to re-run:
+
+    python tools/pre_pr_gate.py                    # smoke gate + every shard
+    python tools/pre_pr_gate.py --shard evolution  # smoke gate + one shard
+    python tools/pre_pr_gate.py --list-shards      # show shards and file counts
+
+The default full run executes exactly the same tests as the pre-shard gate did
+(the shards partition the suite), just grouped with per-shard summaries.
+"""
+
+import argparse
 
 try:
     from tools.gate_common import (
@@ -9,6 +22,7 @@ try:
         run_pytest_with_diagnostics,
         run_steps,
     )
+    from tools.pre_pr_shards import resolve_shards, shard_names
 except ImportError:
     from gate_common import (  # type: ignore[import-not-found,no-redef]
         exit_for_gate,
@@ -17,34 +31,75 @@ except ImportError:
         run_pytest_with_diagnostics,
         run_steps,
     )
+    from pre_pr_shards import (  # type: ignore[import-not-found,no-redef]
+        resolve_shards,
+        shard_names,
+    )
 
 _MARKER_EXPR = "not slow and not integration and not manual"
 
 
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--shard",
+        choices=shard_names(),
+        help="run only this shard of the broad suite (plus the smoke gate)",
+    )
+    parser.add_argument(
+        "--list-shards",
+        action="store_true",
+        help="list shard names with their test-file counts and exit",
+    )
+    return parser.parse_args()
+
+
+def _run_shard(name: str, test_files: list[str]) -> bool:
+    return run_pytest_with_diagnostics(
+        python_command(
+            "-m",
+            "pytest",
+            *test_files,
+            "-m",
+            _MARKER_EXPR,
+            "-n",
+            "auto",
+            "-q",
+            "--durations=25",
+        ),
+        f"Tier 2 shard '{name}': non-slow tests (parallel)",
+        collect_only_args=[*test_files, "-m", _MARKER_EXPR],
+    )
+
+
 def main() -> None:
+    args = _parse_args()
+    shards = resolve_shards()
+
+    if args.list_shards:
+        for name in shard_names():
+            print(f"{name}: {len(shards[name])} test files")
+        raise SystemExit(0)
+
+    selected = [args.shard] if args.shard else shard_names()
     print_gate_header(
-        name="PRE-PR",
+        name="PRE-PR" if args.shard is None else f"PRE-PR (shard: {args.shard})",
         target="varies by hardware; typically under 3 minutes on multi-core CI, longer on constrained sandboxes",
-        includes="the smoke gate, then the broad non-slow test suite run in parallel",
+        includes="the smoke gate, then the broad non-slow test suite run in parallel, sharded as "
+        + ", ".join(selected),
         excludes="integration/manual/slow tests, champion reproduction, and 5k/10k benchmarks",
     )
+
     passed = run_steps([(python_command("tools/smoke_gate.py"), "Tier 1: smoke gate")])
-    if passed:
-        passed = run_pytest_with_diagnostics(
-            python_command(
-                "-m",
-                "pytest",
-                "tests",
-                "-m",
-                _MARKER_EXPR,
-                "-n",
-                "auto",
-                "-q",
-                "--durations=25",
-            ),
-            "Tier 2: broad non-slow tests (parallel)",
-            collect_only_args=["tests", "-m", _MARKER_EXPR],
-        )
+    for name in selected:
+        if not passed:
+            break
+        passed = _run_shard(name, shards[name])
+        if not passed:
+            print(
+                f"\nHint: re-run just this shard with `python tools/pre_pr_gate.py --shard {name}`",
+                flush=True,
+            )
     exit_for_gate("PRE-PR", passed)
 
 

--- a/tools/pre_pr_shards.py
+++ b/tools/pre_pr_shards.py
@@ -1,0 +1,139 @@
+"""Shard definitions for the pre-PR gate.
+
+The broad non-slow suite (~2000 tests) is split into named, thematically
+coherent shards so contributors and agents can isolate failures without
+re-running everything:
+
+  worlds        - soccer, poker, RCSS, petri, and other world-specific rules
+  evolution     - genetics, genomes, traits, mutation, selection, code pools
+  backend_tools - backend API, websockets, persistence, tools, docs, benchmarks
+  core          - the remainder: engine, determinism, energy, entities,
+                  protocols, and architecture contracts
+
+Membership is decided by matching each collected test file's repo-relative
+path against ordered prefix lists (first match wins); files that match no
+prefix fall into the ``core`` remainder shard. Because ``core`` is defined
+as the remainder, the shards always partition the collected files exactly:
+every test file lands in exactly one shard, and new test files are picked
+up automatically. ``tests/test_pre_pr_shards.py`` enforces the partition
+invariants.
+
+File discovery mirrors pytest collection: ``pyproject.toml`` sets
+``python_files = ["test_*.py"]`` under ``testpaths = ["tests"]``, so shards
+glob ``tests/**/test_*.py``. Marker filtering (``not slow and not
+integration and not manual``) stays the gate's job, exactly as before.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TESTS_DIR = REPO_ROOT / "tests"
+
+# The remainder shard: any collected test file not claimed by a prefix below.
+REMAINDER_SHARD = "core"
+
+# Ordered shard -> path-prefix definitions (repo-relative, posix separators).
+# Earlier shards win when prefixes overlap.
+SHARD_PREFIXES: dict[str, tuple[str, ...]] = {
+    "worlds": (
+        "tests/test_soccer",
+        "tests/test_poker",
+        "tests/test_rcss",
+        "tests/test_texas",
+        "tests/test_ball",
+        "tests/test_composable",
+        "tests/test_human_poker",
+        "tests/test_ecosystem_poker",
+        "tests/test_mixed_poker",
+        "tests/test_post_poker",
+        "tests/test_tank_soccer",
+        "tests/test_crab",
+        "tests/test_petri",
+        "tests/test_zigzag",
+    ),
+    "evolution": (
+        "tests/test_gen",
+        "tests/test_evolution",
+        "tests/test_trait",
+        "tests/test_mutation",
+        "tests/test_reproduction",
+        "tests/test_hgt",
+        "tests/test_proximity",
+        "tests/test_selection",
+        "tests/test_migration",
+        "tests/test_diversity",
+        "tests/test_algorithm",
+        "tests/test_code_pool",
+        "tests/test_visual_genetics",
+        "tests/test_behavioral",
+        "tests/test_per_kind",
+        "tests/test_policy",
+        "tests/test_fish_policy",
+        "tests/test_life_evolution",
+        "tests/test_agent_memory",
+        "tests/test_solution_tracking",
+        "tests/test_population_tracker",
+    ),
+    "backend_tools": (
+        "tests/test_backend",
+        "tests/test_websocket",
+        "tests/test_commentary",
+        "tests/test_auto_save",
+        "tests/test_persistence",
+        "tests/test_shutdown",
+        "tests/test_startup",
+        "tests/test_world_manager",
+        "tests/test_world_broadcast",
+        "tests/test_demo_tool",
+        "tests/test_run_bench",
+        "tests/test_gate_common",
+        "tests/test_pre_pr",
+        "tests/test_validation",
+        "tests/test_tally",
+        "tests/test_docs",
+        "tests/test_security",
+        "tests/test_champion",
+        "tests/test_benchmark",
+        "tests/test_serializers",
+        "tests/test_telemetry",
+        "tests/test_metrics",
+        "tests/test_entity_snapshot",
+        "tests/test_entity_transfer",
+        "tests/test_tank_snapshot",
+        "tests/test_fingerprint",
+        "tests/test_replay",
+        "tests/test_mode_switch",
+        "tests/test_guardrails",
+        "tests/test_multi_engine",
+        "tests/test_long_run",
+        "tests/test_connector",
+    ),
+}
+
+
+def shard_names() -> list[str]:
+    """All shard names in run order (remainder shard last)."""
+    return [*SHARD_PREFIXES, REMAINDER_SHARD]
+
+
+def discover_test_files() -> list[str]:
+    """Repo-relative posix paths of every file pytest would collect from tests/."""
+    return sorted(path.relative_to(REPO_ROOT).as_posix() for path in TESTS_DIR.rglob("test_*.py"))
+
+
+def assign_shard(test_file: str) -> str:
+    """Return the shard owning a repo-relative test file path (first match wins)."""
+    for shard, prefixes in SHARD_PREFIXES.items():
+        if any(test_file.startswith(prefix) for prefix in prefixes):
+            return shard
+    return REMAINDER_SHARD
+
+
+def resolve_shards() -> dict[str, list[str]]:
+    """Map every shard name to its sorted list of test files (exact partition)."""
+    shards: dict[str, list[str]] = {name: [] for name in shard_names()}
+    for test_file in discover_test_files():
+        shards[assign_shard(test_file)].append(test_file)
+    return shards


### PR DESCRIPTION
## What

Splits the pre-PR gate's broad non-slow suite (~1950 tests) from one monolithic pytest invocation into four named shards that exactly partition the collected test files, so failures are easy to isolate and cheap to re-run — the top actionable item from the latest external code review.

- **`tools/pre_pr_shards.py`** (new): ordered filename-prefix shard definitions — `worlds` (soccer/poker/RCSS/petri), `evolution` (genetics/genomes/traits/mutation/selection/code pools), `backend_tools` (backend API/websockets/persistence/tools/docs/benchmarks), and `core` as the *remainder* shard. Because `core` is defined as "everything not claimed by a prefix," new test files are picked up automatically and the partition can never drop a file.
- **`tools/pre_pr_gate.py`**: now orchestrates the smoke gate plus every shard by default (same tests as before, grouped with per-shard diagnostics), adds `--shard NAME` to re-run one slice and `--list-shards`, and prints the exact single-shard re-run command when a shard fails.
- **`tests/test_pre_pr_shards.py`** (new, 7 tests): partition invariants — exact cover with no duplicates, no empty shards, no stale prefixes, remainder shard last, and discovery mirroring pytest's `python_files = ["test_*.py"]` convention so shards can't drift from real collection.
- **Docs**: README, AGENTS.md, AGENT_FIELD_GUIDE, AGENT_QUICKSTART mention the shard workflow.

This is a Layer 2 (validation workflow) change only; no simulation, algorithm, or benchmark code is touched. CI's `pre-pr-gate` job invocation is unchanged (`python tools/pre_pr_gate.py`) and runs exactly the same test set.

## Why

A single failure in the ~2000-test suite forced a full re-run, and constrained sandboxes could time out after 10 minutes with no partial signal. Sharding gives per-slice pass/fail, a targeted re-run path, and thematic grouping that matches how agents actually break things.

## Proof

Validation in this sandbox:

```
python tools/pre_pr_gate.py                  -> PASS, 4/4 shards, 324+911+177+538 = 1950 selected tests
python tools/pre_pr_gate.py --shard <each>   -> PASS individually (worlds, evolution, backend_tools, core)
python tools/pre_pr_gate.py --list-shards    -> worlds: 45, evolution: 49, backend_tools: 36, core: 78 test files
python tools/agent_gate.py                   -> PASS
ruff / black / mypy on tools + new test      -> clean
```

Fault injection: a deliberately failing test file landed in the `core` shard, the gate exited 1 and printed the `--shard core` re-run hint (probe removed before committing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtNnMNLzVMPWc29uHGU1iJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtNnMNLzVMPWc29uHGU1iJ)_