### PR TITLE
[codex] Expose Vite dev server on LAN

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: '0.0.0.0',
     port: 3000,
     proxy: {
       '/api': {


### PR DESCRIPTION
## What changed

Configured the Vite dev server to bind to `0.0.0.0` instead of localhost-only, so the Tank World frontend can be reached from another device on the LAN at addresses like `http://192.168.1.38:3000`.

## Why

The backend was already listening on `0.0.0.0:8000`, but the frontend dev server was listening on `::1:3000`, which made it reachable only from the local machine. Binding Vite to all interfaces lets LAN clients load the simulation UI while keeping the existing port and proxy behavior.

## Validation

- `.\.venv\Scripts\python.exe tools\smoke_gate.py` - passed, 39 tests passed
- `npm run build` from `frontend/` - passed
- `Test-NetConnection 192.168.1.38 -Port 3000` - `TcpTestSucceeded: True`

## Notes

- This is a Layer 2 developer-experience change only.
- No champion files were touched.
- The user's local Windows firewall/network profile may still need to allow inbound LAN traffic, but the dev server now binds correctly.