### PR TITLE
[codex] Split frontend bundles by route and feature

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,13 +3,18 @@
  */
 
 import { Routes, Route, Link, useParams, useLocation, useNavigate } from 'react-router-dom';
-import { useState, useEffect, useCallback } from 'react';
+import { lazy, Suspense, useState, useEffect, useCallback } from 'react';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import { TankView } from './components/TankView';
-import { NetworkDashboard } from './pages/NetworkDashboard';
 import { config, type WorldStatus } from './config';
 import { FishIcon, GlobeIcon, WaveIcon, ChevronLeftIcon, ChevronRightIcon } from './components/ui';
 import './App.css';
+
+const TankView = lazy(() =>
+    import('./components/TankView').then((module) => ({ default: module.TankView }))
+);
+const NetworkDashboard = lazy(() =>
+    import('./pages/NetworkDashboard').then((module) => ({ default: module.NetworkDashboard }))
+);
 
 interface TankNavigatorProps {
     currentTankId?: string;
@@ -395,7 +400,9 @@ function TankPage() {
     return (
         <div className="app">
             <main className="main">
-                <TankView worldId={tankId} />
+                <Suspense fallback={<PageLoading label="Loading tank..." />}>
+                    <TankView worldId={tankId} />
+                </Suspense>
             </main>
             <footer className="footer">
                 <p>Built with React + FastAPI + WebSocket | Running at ~30 FPS</p>
@@ -408,7 +415,9 @@ function HomePage() {
     return (
         <div className="app">
             <main className="main">
-                <TankView />
+                <Suspense fallback={<PageLoading label="Loading tank..." />}>
+                    <TankView />
+                </Suspense>
             </main>
             <footer className="footer">
                 <p>Built with React + FastAPI + WebSocket | Running at ~30 FPS</p>
@@ -426,11 +435,36 @@ function App() {
                     <Routes>
                         <Route path="/" element={<HomePage />} />
                         <Route path="/tank/:tankId" element={<TankPage />} />
-                        <Route path="/network" element={<NetworkDashboard />} />
+                        <Route
+                            path="/network"
+                            element={
+                                <Suspense fallback={<PageLoading label="Loading network..." />}>
+                                    <NetworkDashboard />
+                                </Suspense>
+                            }
+                        />
                     </Routes>
                 </div>
             </div>
         </ErrorBoundary>
+    );
+}
+
+function PageLoading({ label }: { label: string }) {
+    return (
+        <div
+            style={{
+                minHeight: '240px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'var(--color-text-muted)',
+                fontSize: '13px',
+                fontWeight: 600,
+            }}
+        >
+            {label}
+        </div>
     );
 }
 

--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -1,4 +1,13 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+    lazy,
+    Suspense,
+    useState,
+    useCallback,
+    useEffect,
+    useRef,
+    type ChangeEvent,
+    type ReactNode,
+} from 'react';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useVisiblePanels, type PanelId } from '../hooks/useVisiblePanels';
 import { Canvas } from './Canvas';
@@ -7,21 +16,31 @@ import { ControlPanel } from './ControlPanel';
 import { PokerScoreDisplay } from './PokerScoreDisplay';
 import { WorldModeSelector } from './WorldModeSelector';
 import { useViewMode } from '../hooks/useViewMode';
-import { initRenderers } from '../renderers/init';
-import { TransferDialog } from './TransferDialog';
 import { PlantIcon } from './ui';
-import {
-    TankSoccerTab,
-    TankPokerTab,
-    TankEcosystemTab,
-    TankGeneticsTab,
-    TankTrendsTab,
-} from './tank_tabs';
 import styles from './TankView.module.css';
 
 interface TankViewProps {
     worldId?: string;
 }
+
+const TransferDialog = lazy(() =>
+    import('./TransferDialog').then((module) => ({ default: module.TransferDialog }))
+);
+const TankSoccerTab = lazy(() =>
+    import('./tank_tabs/TankSoccerTab').then((module) => ({ default: module.TankSoccerTab }))
+);
+const TankPokerTab = lazy(() =>
+    import('./tank_tabs/TankPokerTab').then((module) => ({ default: module.TankPokerTab }))
+);
+const TankEcosystemTab = lazy(() =>
+    import('./tank_tabs/TankEcosystemTab').then((module) => ({ default: module.TankEcosystemTab }))
+);
+const TankGeneticsTab = lazy(() =>
+    import('./tank_tabs/TankGeneticsTab').then((module) => ({ default: module.TankGeneticsTab }))
+);
+const TankTrendsTab = lazy(() =>
+    import('./tank_tabs/TankTrendsTab').then((module) => ({ default: module.TankTrendsTab }))
+);
 
 const PANEL_CONFIG: { id: PanelId; label: string; icon: string }[] = [
     { id: 'insights', label: 'Insights', icon: '💬' },
@@ -54,7 +73,7 @@ export function TankView({ worldId }: TankViewProps) {
     const [plantEnergyInput, setPlantEnergyInput] = useState(0.15);
 
     const handlePlantEnergyChange = useCallback(
-        (e: React.ChangeEvent<HTMLInputElement>) => {
+        (e: ChangeEvent<HTMLInputElement>) => {
             const rate = parseFloat(e.target.value);
             setPlantEnergyInput(rate);
             sendCommand({ command: 'set_plant_energy_input', data: { rate } });
@@ -87,9 +106,6 @@ export function TankView({ worldId }: TankViewProps) {
 
     // Effective world ID - use connected ID which is available immediately
     const effectiveWorldId = worldId || connectedWorldId || state?.world_id;
-
-    // Ensure renderers are initialized
-    initRenderers();
 
     const handleEntityClick = (entityId: number, entityType: string) => {
         setSelectedEntityId(entityId);
@@ -387,47 +403,57 @@ export function TankView({ worldId }: TankViewProps) {
 
                     {isVisible('soccer') && (
                         <CollapsiblePanel title="Soccer League" icon="⚽">
-                            <TankSoccerTab
-                                liveState={state?.soccer_league_live ?? null}
-                                events={state?.soccer_events ?? []}
-                                currentFrame={state?.snapshot?.frame ?? state?.frame ?? 0}
-                            />
+                            <Suspense fallback={<PanelLoading />}>
+                                <TankSoccerTab
+                                    liveState={state?.soccer_league_live ?? null}
+                                    events={state?.soccer_events ?? []}
+                                    currentFrame={state?.snapshot?.frame ?? state?.frame ?? 0}
+                                />
+                            </Suspense>
                         </CollapsiblePanel>
                     )}
 
                     {isVisible('poker') && (
                         <CollapsiblePanel title="Poker" icon="♠">
-                            <TankPokerTab
-                                worldId={effectiveWorldId}
-                                isConnected={isConnected}
-                                pokerLeaderboard={state?.poker_leaderboard ?? []}
-                                pokerEvents={state?.poker_events ?? []}
-                                pokerStats={state?.stats?.poker_stats}
-                                currentFrame={state?.snapshot?.frame ?? state?.frame ?? 0}
-                                sendCommandWithResponse={sendCommandWithResponse}
-                                worldType={effectiveWorldType}
-                            />
+                            <Suspense fallback={<PanelLoading />}>
+                                <TankPokerTab
+                                    worldId={effectiveWorldId}
+                                    isConnected={isConnected}
+                                    pokerLeaderboard={state?.poker_leaderboard ?? []}
+                                    pokerEvents={state?.poker_events ?? []}
+                                    pokerStats={state?.stats?.poker_stats}
+                                    currentFrame={state?.snapshot?.frame ?? state?.frame ?? 0}
+                                    sendCommandWithResponse={sendCommandWithResponse}
+                                    worldType={effectiveWorldType}
+                                />
+                            </Suspense>
                         </CollapsiblePanel>
                     )}
 
                     {isVisible('trends') && (
                         <CollapsiblePanel title="Trends" icon="📈">
-                            <TankTrendsTab history={state?.metrics_history ?? null} />
+                            <Suspense fallback={<PanelLoading />}>
+                                <TankTrendsTab history={state?.metrics_history ?? null} />
+                            </Suspense>
                         </CollapsiblePanel>
                     )}
 
                     {isVisible('ecosystem') && (
                         <CollapsiblePanel title="Ecosystem" icon="🌿">
-                            <TankEcosystemTab
-                                stats={state?.stats ?? null}
-                                autoEvaluation={state?.auto_evaluation}
-                            />
+                            <Suspense fallback={<PanelLoading />}>
+                                <TankEcosystemTab
+                                    stats={state?.stats ?? null}
+                                    autoEvaluation={state?.auto_evaluation}
+                                />
+                            </Suspense>
                         </CollapsiblePanel>
                     )}
 
                     {isVisible('genetics') && (
                         <CollapsiblePanel title="Genetics" icon="🧬">
-                            <TankGeneticsTab worldId={effectiveWorldId} />
+                            <Suspense fallback={<PanelLoading />}>
+                                <TankGeneticsTab worldId={effectiveWorldId} />
+                            </Suspense>
                         </CollapsiblePanel>
                     )}
                 </div>
@@ -438,14 +464,16 @@ export function TankView({ worldId }: TankViewProps) {
                 selectedEntityId !== null &&
                 selectedEntityType !== null &&
                 state?.world_id && (
-                    <TransferDialog
-                        entityId={selectedEntityId}
-                        entityType={selectedEntityType}
-                        sourceWorldId={state.world_id}
-                        sourceWorldName={state.world_id}
-                        onClose={handleCloseTransferDialog}
-                        onTransferComplete={handleTransferComplete}
-                    />
+                    <Suspense fallback={null}>
+                        <TransferDialog
+                            entityId={selectedEntityId}
+                            entityType={selectedEntityType}
+                            sourceWorldId={state.world_id}
+                            sourceWorldName={state.world_id}
+                            onClose={handleCloseTransferDialog}
+                            onTransferComplete={handleTransferComplete}
+                        />
+                    </Suspense>
                 )}
 
             {/* Transfer Notification */}
@@ -474,7 +502,25 @@ export function TankView({ worldId }: TankViewProps) {
     );
 }
 
-function CollapsiblePanel({ title, icon, children }: { title: string; icon: string; children: React.ReactNode }) {
+function PanelLoading() {
+    return (
+        <div
+            style={{
+                minHeight: '96px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'var(--color-text-muted)',
+                fontSize: '12px',
+                fontWeight: 600,
+            }}
+        >
+            Loading panel...
+        </div>
+    );
+}
+
+function CollapsiblePanel({ title, icon, children }: { title: string; icon: string; children: ReactNode }) {
     const [isOpen, setIsOpen] = useState(true);
 
     return (

--- a/frontend/src/renderers/init.ts
+++ b/frontend/src/renderers/init.ts
@@ -1,20 +1,108 @@
-
 import { rendererRegistry } from '../rendering/registry';
-import { TankSideRenderer } from './tank/TankSideRenderer';
-import { TankTopDownRenderer } from './tank/TankTopDownRenderer';
-import { PetriTopDownRenderer } from './petri/PetriTopDownRenderer';
-import { SoccerTopDownRenderer } from './soccer/SoccerTopDownRenderer';
+import type { Renderer, RenderContext, RenderFrame } from '../rendering/types';
 
 let initialized = false;
+
+type RendererLoader = () => Promise<Renderer>;
+
+class LazyRenderer implements Renderer {
+    id: string;
+    private renderer: Renderer | null = null;
+    private loadPromise: Promise<Renderer> | null = null;
+    private disposed = false;
+    private readonly loader: RendererLoader;
+
+    constructor(id: string, loader: RendererLoader) {
+        this.id = id;
+        this.loader = loader;
+    }
+
+    dispose() {
+        this.disposed = true;
+        if (this.renderer) {
+            this.renderer.dispose();
+            this.renderer = null;
+        }
+    }
+
+    clearPathCache() {
+        this.renderer?.clearPathCache?.();
+    }
+
+    render(frame: RenderFrame, rc: RenderContext) {
+        if (this.renderer) {
+            this.renderer.render(frame, rc);
+            return;
+        }
+
+        this.startLoading();
+        drawLoadingFrame(rc, this.id);
+    }
+
+    private startLoading() {
+        if (this.loadPromise) return;
+
+        this.loadPromise = this.loader().then((renderer) => {
+            if (this.disposed) {
+                renderer.dispose();
+                return renderer;
+            }
+            this.renderer = renderer;
+            return renderer;
+        });
+    }
+}
+
+function drawLoadingFrame({ ctx, canvas }: RenderContext, rendererId: string) {
+    ctx.fillStyle = '#07111f';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#8aa3b8';
+    ctx.font = '14px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(`Loading ${rendererId} renderer...`, canvas.width / 2, canvas.height / 2);
+}
 
 export function initRenderers() {
     if (initialized) return;
     initialized = true;
 
-    rendererRegistry.register('tank', 'side', () => new TankSideRenderer());
-    rendererRegistry.register('tank', 'topdown', () => new TankTopDownRenderer());
-    rendererRegistry.register('petri', 'topdown', () => new PetriTopDownRenderer());
-    rendererRegistry.register('soccer', 'topdown', () => new SoccerTopDownRenderer());
+    rendererRegistry.register(
+        'tank',
+        'side',
+        () =>
+            new LazyRenderer('tank-side', async () => {
+                const module = await import('./tank/TankSideRenderer');
+                return new module.TankSideRenderer();
+            })
+    );
+    rendererRegistry.register(
+        'tank',
+        'topdown',
+        () =>
+            new LazyRenderer('tank-topdown', async () => {
+                const module = await import('./tank/TankTopDownRenderer');
+                return new module.TankTopDownRenderer();
+            })
+    );
+    rendererRegistry.register(
+        'petri',
+        'topdown',
+        () =>
+            new LazyRenderer('petri-topdown', async () => {
+                const module = await import('./petri/PetriTopDownRenderer');
+                return new module.PetriTopDownRenderer();
+            })
+    );
+    rendererRegistry.register(
+        'soccer',
+        'topdown',
+        () =>
+            new LazyRenderer('soccer-topdown', async () => {
+                const module = await import('./soccer/SoccerTopDownRenderer');
+                return new module.SoccerTopDownRenderer();
+            })
+    );
 
     console.debug('[Renderer] Registered default renderers');
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,27 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+
+          if (/[\\/]node_modules[\\/](react-d3-tree|d3-hierarchy)[\\/]/.test(id)) {
+            return 'tree-vendor'
+          }
+          if (/[\\/]node_modules[\\/](recharts|victory-vendor)[\\/]/.test(id)) {
+            return 'charts-vendor'
+          }
+          if (/[\\/]node_modules[\\/](react|react-dom|react-router-dom)[\\/]/.test(id)) {
+            return 'react-vendor'
+          }
+
+          return undefined
+        },
+      },
+    },
+  },
   server: {
     port: 3000,
     proxy: {


### PR DESCRIPTION
## What changed
Split the frontend production bundle along route, panel, renderer, and vendor boundaries.

- Lazy-load `TankView` and `NetworkDashboard` from the app shell.
- Lazy-load optional tank panels and the transfer dialog so charts, genetics/tree UI, poker UI, and network UI are loaded on demand.
- Replace eager renderer registration with lazy renderer wrappers so concrete side/top-down/petri/soccer renderers load only when selected.
- Add Vite manual chunks for stable `react-vendor`, `charts-vendor`, and `tree-vendor` outputs.

## Layer
- [x] Layer 2 (frontend/tooling; does not affect simulation behavior)
- [ ] Layer 1 (algorithm/config; affects simulation results)

## Why
The frontend build previously emitted a single large JS bundle around 1.02 MB minified, triggering Vite's chunk-size warning. The heavy code paths were mostly optional UI surfaces and renderer variants, so loading them eagerly made the app shell heavier than necessary.

## Impact
The initial HTML now loads only the app shell plus `react-vendor`. Heavy chart, tree, network, panel, and renderer code moves into route/feature chunks that are fetched when used.

Observed production build shape:

- Before: `assets/index-*.js` was 1,021.74 kB minified / 292.67 kB gzip, with Vite large-chunk warning.
- After: app shell `index` is 17.42 kB / 5.01 kB gzip, preloaded `react-vendor` is 229.62 kB / 73.51 kB gzip.
- Deferred examples: `charts-vendor` 381.57 kB, `tree-vendor` 96.49 kB, `TankView` 24.87 kB, `TankSideRenderer` 24.00 kB, `TankTrendsTab` 15.77 kB.
- `npm run build` no longer emits the large chunk warning.

## Proof
Commands run:

```bash
py -3 tools\smoke_gate.py
npm run build
npm test -- --run
npm run lint
py -3 tools\agent_gate.py
py -3 tools\pre_pr_gate.py
git diff --check
```

Results:

- Smoke gate: 39 passed.
- Frontend build: passed, no Vite chunk-size warning.
- Frontend tests: 12 files, 45 tests passed.
- Frontend lint: passed.
- Agent gate: 593 passed, 106 deselected.
- Pre-PR gate: passed across all shards.
- `git diff --check`: passed.

No simulation benchmarks were run because this is a Layer 2 frontend bundling change only.