### PR TITLE
meta: expand mypy type checking to cover backend/ and tools/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         TANK_ENFORCE_MUTATION_INVARIANTS: "1"
       run: python tools/pre_pr_gate.py
     - name: Type check with mypy
-      run: python -m mypy core/
+      run: python -m mypy core/ backend/ tools/
 
   frontend-ci:
     runs-on: ubuntu-latest

--- a/tools/agent_gate.py
+++ b/tools/agent_gate.py
@@ -56,6 +56,16 @@ def main() -> None:
         (
             python_command(
                 "-m",
+                "mypy",
+                "core",
+                "backend",
+                "tools",
+            ),
+            "Mypy type check",
+        ),
+        (
+            python_command(
+                "-m",
                 "pytest",
                 *_AGENT_CURATED_TESTS,
                 "-m",

--- a/tools/gate_common.py
+++ b/tools/gate_common.py
@@ -99,7 +99,10 @@ def _kill_step_process_group(pgid: int) -> None:
     if not _POSIX:
         return
     try:
-        os.killpg(pgid, signal.SIGKILL)
+        killpg = getattr(os, "killpg", None)
+        sigkill = getattr(signal, "SIGKILL", None)
+        if killpg is not None and sigkill is not None:
+            killpg(pgid, sigkill)
     except (ProcessLookupError, PermissionError):
         pass
 

--- a/tools/verify_poker_score.py
+++ b/tools/verify_poker_score.py
@@ -1,11 +1,11 @@
-import requests  # type: ignore[import-untyped]
+import httpx
 
 
 def verify_poker_score():
     try:
         # Get list of servers
         print("Fetching servers...")
-        response = requests.get("http://localhost:8000/api/servers")
+        response = httpx.get("http://localhost:8000/api/servers")
         response.raise_for_status()
         data = response.json()
 


### PR DESCRIPTION
- Update agent_gate.py to run mypy check across core/, backend/, and tools/
- Update ci.yml to enforce mypy type checks on backend/ and tools/ directories in CI
- Fix Windows-specific mypy error in gate_common.py dynamically via getattr
- Migrate verify_poker_score.py to use httpx instead of requests to align dependencies

Verification:
- python tools/smoke_gate.py (PASS)
- python tools/agent_gate.py (PASS)
- python tools/pre_pr_gate.py --no-xdist (PASS)