### PR TITLE
meta: make gate scripts exit cleanly by reaping orphaned step processes

### DIFF
--- a/tests/test_gate_common.py
+++ b/tests/test_gate_common.py
@@ -1,14 +1,25 @@
-"""Tests for the pytest-output parsing helpers behind the pre-PR gate diagnostics.
+"""Tests for the helpers behind the validation gates.
 
-These are pure string-parsing functions exercised with literal sample text captured
-from real pytest/pytest-xdist runs, so they stay fast and deterministic - no
-subprocesses, no sleeps.
+The parsing tests are pure string-parsing functions exercised with literal
+sample text captured from real pytest/pytest-xdist runs, so they stay fast and
+deterministic. The step-runner tests spawn tiny real subprocesses to prove the
+gates reap orphaned grandchildren instead of hanging on them.
 """
 
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from tools import gate_common
 from tools.gate_common import (
     parse_banner_line,
     parse_collected_counts,
     parse_duration_line,
+    run_captured_step,
+    run_step_command,
     summarize_pytest_lines,
 )
 
@@ -94,3 +105,68 @@ def test_summarize_pytest_lines_ignores_collect_only_style_banner():
 
 def test_summarize_pytest_lines_handles_no_matches():
     assert summarize_pytest_lines([]) == (None, {})
+
+
+# A grandchild leaked by a step sleeps this long; the gate must never wait it out.
+_ORPHAN_SLEEP_SECONDS = 30
+
+posix_only = pytest.mark.skipif(os.name != "posix", reason="process-group reaping is POSIX-only")
+
+
+@posix_only
+def test_run_captured_step_does_not_hang_on_orphan_holding_pipe(monkeypatch):
+    """A step that leaks a background grandchild (e.g. a stuck formatter pool
+    worker) must not wedge the gate's output-capture loop: once the leader
+    exits, the watchdog kills the step's process group and the pipe closes.
+    """
+    monkeypatch.setattr(gate_common, "_STRAGGLER_GRACE_SECONDS", 0.5)
+    leaker = (
+        "import subprocess, sys;"
+        "subprocess.Popen([sys.executable, '-c',"
+        f" 'import time; time.sleep({_ORPHAN_SLEEP_SECONDS})']);"
+        "print('leader done')"
+    )
+
+    start = time.monotonic()
+    returncode, lines = run_captured_step([sys.executable, "-c", leaker], echo=False)
+    elapsed = time.monotonic() - start
+
+    assert returncode == 0
+    assert "leader done" in lines
+    assert elapsed < _ORPHAN_SLEEP_SECONDS / 2
+
+
+@posix_only
+def test_run_step_command_reaps_orphaned_grandchild(tmp_path):
+    """Orphans left behind by a finished step inherit the gate's own stdout, so
+    they must be dead by the time the step returns - otherwise a harness reading
+    the gate's output to EOF hangs even after the gate exits.
+    """
+    pid_file = tmp_path / "orphan_pid.txt"
+    leaker = (
+        "import pathlib, subprocess, sys;"
+        "child = subprocess.Popen([sys.executable, '-c',"
+        f" 'import time; time.sleep({_ORPHAN_SLEEP_SECONDS})']);"
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(child.pid))"
+    )
+
+    returncode = run_step_command([sys.executable, "-c", leaker])
+
+    assert returncode == 0
+    orphan_pid = int(pid_file.read_text())
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if _process_gone_or_zombie(orphan_pid):
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"orphaned grandchild {orphan_pid} survived run_step_command")
+
+
+def _process_gone_or_zombie(pid: int) -> bool:
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+    except (FileNotFoundError, ProcessLookupError):
+        return True
+    # Field after the parenthesized command name is the state; a zombie has
+    # been killed and merely awaits reaping by init.
+    return stat.rsplit(")", 1)[1].split()[0] == "Z"

--- a/tools/gate_common.py
+++ b/tools/gate_common.py
@@ -2,13 +2,24 @@
 
 from __future__ import annotations
 
+import os
 import re
+import signal
 import subprocess
 import sys
+import threading
 from collections.abc import Sequence
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Process-group isolation and reaping are POSIX-only; on other platforms the
+# gates simply run steps the plain way.
+_POSIX = os.name == "posix"
+
+# How long after a step's leader process exits to wait for its output pipe to
+# reach EOF before force-killing the step's process group.
+_STRAGGLER_GRACE_SECONDS = 5.0
 
 _BANNER_RE = re.compile(r"^=+\s*(.*?)\s*=+$")
 _COLLECTED_RE = re.compile(
@@ -75,6 +86,85 @@ def summarize_pytest_lines(lines: Sequence[str]) -> tuple[str | None, dict[str, 
     return result_line, module_durations
 
 
+def _kill_step_process_group(pgid: int) -> None:
+    """Best-effort SIGKILL of a finished step's whole process group.
+
+    Each gate step runs as its own session leader, so once the leader has
+    exited, anything still alive in its group is an orphaned grandchild (for
+    example a stuck worker from a formatter's process pool in a sandboxed
+    environment). Orphans inherit the gate's output pipes, and any harness that
+    reads gate output until EOF will hang on them even after the gate itself
+    prints its final result and exits - so reap them explicitly.
+    """
+    if not _POSIX:
+        return
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+def run_step_command(args: Sequence[str]) -> int:
+    """Run one gate step in its own process group, reaping stragglers after."""
+    process = subprocess.Popen(
+        list(args),
+        cwd=str(REPO_ROOT),
+        stdin=subprocess.DEVNULL,
+        start_new_session=_POSIX,
+    )
+    try:
+        returncode = process.wait()
+    except BaseException:
+        # The step runs in its own session, so terminal signals (Ctrl-C) do
+        # not reach it directly - propagate the interruption ourselves.
+        _kill_step_process_group(process.pid)
+        raise
+    _kill_step_process_group(process.pid)
+    return returncode
+
+
+def run_captured_step(args: Sequence[str], echo: bool) -> tuple[int, list[str]]:
+    """Like `run_step_command`, but captures (and optionally echoes) the step's
+    merged stdout/stderr lines. A watchdog force-kills the step's process group
+    if its output pipe does not reach EOF shortly after the leader exits, so an
+    orphaned grandchild holding the pipe open can never wedge the gate.
+    """
+    process = subprocess.Popen(
+        list(args),
+        cwd=str(REPO_ROOT),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        start_new_session=_POSIX,
+    )
+    assert process.stdout is not None
+    eof_seen = threading.Event()
+
+    def _reap_if_pipe_stays_open() -> None:
+        process.wait()
+        if not eof_seen.wait(_STRAGGLER_GRACE_SECONDS):
+            _kill_step_process_group(process.pid)
+
+    threading.Thread(target=_reap_if_pipe_stays_open, daemon=True).start()
+
+    captured: list[str] = []
+    try:
+        for line in process.stdout:
+            if echo:
+                print(line, end="", flush=True)
+            captured.append(line.rstrip("\n"))
+    except BaseException:
+        _kill_step_process_group(process.pid)
+        raise
+    finally:
+        eof_seen.set()
+    returncode = process.wait()
+    _kill_step_process_group(process.pid)
+    return returncode, captured
+
+
 def collect_only_counts(target_args: Sequence[str]) -> tuple[int, int, int] | None:
     """Run a fast `--collect-only` pass to report exact (total, selected, deselected)
     counts for a marker expression, without executing any tests. `-n auto` runs do
@@ -82,14 +172,11 @@ def collect_only_counts(target_args: Sequence[str]) -> tuple[int, int, int] | No
     Returns None if the summary banner could not be parsed (purely diagnostic - never
     raises, since it must not affect the gate's pass/fail result).
     """
-    result = subprocess.run(
+    _, lines = run_captured_step(
         python_command("-m", "pytest", *target_args, "--collect-only", "-q"),
-        cwd=str(REPO_ROOT),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
+        echo=False,
     )
-    for line in reversed(result.stdout.splitlines()):
+    for line in reversed(lines):
         banner = parse_banner_line(line)
         if banner is None:
             continue
@@ -114,21 +201,7 @@ def run_pytest_with_diagnostics(
     print(f"\n=== {name} ===", flush=True)
 
     counts = collect_only_counts(collect_only_args)
-
-    process = subprocess.Popen(
-        list(args),
-        cwd=str(REPO_ROOT),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-    )
-    assert process.stdout is not None
-    captured = []
-    for line in process.stdout:
-        print(line, end="", flush=True)
-        captured.append(line.rstrip("\n"))
-    returncode = process.wait()
+    returncode, captured = run_captured_step(args, echo=True)
 
     result_line, module_durations = summarize_pytest_lines(captured)
 
@@ -156,9 +229,9 @@ def run_pytest_with_diagnostics(
 def run_steps(steps: Sequence[tuple[list[str], str]]) -> bool:
     for args, name in steps:
         print(f"\n=== {name} ===", flush=True)
-        result = subprocess.run(args, cwd=str(REPO_ROOT))
-        if result.returncode != 0:
-            print(f"[FAIL] {name} failed with exit code {result.returncode}", flush=True)
+        returncode = run_step_command(args)
+        if returncode != 0:
+            print(f"[FAIL] {name} failed with exit code {returncode}", flush=True)
             return False
         print(f"[PASS] {name}", flush=True)
     return True


### PR DESCRIPTION
## Problem

An outside review found that `smoke_gate.py` and `agent_gate.py` can print their full `[PASS]` output in sandboxed agent environments and then the invoking command still times out, while the same pytest commands run directly return cleanly.

**Mechanism:** sandboxed harnesses read a command's output until pipe **EOF**, not just process exit. If a gate step leaves an orphaned grandchild behind, the orphan inherits the gate's stdout and holds the pipe open after the gate exits. The prime suspect is black: even with `-W 1`, formatting multiple files always goes through a `ProcessPoolExecutor` worker process — and the smoke gate already documents that pool misbehaving in sandboxed agent environments. This also explains why direct pytest commands return cleanly: they never invoke black; only the gates do.

## Fix

All four gates funnel through shared step runners in `tools/gate_common.py`, so the hardening lands in one place:

- **`run_step_command`**: each step runs as its own session leader; once the leader exits, its whole process group is SIGKILLed, so stragglers die before the gate moves on. Also explicitly propagates Ctrl-C across the new session boundary.
- **`run_captured_step`** (new): same isolation for output-captured steps, plus a watchdog that force-kills the group if the pipe does not reach EOF within a 5s grace period after the leader exits — the gate's own read loop can never wedge either. `run_pytest_with_diagnostics` and `collect_only_counts` now route through it.
- POSIX-only guards keep the gates runnable on other platforms (plain behavior there).

## Tests

Two regression tests in `tests/test_gate_common.py` spawn a step that deliberately leaks a 30-second background grandchild and assert the runners return promptly with the orphan dead (they complete in well under a second).

## Verification

- `python tools/smoke_gate.py` → exit 0
- `python tools/agent_gate.py` → exit 0 (593 passed, 106 deselected)
- `python tools/pre_pr_gate.py --shard backend_tools` → exit 0, 179 passed, diagnostics (collected counts, slowest modules) intact
- ruff, black, and `mypy tools` (33 files) all pass

Layer 2 change only: validation tooling and its tests — no algorithm, benchmark, or champion changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018B6uBPCPin1bBo5W75pUuV

---
_Generated by [Claude Code](https://claude.ai/code/session_018B6uBPCPin1bBo5W75pUuV)_