### PR TITLE
[codex] Fix banked reproduction cooldown

### DIFF
--- a/core/agents/components/reproduction_component.py
+++ b/core/agents/components/reproduction_component.py
@@ -13,6 +13,8 @@ triggers immediately when conditions are met, and offspring are created in the s
 
 from typing import TYPE_CHECKING, Optional
 
+from core.config.fish import REPRODUCTION_COOLDOWN as CONFIG_REPRODUCTION_COOLDOWN
+
 if TYPE_CHECKING:
     from random import Random
 
@@ -43,7 +45,7 @@ class ReproductionComponent:
     # Reproduction constants
     REPRODUCTION_ENERGY_PERCENTAGE = 0.9  # Require ~90% energy before any reproduction path
     ASEXUAL_REPRODUCTION_THRESHOLD = 0.95  # Asexual requires 95% (higher since no mate to help)
-    REPRODUCTION_COOLDOWN = 300  # 10 seconds at 30fps - prevents constant reproduction
+    REPRODUCTION_COOLDOWN = CONFIG_REPRODUCTION_COOLDOWN
     MATING_DISTANCE = 60.0  # Maximum distance for poker-triggered reproduction
     REPRODUCTION_ENERGY_COST = 10.0  # Energy cost for reproduction
     ENERGY_TRANSFER_TO_BABY = 0.30  # Parent transfers 30% of their current energy to baby

--- a/tests/test_overflow_routing.py
+++ b/tests/test_overflow_routing.py
@@ -143,3 +143,26 @@ def test_overflow_spills_to_food_when_bank_is_full(simulation_env):
     )
 
     assert entities_after == entities_before + 1
+
+
+def test_banked_reproduction_uses_configured_cooldown(simulation_env):
+    _unused_env, _agents_wrapper = simulation_env
+    env = _EnvironmentStub()
+    eco = _EcosystemStub()
+
+    fish = _make_fish(env, fish_id=1, ecosystem=eco)
+    _set_adult(fish)
+    fish.energy = fish.max_energy
+    fish._reproduction_component.bank_overflow_energy(160.0, max_bank=fish.max_energy * 3)
+
+    from core.config.fish import REPRODUCTION_COOLDOWN
+    from core.reproduction.reproduction_service import ReproductionService
+
+    first_baby = ReproductionService.maybe_create_banked_offspring(fish)
+
+    assert first_baby is not None
+    assert fish._reproduction_component.reproduction_cooldown == REPRODUCTION_COOLDOWN
+
+    second_baby = ReproductionService.maybe_create_banked_offspring(fish)
+
+    assert second_baby is not None


### PR DESCRIPTION
## Summary

Fix bank-funded asexual reproduction so it honors the configured reproduction cooldown instead of an obsolete hard-coded 300-frame delay.

## Root Cause

Fish correctly route excess energy into `overflow_energy_bank` before spilling any remainder as food. However, bank-funded reproduction called `trigger_asexual_reproduction()`, which set `reproduction_cooldown` from `ReproductionComponent.REPRODUCTION_COOLDOWN`. That component constant was still hard-coded to 300 frames, while `core/config/fish.py` sets `REPRODUCTION_COOLDOWN = 0` with the intended rule: reproduce whenever the bank has enough energy.

A fish could therefore reproduce once, remain or become bank-full, and then spill further excess as falling food for 10 seconds instead of spending the bank on another eligible birth.

## Changes

- Wire `ReproductionComponent.REPRODUCTION_COOLDOWN` to `core.config.fish.REPRODUCTION_COOLDOWN`.
- Add a regression test that verifies banked reproduction uses the configured cooldown and can spend enough banked energy on consecutive offspring when cooldown is zero.

## Validation

- `py -m pytest tests/test_overflow_routing.py -q` -> 3 passed
- `py -m pytest tests/test_life_evolution_flow.py tests/test_reproduction_credits.py -q` -> 2 passed
- `py tools/smoke_gate.py` -> passed, 39 tests passed
- `py tools/agent_gate.py` -> passed, 595 passed / 106 deselected
- `py tools/pre_pr_gate.py` -> passed; all non-slow shards passed