### PR TITLE
perf: 2x headless simulation speedup via genetic-distance and reproduction-path caching

### DIFF
--- a/core/genetics/diversity.py
+++ b/core/genetics/diversity.py
@@ -69,6 +69,107 @@ def _circular_distance(a: float, b: float) -> float:
     return min(diff, 1.0 - diff)
 
 
+# Trait comparison kinds for the precomputed distance table.
+_KIND_CONTINUOUS = 0
+_KIND_DISCRETE = 1
+_KIND_HUE = 2
+
+# Lazily built once from the trait specs (deferred to avoid circular imports):
+# - rows: (is_physical, trait_name, kind, weight, min_val, max_val)
+# - kind_weight_rows: (kind, weight) per row, for the distance inner loop
+# - base_total_weight: sum of all row weights, accumulated in row order so the
+#   floating-point result matches an incremental per-row summation exactly
+_trait_table: (
+    tuple[
+        list[tuple[bool, str, int, float, float, float]],
+        list[tuple[int, float]],
+        float,
+    ]
+    | None
+) = None
+
+
+def _get_trait_table() -> tuple[
+    list[tuple[bool, str, int, float, float, float]],
+    list[tuple[int, float]],
+    float,
+]:
+    global _trait_table
+    if _trait_table is None:
+        from core.genetics.behavioral import BEHAVIORAL_TRAIT_SPECS
+        from core.genetics.physical import PHYSICAL_TRAIT_SPECS
+
+        rows: list[tuple[bool, str, int, float, float, float]] = []
+        for spec in PHYSICAL_TRAIT_SPECS:
+            weight = _PHYSICAL_TRAIT_WEIGHTS.get(spec.name, 0.5)
+            if spec.name == "color_hue":
+                kind = _KIND_HUE
+            elif spec.discrete:
+                kind = _KIND_DISCRETE
+            else:
+                kind = _KIND_CONTINUOUS
+            rows.append((True, spec.name, kind, weight, spec.min_val, spec.max_val))
+        for spec in BEHAVIORAL_TRAIT_SPECS:
+            weight = _BEHAVIORAL_TRAIT_WEIGHTS.get(spec.name, 0.5)
+            rows.append((False, spec.name, _KIND_CONTINUOUS, weight, spec.min_val, spec.max_val))
+
+        kind_weight_rows = [(kind, weight) for _, _, kind, weight, _, _ in rows]
+        base_total_weight = 0.0
+        for _, weight in kind_weight_rows:
+            base_total_weight += weight
+        _trait_table = (rows, kind_weight_rows, base_total_weight)
+    return _trait_table
+
+
+def _build_distance_profile(
+    genome: Genome,
+) -> tuple[tuple[float | int, ...], tuple[object, ...] | None]:
+    """Precompute the per-genome values genetic_distance compares.
+
+    Continuous traits are stored already normalized, discrete traits as ints,
+    and hue as the raw float, so the distance loop needs no trait lookups.
+    """
+    from core.genetics.trait_utils import get_trait_value
+
+    rows, _, _ = _get_trait_table()
+    values: list[float | int] = []
+    for is_physical, name, kind, _weight, min_val, max_val in rows:
+        traits = genome.physical if is_physical else genome.behavioral
+        val = get_trait_value(getattr(traits, name), default=0.0)
+        if kind == _KIND_HUE:
+            values.append(float(val))
+        elif kind == _KIND_DISCRETE:
+            values.append(int(val))
+        else:
+            values.append(_normalize_trait(float(val), min_val, max_val))
+
+    behavior = genome.behavioral.behavior
+    behavior_key: tuple[object, ...] | None = None
+    if behavior is not None and behavior.value is not None:
+        cb = behavior.value
+        behavior_key = (cb.threat_response, cb.food_approach, cb.social_mode, cb.poker_engagement)
+    return (tuple(values), behavior_key)
+
+
+def _distance_profile(
+    genome: Genome,
+) -> tuple[tuple[float | int, ...], tuple[object, ...] | None]:
+    """Return the genome's cached distance profile, building it if needed.
+
+    The cache lives on the genome (cleared by Genome.invalidate_caches) and is
+    valid because distance-relevant traits are fixed after genome creation:
+    mutation happens when offspring genomes are created, never in place.
+    """
+    profile = getattr(genome, "_distance_profile_cache", None)
+    if profile is None:
+        profile = _build_distance_profile(genome)
+        try:
+            object.__setattr__(genome, "_distance_profile_cache", profile)
+        except AttributeError:
+            pass  # Duck-typed genome that rejects the attribute; skip caching
+    return profile
+
+
 def genetic_distance(genome1: Genome, genome2: Genome) -> float:
     """Calculate genetic distance between two genomes.
 
@@ -89,53 +190,24 @@ def genetic_distance(genome1: Genome, genome2: Genome) -> float:
     Returns:
         Non-negative genetic distance (typically 0.0 to ~5.0)
     """
-    from core.genetics.behavioral import BEHAVIORAL_TRAIT_SPECS
-    from core.genetics.physical import PHYSICAL_TRAIT_SPECS
-    from core.genetics.trait_utils import get_trait_value
+    _, kind_weight_rows, total_weight = _get_trait_table()
+    values1, behavior1 = _distance_profile(genome1)
+    values2, behavior2 = _distance_profile(genome2)
 
     distance_sq = 0.0
-    total_weight = 0.0
-
-    # Physical trait distances
-    for spec in PHYSICAL_TRAIT_SPECS:
-        weight = _PHYSICAL_TRAIT_WEIGHTS.get(spec.name, 0.5)
-        val1 = get_trait_value(getattr(genome1.physical, spec.name), default=0.0)
-        val2 = get_trait_value(getattr(genome2.physical, spec.name), default=0.0)
-
-        if spec.name == "color_hue":
-            # Circular distance for hue
-            d = _circular_distance(float(val1), float(val2))
-        elif spec.discrete:
-            # Discrete traits: 0 or 1 (match/mismatch)
-            d = 0.0 if int(val1) == int(val2) else 1.0
+    for (kind, weight), v1, v2 in zip(kind_weight_rows, values1, values2, strict=True):
+        if kind == _KIND_CONTINUOUS:
+            d = v1 - v2
+        elif kind == _KIND_DISCRETE:
+            d = 0.0 if v1 == v2 else 1.0
         else:
-            d = _normalize_trait(float(val1), spec.min_val, spec.max_val) - _normalize_trait(
-                float(val2), spec.min_val, spec.max_val
-            )
-
+            d = _circular_distance(v1, v2)
         distance_sq += weight * d * d
-        total_weight += weight
-
-    # Behavioral trait distances
-    for spec in BEHAVIORAL_TRAIT_SPECS:
-        weight = _BEHAVIORAL_TRAIT_WEIGHTS.get(spec.name, 0.5)
-        val1 = get_trait_value(getattr(genome1.behavioral, spec.name), default=0.0)
-        val2 = get_trait_value(getattr(genome2.behavioral, spec.name), default=0.0)
-
-        d = _normalize_trait(float(val1), spec.min_val, spec.max_val) - _normalize_trait(
-            float(val2), spec.min_val, spec.max_val
-        )
-        distance_sq += weight * d * d
-        total_weight += weight
 
     # Composable behavior sub-behavior distances (discrete mismatches)
-    b1 = genome1.behavioral.behavior
-    b2 = genome2.behavioral.behavior
-    if b1 is not None and b2 is not None and b1.value is not None and b2.value is not None:
-        cb1 = b1.value
-        cb2 = b2.value
-        for attr in ("threat_response", "food_approach", "social_mode", "poker_engagement"):
-            if getattr(cb1, attr) != getattr(cb2, attr):
+    if behavior1 is not None and behavior2 is not None:
+        for a, b in zip(behavior1, behavior2, strict=True):
+            if a != b:
                 distance_sq += _BEHAVIOR_MISMATCH_WEIGHT
                 total_weight += _BEHAVIOR_MISMATCH_WEIGHT
 

--- a/core/genetics/genome.py
+++ b/core/genetics/genome.py
@@ -59,6 +59,8 @@ class Genome:
     # OPTIMIZATION: Cache for computed properties to avoid repeated calculations
     _speed_modifier_cache: float | None = field(default=None, repr=False, compare=False)
     _metabolism_rate_cache: float | None = field(default=None, repr=False, compare=False)
+    # Precomputed trait values for genetic_distance (see core/genetics/diversity.py)
+    _distance_profile_cache: Any = field(default=None, repr=False, compare=False)
 
     @property
     def speed_modifier(self) -> float:
@@ -89,6 +91,7 @@ class Genome:
         """Invalidate cached computed properties when traits change."""
         object.__setattr__(self, "_speed_modifier_cache", None)
         object.__setattr__(self, "_metabolism_rate_cache", None)
+        object.__setattr__(self, "_distance_profile_cache", None)
 
     def to_dict(
         self,

--- a/core/reproduction/asexual_factory.py
+++ b/core/reproduction/asexual_factory.py
@@ -32,18 +32,22 @@ def maybe_create_banked_offspring(
     mutation_context: ReproductionMutationContext | None = None,
 ) -> Fish | None:
     """Attempt a bank-funded asexual reproduction for a single fish."""
+    from core.reproduction.niche_cost import MIN_NICHE_COST_MULTIPLIER, get_niche_cost_multiplier
+
+    if fish._reproduction_component.reproduction_cooldown > 0 or fish.life_stage != LifeStage.ADULT:
+        return None
+
     bank = fish._reproduction_component.overflow_energy_bank
     baby_energy_needed = ENERGY_MAX_DEFAULT * FISH_BABY_SIZE
 
-    from core.reproduction.niche_cost import get_niche_cost_multiplier
+    # The niche multiplier scans the population, so rule out fish whose bank
+    # cannot cover even the cheapest possible cost before computing it.
+    if bank < baby_energy_needed * MIN_NICHE_COST_MULTIPLIER:
+        return None
 
     baby_energy_needed *= get_niche_cost_multiplier(fish)
 
-    if (
-        fish._reproduction_component.reproduction_cooldown <= 0
-        and fish.life_stage == LifeStage.ADULT
-        and bank >= baby_energy_needed
-    ):
+    if bank >= baby_energy_needed:
         return create_asexual_offspring(fish, mutation_context=mutation_context)
 
     return None

--- a/core/reproduction/mutation_controller.py
+++ b/core/reproduction/mutation_controller.py
@@ -12,8 +12,8 @@ from core.genetics.reproduction import (
 )
 
 if TYPE_CHECKING:
-    from core.entities import Fish
     from core.config.simulation_config import EcosystemConfig
+    from core.entities import Fish
 
 
 class DiversityMutationController:
@@ -35,8 +35,20 @@ class DiversityMutationController:
         self._fish_provider = fish_provider
         self._diversity_samples: list[tuple[int, float]] = []
         self._escalation_active = False
+        # Per-population memoization for lineage-preservation checks. Both the
+        # behavior counts and per-parent isolation results depend only on fish
+        # list membership and genomes, which are fixed while the (cached) fish
+        # list object is unchanged: spawns/removals go through the engine's
+        # mutation queue and rebuild the list, and genomes never mutate in
+        # place after creation. Reset every frame as a safety net.
+        self._cached_fish_list: list[Fish] | None = None
+        self._cached_behavior_counts: dict[str, int] = {}
+        # Keyed by id(parent); the stored parent reference keeps the object
+        # alive so ids cannot be recycled while an entry exists.
+        self._cached_isolation: dict[int, tuple[Fish, bool]] = {}
 
     def record_diversity_sample(self, frame: int) -> None:
+        self._reset_population_cache()
         score = self._diversity_score_provider()
         if score is None:
             return
@@ -95,16 +107,29 @@ class DiversityMutationController:
             return None
         return (last_score - first_score) / frame_span
 
+    def _reset_population_cache(self) -> None:
+        self._cached_fish_list = None
+        self._cached_behavior_counts = {}
+        self._cached_isolation = {}
+
+    def _behavior_counts_for(self, fish_list: list[Fish]) -> dict[str, int]:
+        if fish_list is not self._cached_fish_list:
+            counts: dict[str, int] = {}
+            for fish in fish_list:
+                behavior_id = self._behavior_id_for(fish)
+                if behavior_id is not None:
+                    counts[behavior_id] = counts.get(behavior_id, 0) + 1
+            self._cached_fish_list = fish_list
+            self._cached_behavior_counts = counts
+            self._cached_isolation = {}
+        return self._cached_behavior_counts
+
     def _preserve_underrepresented_lineage(self, parents: tuple[Fish, ...]) -> bool:
         fish_list = self._fish_provider()
         if len(fish_list) < 4 or not parents:
             return False
 
-        counts: dict[str, int] = {}
-        for fish in fish_list:
-            behavior_id = self._behavior_id_for(fish)
-            if behavior_id is not None:
-                counts[behavior_id] = counts.get(behavior_id, 0) + 1
+        counts = self._behavior_counts_for(fish_list)
 
         population = len(fish_list)
         if len(counts) > 1:
@@ -121,23 +146,37 @@ class DiversityMutationController:
         parents: tuple[Fish, ...],
         fish_list: list[Fish],
     ) -> bool:
-        from core.genetics.diversity import genetic_distance
-
         population = len(fish_list)
         if population < 4:
             return False
 
         max_neighbors = max(1, int(population * self.UNDERREPRESENTED_GENETIC_NICHE_SHARE))
         for parent in parents:
-            neighbor_count = 0
-            for fish in fish_list:
-                if genetic_distance(parent.genome, fish.genome) <= self.GENETIC_NICHE_RADIUS:
-                    neighbor_count += 1
-                    if neighbor_count > max_neighbors:
-                        break
-            if neighbor_count <= max_neighbors:
+            cached = self._cached_isolation.get(id(parent))
+            if cached is None or cached[0] is not parent:
+                isolated = self._is_genetically_isolated(parent, fish_list, max_neighbors)
+                self._cached_isolation[id(parent)] = (parent, isolated)
+            else:
+                isolated = cached[1]
+            if isolated:
                 return True
         return False
+
+    def _is_genetically_isolated(
+        self,
+        parent: Fish,
+        fish_list: list[Fish],
+        max_neighbors: int,
+    ) -> bool:
+        from core.genetics.diversity import genetic_distance
+
+        neighbor_count = 0
+        for fish in fish_list:
+            if genetic_distance(parent.genome, fish.genome) <= self.GENETIC_NICHE_RADIUS:
+                neighbor_count += 1
+                if neighbor_count > max_neighbors:
+                    return False
+        return True
 
     @staticmethod
     def _behavior_id_for(fish: Fish) -> str | None:

--- a/core/reproduction/niche_cost.py
+++ b/core/reproduction/niche_cost.py
@@ -1,10 +1,17 @@
 """Niche-based reproduction cost calculations."""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from core.entities import Fish
+
+# Bounds of the multiplier returned by get_niche_cost_multiplier. Callers may
+# use MIN_NICHE_COST_MULTIPLIER to rule out reproduction without paying for
+# the population scan (a bank below base_cost * MIN can never be sufficient).
+MIN_NICHE_COST_MULTIPLIER = 0.6
+MAX_NICHE_COST_MULTIPLIER = 1.8
 
 
 def get_niche_cost_multiplier(fish: Fish) -> float:
@@ -78,4 +85,4 @@ def get_niche_cost_multiplier(fish: Fish) -> float:
 
     p = N_same / N_total
     # Cost scales from 0.6x (unique) to 1.8x (dominant)
-    return float(max(0.6, min(1.8, 0.6 + 1.2 * p)))
+    return float(max(MIN_NICHE_COST_MULTIPLIER, min(MAX_NICHE_COST_MULTIPLIER, 0.6 + 1.2 * p)))


### PR DESCRIPTION
## Summary

Profiling a 3000-frame headless run (seed 42) showed ~60% of total runtime in the reproduction phase: `DiversityMutationController.context_for_parents` is called per fish per frame, and each call re-counted behavior lineages over the whole population and re-scanned it with `genetic_distance` (685k calls / 17.8M trait normalizations per 3k frames). `get_niche_cost_multiplier` added another full entity scan per banked-reproduction check.

This PR eliminates the redundant recomputation. All changes are exactly behavior-preserving: exported simulation stats are **bit-identical** to baseline on every run compared.

## Changes

- **`core/genetics/diversity.py`**: `genetic_distance` now compares precomputed per-genome trait profiles (normalized continuous values, discrete ints, raw hue, behavior tuple), built once per genome and cached on it. Accumulation order and arithmetic are unchanged, so results are bit-identical to the previous implementation.
- **`core/genetics/genome.py`**: add `_distance_profile_cache` field, cleared in `invalidate_caches()` alongside the existing derived-property caches. Safe because distance-relevant traits are fixed after genome creation — mutation always produces new offspring genomes, and the tests' in-place-edit pattern already goes through `invalidate_caches()`.
- **`core/reproduction/mutation_controller.py`**: memoize behavior-lineage counts and per-parent genetic-isolation results while the (engine-cached) fish list object is unchanged; reset every frame as a safety net. Both depend only on list membership and genomes, which are fixed within a frame (spawns/removals go through the mutation queue). The escalation-latch hysteresis still runs on every call, so its state evolution is untouched.
- **`core/reproduction/asexual_factory.py` + `niche_cost.py`**: in `maybe_create_banked_offspring`, check cooldown/life-stage first and skip the population scan when the energy bank cannot cover even the minimum possible niche cost. The multiplier is clamped to >= 0.6 (now the named constant `MIN_NICHE_COST_MULTIPLIER`), so this pre-filter is an exact bound, not a heuristic.

## Evidence (wall clock, no profiler)

| Run | Baseline | This PR | Speedup |
|-----|----------|---------|---------|
| 3,000 frames, seed 42 | 27.1s | 13.1s | 2.06x |
| 3,000 frames, seed 7 | 25.3s | 12.7s | 2.0x |
| 10,000 frames, seed 42 | 87.9s | 43.0s | 2.04x |

Exported stats compared field-by-field against unmodified code: identical except `elapsed_real_time` and `simulation_speed`. Determinism is preserved exactly — same trajectories, same populations, same generations.

Repro: `python main.py --headless --max-frames 3000 --export-stats out.json --seed 42`

## Validation

- `tools/smoke_gate.py`, `tools/agent_gate.py`, `tools/pre_pr_gate.py` all pass
- ruff, black, isort, mypy clean; pre-commit hooks pass

## Tradeoffs

The genome-level cache assumes distance-relevant traits stay immutable after creation. The invariant is documented at the cache site and enforced through `invalidate_caches()`; any future in-place-mutation feature must call that hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QD9TwAx8oJzg6NLiHVxYyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD9TwAx8oJzg6NLiHVxYyx)_