### PR TITLE
[codex] Starvation-triggered ball suppression to strengthen foraging selection

### DIFF
--- a/core/movement/ball_pursuit.py
+++ b/core/movement/ball_pursuit.py
@@ -31,7 +31,7 @@ Velocity = tuple[float, float]
 # below max is still climbing toward its next birth - diverting it to the ball
 # burns the very energy that would fund offspring. Gate on near-max energy so
 # only fish at the overflow boundary spend genuine surplus on play.
-PLAY_ENERGY_THRESHOLD_RATIO = 0.90
+PLAY_ENERGY_THRESHOLD_RATIO = 0.98
 
 # Target magnitude for the pursuit velocity. The arbiter's velocity tail in
 # AlgorithmicMovement.move() re-scales by the fish's speed and clamps the

--- a/tests/fixtures/replays/tank_petri_seed42_v2.jsonl
+++ b/tests/fixtures/replays/tank_petri_seed42_v2.jsonl
@@ -13,9 +13,9 @@
 {"type":"op","op":"switch_mode","mode":"petri","frame":10,"fingerprint":"0d22ba2cabc8a05d33a7c61336583844"}
 {"type":"op","op":"step","n":1,"frame":11,"fingerprint":"b9b30373be27b9f612a9bbf9fcd597a6"}
 {"type":"op","op":"step","n":1,"frame":12,"fingerprint":"9731402e17747dadfda94c66fbbf5adb"}
-{"type":"op","op":"step","n":1,"frame":13,"fingerprint":"a7e09f51b7a5cf95f6a841a1cd4d29b2"}
-{"type":"op","op":"step","n":1,"frame":14,"fingerprint":"d4cb5e81500513a714dd6611ca1ff320"}
-{"type":"op","op":"step","n":1,"frame":15,"fingerprint":"466e4cdcbb761be63a9db5ad021fd827"}
-{"type":"op","op":"step","n":1,"frame":16,"fingerprint":"508890fadd95666e1d80f1b70afdb4b0"}
-{"type":"op","op":"step","n":1,"frame":17,"fingerprint":"139150961cc7e30f58391b2fbe73ba08"}
-{"type":"op","op":"step","n":1,"frame":18,"fingerprint":"4a176cae4d97be31834b09b034726d12"}
+{"type":"op","op":"step","n":1,"frame":13,"fingerprint":"eadefe813b03fda17aa37768bbad039b"}
+{"type":"op","op":"step","n":1,"frame":14,"fingerprint":"d044bb2a151f3f3f2b086235d74afc7e"}
+{"type":"op","op":"step","n":1,"frame":15,"fingerprint":"dc3e68f0f1038f66f5458ddccc2bada0"}
+{"type":"op","op":"step","n":1,"frame":16,"fingerprint":"491a910e57f6176909008e294c6302ac"}
+{"type":"op","op":"step","n":1,"frame":17,"fingerprint":"156cba909d91a076bdda7b173638b3d6"}
+{"type":"op","op":"step","n":1,"frame":18,"fingerprint":"2c4fb5766ce4e93690ec190ac90bbe20"}

--- a/tests/test_movement_strategy.py
+++ b/tests/test_movement_strategy.py
@@ -162,6 +162,27 @@ class TestAlgorithmicMovement:
         behavior.has_survival_priority = lambda f: True
         assert ball_pursuit_velocity(fish) is None
 
+    def test_ball_pursuit_requires_near_full_energy(self, simulation_env):
+        """Ball play should stay rare until a fish is genuinely surplus-rich."""
+        env, agents = simulation_env
+        strategy = AlgorithmicMovement()
+        genome = Genome.random(use_algorithm=True)
+        fish = Fish(env, strategy, "george1.png", 100, 100, 3, genome=genome)
+        agents.add(fish)
+        env.ball = Ball(env, 500, 500)
+
+        class FixedRng:
+            def random(self) -> float:
+                return 0.0
+
+        env._rng = FixedRng()
+
+        fish.energy = fish.max_energy * 0.95
+        assert ball_pursuit_velocity(fish) is None
+
+        fish.energy = fish.max_energy * 0.99
+        assert ball_pursuit_velocity(fish) is not None
+
     def test_isolated_full_fish_has_no_survival_priority(self, simulation_env):
         """A full fish with no predator or reachable food has no survival drive,
         so it is free to play (real has_survival_priority path, RNG-free)."""


### PR DESCRIPTION
## What changed
Raised the ball-play gate so soccer pursuit only activates at near-surplus energy (`PLAY_ENERGY_THRESHOLD_RATIO` from `0.90` to `0.98`), which makes leisure less likely to spend energy before reproduction-funding overflow is actually available. I also added a regression test for the activation boundary and regenerated the golden replay fixture to reflect the intentional deterministic trajectory shift.

## Why
The elected proposal targeted the foraging bottleneck: the tank already shows directional selection, but much of the pressure was being spent under starvation-dominated conditions. Tightening the ball gate tests whether reducing that energy sink improves the evolvability signal without flattening selection.

## Validation
- `py -3 tools/smoke_gate.py` ✅
- `py -3 tools/agent_gate.py` ✅
- `py -3 tools/pre_pr_gate.py --no-xdist` ✅
- `py -3 -m pytest tests/test_movement_strategy.py -v` ✅
- `py -3 -m pytest tests/test_code_pool_movement_integration.py -v` ✅
- `py -3 -m pytest tests/test_replay_golden.py tests/test_replay_roundtrip.py -v` ✅ after regenerating the replay fixture

## Reproduction / evidence
Seed-42 ecosystem benchmark:
- Before: `python tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 42 --out before_ecosystem.json`
- After: `python tools/run_bench.py benchmarks/tank/ecosystem_health_10k.py --seed 42 --out after_ecosystem.json`
- Score: `7.5670 -> 8.3388` (+10.2%)

Additional standard-seed checks:
- Seed 7: `8.4110`
- Seed 123: `10.0482`

Held-out selection assay:
- `python tools/run_selection_response_assay.py --seeds 42,7,123 --out selection_response_after.json`
- Mean score: `72.1141`
- `all_selection_detected: true`
- `mean_drift_per_generation_pct: 4.3908`
- `mean_diversity_retention: 1.0442`
- `min_final_diversity: 0.263`

## Notes
- Champion files were not touched.
- `tools/validate_improvement.py after_ecosystem.json champions/tank/ecosystem_health_10k.json` reported a config-hash mismatch, so I did not use it as a champion comparison.
- The golden replay fixture `tests/fixtures/replays/tank_petri_seed42_v2.jsonl` was intentionally regenerated because the change legitimately alters the deterministic trajectory.