### PR TITLE
Improve evolvability: Bottleneck-Conditioned Selection Ruler

### DIFF
--- a/backend/metrics_history.py
+++ b/backend/metrics_history.py
@@ -9,7 +9,20 @@ logger = logging.getLogger(__name__)
 
 # Bumped to 2 when per-trait means ("traits") were added to each sample so the
 # running UI/API can show directional selection over time, not just churn.
-SCHEMA_VERSION = 2
+# Bumped to 3 when boot_id was added to each sample so evolution_report.py can
+# detect code-epoch mixing across server restarts (Proposal #27).
+SCHEMA_VERSION = 3
+
+# ---------------------------------------------------------------------------
+# Boot-ID counter
+# ---------------------------------------------------------------------------
+# Each MetricsHistory instance is created once per server start (inside the
+# AppContext / WorldRunner).  We bump a module-level counter at construction
+# time so every sample recorded in *this process* shares the same boot_id,
+# and samples from a previous process have a *different* id.
+# This is intentionally process-local: it resets to 0 whenever the module is
+# imported freshly (i.e. on a new server start).
+_BOOT_ID_COUNTER: int = 0
 
 
 def get_val(obj: Any, attr: str, default: Any = 0) -> Any:
@@ -30,6 +43,10 @@ class MetricsHistory:
         sample_interval_frames: int = 500,
         max_samples: int = 2000,
     ) -> None:
+        global _BOOT_ID_COUNTER
+        _BOOT_ID_COUNTER += 1
+        self.boot_id: int = _BOOT_ID_COUNTER
+
         self.schema_version = SCHEMA_VERSION
         self.world_id = world_id or "unknown"
         self.sample_interval_frames = sample_interval_frames
@@ -120,6 +137,7 @@ class MetricsHistory:
 
                 sample = {
                     "frame": frame,
+                    "boot_id": self.boot_id,
                     "max_generation": get_val(stats, "max_generation", 0),
                     "population": get_val(stats, "population", 0),
                     "births_total": get_val(stats, "births", 0),

--- a/tests/test_metrics_trends.py
+++ b/tests/test_metrics_trends.py
@@ -64,9 +64,9 @@ def test_metrics_history_capacity_and_interval() -> None:
     assert history.samples[0]["frame"] == 10
     assert history.samples[1]["frame"] == 15
     assert history.samples[2]["frame"] == 20
-    # Every sample carries a (possibly empty) traits mapping for schema v2.
+    # Every sample carries a (possibly empty) traits mapping for schema v2/v3.
     assert all("traits" in sample for sample in history.samples)
-    assert history.schema_version == 2
+    assert history.schema_version == 3
 
 
 def test_is_sample_due_matches_interval() -> None:

--- a/tests/test_selection_quality_ruler.py
+++ b/tests/test_selection_quality_ruler.py
@@ -1,0 +1,355 @@
+"""Tests for Proposal #27: Bottleneck-Conditioned Selection Ruler.
+
+Covers the three new functions added to tools/evolution_report.py:
+  - _stable_samples(): population floor + local-CV filter
+  - _range_normalized_drift(): percent-blowup-immune normalization
+  - _selection_quality(): confidence label + conditioned_drift + epoch detection
+
+Also covers the boot_id tagging in backend/metrics_history.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Import evolution_report without installing it as a package
+# ---------------------------------------------------------------------------
+_ER_SPEC = importlib.util.spec_from_file_location(
+    "evolution_report",
+    Path(__file__).resolve().parents[1] / "tools" / "evolution_report.py",
+)
+assert _ER_SPEC and _ER_SPEC.loader
+er = importlib.util.module_from_spec(_ER_SPEC)
+_ER_SPEC.loader.exec_module(er)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sample(frame, gen, pop, div, traits, boot_id=None):
+    s = {
+        "frame": frame,
+        "max_generation": gen,
+        "population": pop,
+        "births_total": 0,
+        "deaths_total": 0,
+        "diversity_score": div,
+        "traits": traits,
+    }
+    if boot_id is not None:
+        s["boot_id"] = boot_id
+    return s
+
+
+def _stable_pop_samples(n=30, pop=35, trait_val=0.5, boot_id=1):
+    """Generate n stable-population samples with consistent traits."""
+    return [
+        _sample(
+            frame=i * 1000,
+            gen=i,
+            pop=pop,
+            div=0.5,
+            traits={"pursuit_aggression": trait_val + i * 0.001, "speed": 1.2},
+            boot_id=boot_id,
+        )
+        for i in range(1, n + 1)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _stable_samples tests
+# ---------------------------------------------------------------------------
+
+
+def test_stable_samples_rejects_low_population() -> None:
+    """Samples with population < POP_STABLE_MIN should be filtered out."""
+    # Create 40 samples: the first is low-pop, the rest are stable pop 30
+    samples = [_sample(1000, 1, 5, 0.5, {"pursuit_aggression": 0.5})] + [
+        _sample(i * 1000, i, 30, 0.5, {"pursuit_aggression": 0.5}) for i in range(2, 42)
+    ]
+    stable = er._stable_samples(samples)
+    frames = [s["frame"] for s in stable]
+    assert 1000 not in frames, "Low-pop sample (frame 1000) should be filtered"
+    # Samples in the stable region (e.g. frame 30000, index 30) should pass because their local CV window (width 20)
+    # does not reach the low-pop sample at index 0.
+    assert 30000 in frames, "Stable samples far from the low-pop sample should pass"
+
+
+def test_stable_samples_rejects_boom_bust_shoulder() -> None:
+    """Even if pop >= floor, a sample inside a boom/bust window should be rejected."""
+    # Create 30 samples where population fluctuates wildly (CV >> 0.35)
+    pops = [
+        5,
+        80,
+        5,
+        80,
+        5,
+        80,
+        5,
+        80,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+        30,
+    ]
+    samples = [
+        _sample(i * 500, i, pop, 0.5, {"pursuit_aggression": 0.5}) for i, pop in enumerate(pops, 1)
+    ]
+    stable = er._stable_samples(samples)
+    # The boom/bust shoulder samples should be excluded
+    # The tail of stable-population samples should survive
+    stable_pops = [s["population"] for s in stable]
+    assert all(p >= er.POP_STABLE_MIN for p in stable_pops), "No low-pop samples should survive"
+
+
+def test_stable_samples_passes_consistently_stable_run() -> None:
+    """A run with pop always >= 20 and low CV should pass almost all samples."""
+    samples = _stable_pop_samples(n=50, pop=35)
+    stable = er._stable_samples(samples)
+    # At least 80% should survive (edges may be clipped by local CV window)
+    assert len(stable) >= int(
+        len(samples) * 0.7
+    ), f"Expected >= 70% stable samples, got {len(stable)}/{len(samples)}"
+
+
+# ---------------------------------------------------------------------------
+# _range_normalized_drift tests
+# ---------------------------------------------------------------------------
+
+
+def test_range_normalized_drift_behavioral_traits() -> None:
+    """Behavioral traits [0,1] should return |delta|/1.0 = |delta|."""
+    raw_drift = {
+        "pursuit_aggression": {
+            "start": 0.1,
+            "end": 0.9,
+            "delta": 0.8,
+            "pct": 800.0,
+            "selection": True,
+        },
+        "prediction_skill": {
+            "start": 0.03,
+            "end": 0.9,
+            "delta": 0.87,
+            "pct": 2900.0,
+            "selection": True,
+        },
+    }
+    rn = er._range_normalized_drift(raw_drift)
+    # pursuit_aggression: |0.8| / (1.0 - 0.0) = 0.8
+    assert abs(rn["pursuit_aggression"] - 0.8) < 1e-4
+    # prediction_skill: |0.87| / 1.0 = 0.87  (not 2900%!)
+    assert abs(rn["prediction_skill"] - 0.87) < 1e-4
+
+
+def test_range_normalized_drift_clips_at_one() -> None:
+    """Delta larger than the known range should be clipped to 1.0."""
+    raw_drift = {
+        "pursuit_aggression": {
+            "start": 0.0,
+            "end": 2.0,
+            "delta": 2.0,
+            "pct": 9999.0,
+            "selection": True,
+        },
+    }
+    rn = er._range_normalized_drift(raw_drift)
+    assert rn["pursuit_aggression"] == 1.0
+
+
+def test_range_normalized_drift_skips_unknown_traits() -> None:
+    """Traits not in TRAIT_BOUNDS should be silently skipped."""
+    raw_drift = {
+        "unknown_trait": {"start": 0.1, "end": 0.9, "delta": 0.8, "pct": 800.0, "selection": True},
+    }
+    rn = er._range_normalized_drift(raw_drift)
+    assert "unknown_trait" not in rn
+
+
+# ---------------------------------------------------------------------------
+# _selection_quality / confidence label tests
+# ---------------------------------------------------------------------------
+
+
+def test_selection_quality_high_confidence_on_stable_run() -> None:
+    """A stable, single-boot run with clear drift should be high_confidence_selection."""
+    # 40 stable samples, pop=35, trait drifts strongly
+    samples = [
+        _sample(i * 500, i, 35, 0.5, {"pursuit_aggression": 0.3 + i * 0.015}, boot_id=1)
+        for i in range(1, 41)
+    ]
+    raw_drift = er._trait_drift(samples)
+    sq = er._selection_quality(samples, raw_drift)
+    assert sq["confidence"] == "high_confidence_selection", sq
+    assert sq["epoch_mixed"] is False
+    assert sq["conditioned_selection_detected"] is True
+    assert sq["stable_sample_count"] >= 30
+
+
+def test_selection_quality_epoch_confounded_multi_boot() -> None:
+    """Samples from multiple boot_ids should be flagged as epoch_confounded."""
+    samples = _stable_pop_samples(n=20, pop=35, trait_val=0.3, boot_id=1) + _stable_pop_samples(
+        n=20, pop=35, trait_val=0.7, boot_id=2
+    )
+    raw_drift = er._trait_drift(samples)
+    sq = er._selection_quality(samples, raw_drift)
+    assert sq["confidence"] == "epoch_confounded", sq
+    assert sq["epoch_mixed"] is True
+    assert 1 in sq["boot_ids_in_window"]
+    assert 2 in sq["boot_ids_in_window"]
+
+
+def test_selection_quality_bottleneck_confounded() -> None:
+    """A trait drift that disappears after pop filtering should be bottleneck_confounded.
+
+    We engineer this by having the 'drift' only appear in low-population crash samples
+    (start near zero, then crash, then stable at a different value) so the filtered
+    window shows no drift.
+    """
+    # 10 samples with pop=4 (crash, low), traits jumping 0.1 -> 0.9
+    crash = [
+        _sample(i * 500, i, 4, 0.1, {"pursuit_aggression": 0.1 + i * 0.08}, boot_id=1)
+        for i in range(1, 11)
+    ]
+    # 30 samples with pop=35 (stable), traits stable at 0.9
+    stable_tail = [
+        _sample(
+            5500 + i * 500, 10 + i, 35, 0.5, {"pursuit_aggression": 0.89 + i * 0.0001}, boot_id=1
+        )
+        for i in range(1, 31)
+    ]
+    samples = crash + stable_tail
+    # Raw drift: start=0.1 end=~0.892 -> large pct -> selection
+    raw_drift = er._trait_drift(samples)
+    assert (
+        raw_drift.get("pursuit_aggression", {}).get("selection") is True
+    ), "raw drift should show selection from crash window"
+    sq = er._selection_quality(samples, raw_drift)
+    # Conditioned drift only covers stable tail (pop>=20), which is ~flat
+    # So confidence should be bottleneck_confounded
+    assert sq["confidence"] == "bottleneck_confounded", (
+        f"Expected bottleneck_confounded, got {sq['confidence']!r}. "
+        f"conditioned_selection_detected={sq['conditioned_selection_detected']}, "
+        f"stable_sample_count={sq['stable_sample_count']}"
+    )
+
+
+def test_selection_quality_no_boot_id_samples() -> None:
+    """Old samples without boot_id should not be epoch_confounded (just no tag info)."""
+    samples = [
+        _sample(i * 500, i, 35, 0.5, {"pursuit_aggression": 0.3 + i * 0.015}) for i in range(1, 41)
+    ]
+    raw_drift = er._trait_drift(samples)
+    sq = er._selection_quality(samples, raw_drift)
+    assert sq["epoch_mixed"] is False
+    assert sq["boot_ids_in_window"] == []
+
+
+def test_selection_quality_in_analyze_history() -> None:
+    """analyze_history() should now include selection_quality in its output."""
+    samples = _stable_pop_samples(n=20, pop=35, boot_id=1)
+    hist = er.analyze_history(samples)
+    assert "selection_quality" in hist, "selection_quality should be in analyze_history output"
+    sq = hist["selection_quality"]
+    assert "confidence" in sq
+    assert "stable_sample_count" in sq
+    assert "range_normalized_drift" in sq
+    assert "conditioned_drift" in sq
+
+
+def test_selection_quality_in_build_report() -> None:
+    """build_report() should propagate selection_quality through the history block."""
+    samples = _stable_pop_samples(n=20, pop=35, boot_id=1)
+    report = er.build_report(samples, {"population": 35}, "test")
+    assert "selection_quality" in report["history"]
+
+
+def test_format_human_includes_selection_quality() -> None:
+    """format_human() should render the SELECTION QUALITY section."""
+    samples = _stable_pop_samples(n=20, pop=35, boot_id=1)
+    report = er.build_report(samples, {"population": 35}, "test")
+    text = er.format_human(report)
+    assert "SELECTION QUALITY" in text, "format_human should include SELECTION QUALITY section"
+    assert "confidence" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# backend/metrics_history.py boot_id tests
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_history_boot_id_increments() -> None:
+    """Each MetricsHistory instance should get a unique, incrementing boot_id."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from backend.metrics_history import MetricsHistory
+
+    h1 = MetricsHistory("world-1")
+    h2 = MetricsHistory("world-2")
+    assert isinstance(h1.boot_id, int)
+    assert isinstance(h2.boot_id, int)
+    assert h2.boot_id == h1.boot_id + 1, "boot_id should increment monotonically"
+
+
+def test_metrics_history_sample_has_boot_id() -> None:
+    """Recorded samples should include the boot_id field."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from backend.metrics_history import MetricsHistory
+
+    mh = MetricsHistory("world-boot-test", sample_interval_frames=10)
+    # Create a minimal stats-like dict
+    stats = type(
+        "S",
+        (),
+        {
+            "max_generation": 1,
+            "population": 30,
+            "births": 10,
+            "deaths": 8,
+            "fish_energy": 100.0,
+            "diversity_score": 0.5,
+            "poker_elo": None,
+        },
+    )()
+    mh.maybe_sample(
+        frame=10,
+        stats=stats,
+        poker=None,
+        soccer=None,
+        auto_eval=None,
+        trait_means={"pursuit_aggression": 0.5},
+    )
+    assert mh.samples, "Expected at least one sample"
+    sample = mh.samples[0]
+    assert "boot_id" in sample, "Sample must include boot_id"
+    assert sample["boot_id"] == mh.boot_id
+
+
+def test_metrics_history_schema_version_is_3() -> None:
+    """After the Proposal #27 change, SCHEMA_VERSION should be 3."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from backend.metrics_history import SCHEMA_VERSION
+
+    assert SCHEMA_VERSION == 3, f"Expected SCHEMA_VERSION=3, got {SCHEMA_VERSION}"

--- a/tools/evolution_report.py
+++ b/tools/evolution_report.py
@@ -63,6 +63,30 @@ POP_STABLE_MIN = 20.0  # stable population floor (fish)
 POP_CV_UNSTABLE = 0.35  # coefficient of variation above this => boom/bust
 DIVERSITY_LOW = 0.30  # diversity_score below this => converging
 MIN_SAMPLES_FOR_TREND = 3
+# Sliding window width (in samples) for local CV when filtering stable windows
+_STABLE_POP_LOCAL_WINDOW = 20
+
+# Known [min, max] bounds for the tracked behavioral traits.  Behavioral traits
+# are genome floats in [0, 1]; expressed traits (speed, size) have wider ranges
+# derived from the composable parameter bounds + body-size model.  These are
+# used by the conditioned ruler to compute *range-normalized absolute drift*
+# (delta / range) so that near-zero-baseline traits (prediction_skill starting
+# at 0.027) don't produce meaningless percent blowups.
+#
+# Conservative estimates — if the actual runtime value is outside this range
+# (because of future parameter changes) the normalization just exceeds [0, 1]
+# and the pct_norm field still communicates the scale of the change honestly.
+TRAIT_BOUNDS: dict[str, tuple[float, float]] = {
+    "pursuit_aggression": (0.0, 1.0),
+    "prediction_skill": (0.0, 1.0),
+    "hunting_stamina": (0.0, 1.0),
+    "aggression": (0.0, 1.0),
+    # speed: expressed from base_speed_multiplier (0.5-0.9427) * burst (1.1-1.7)
+    # upper bound observed empirically; use a generous [0.5, 3.0] bracket.
+    "speed": (0.5, 3.0),
+    # size: body-size modifier; range [0.5, 3.0] observed in long runs.
+    "size": (0.5, 3.0),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +255,8 @@ def analyze_history(samples: list[dict[str, Any]]) -> dict[str, Any]:
     # Trait drift (first -> last population mean), the selection-vs-churn signal.
     result["trait_drift"] = _trait_drift(samples)
     result["selection_detected"] = any(d["selection"] for d in result["trait_drift"].values())
+    # Bottleneck-conditioned selection quality (Proposal #27)
+    result["selection_quality"] = _selection_quality(samples, result["trait_drift"])
     return result
 
 
@@ -255,6 +281,150 @@ def _trait_drift(samples: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
             "selection": abs(rel) >= TRAIT_DRIFT_SELECTION_PCT,
         }
     return drift
+
+
+# ---------------------------------------------------------------------------
+# Bottleneck-Conditioned Selection Ruler (Proposal #27)
+# ---------------------------------------------------------------------------
+
+
+def _local_cv(pops: list[float], center: int, window: int) -> float:
+    """Coefficient of variation of the *window* samples around *center*."""
+    half = window // 2
+    start = max(0, center - half)
+    end = min(len(pops), center + half + 1)
+    return _coefficient_of_variation(pops[start:end])
+
+
+def _stable_samples(
+    samples: list[dict[str, Any]],
+    pop_floor: float = POP_STABLE_MIN,
+    local_window: int = _STABLE_POP_LOCAL_WINDOW,
+    local_cv_ceiling: float = POP_CV_UNSTABLE,
+) -> list[dict[str, Any]]:
+    """Return only samples that appear to come from a stable, non-bottleneck
+    population window.
+
+    A sample is *stable* when:
+    1. Its recorded population >= *pop_floor* (eliminates low-N founder pools).
+    2. The local CV across the surrounding *local_window* samples is below
+       *local_cv_ceiling* (eliminates boom/bust shoulders).
+    """
+    pops = [float(s.get("population", 0)) for s in samples]
+    result: list[dict[str, Any]] = []
+    for i, s in enumerate(samples):
+        pop = float(s.get("population", 0))
+        if pop < pop_floor:
+            continue
+        if _local_cv(pops, i, local_window) >= local_cv_ceiling:
+            continue
+        result.append(s)
+    return result
+
+
+def _boot_ids(samples: list[dict[str, Any]]) -> set[int]:
+    """Unique boot_ids present in the sample set; skips samples without one."""
+    ids: set[int] = set()
+    for s in samples:
+        bid = s.get("boot_id")
+        if isinstance(bid, int):
+            ids.add(bid)
+    return ids
+
+
+def _range_normalized_drift(
+    raw_drift: dict[str, dict[str, Any]],
+) -> dict[str, float]:
+    """Return per-trait |delta| / trait_range, clipped to [0, 1].
+
+    This is the range-normalized absolute drift requested in Proposal #27/#29:
+    it is immune to near-zero-baseline percent blowups because it divides by the
+    known trait range rather than by the (possibly tiny) starting value.
+    """
+    result: dict[str, float] = {}
+    for key, d in raw_drift.items():
+        lo, hi = TRAIT_BOUNDS.get(key, (None, None))
+        if lo is None or hi is None or hi == lo:
+            continue
+        norm = abs(d["delta"]) / (hi - lo)
+        result[key] = round(min(norm, 1.0), 5)
+    return result
+
+
+def _selection_quality(
+    all_samples: list[dict[str, Any]],
+    raw_drift: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Bottleneck-Conditioned Selection Ruler (Proposal #27).
+
+    Produces a ``selection_quality`` block with:
+
+    * ``confidence``: one of
+      - ``high_confidence_selection``  -- raw drift and conditioned drift agree
+        (both show selection or both show no selection) AND the window is single-epoch.
+      - ``bottleneck_confounded``      -- raw drift shows selection but the
+        conditioned (population-filtered) drift does not, or stable sample count
+        is too low to judge.
+      - ``epoch_confounded``           -- samples span more than one ``boot_id``
+        (code-epoch mixing); conditioned drift may still be reported but trust is
+        reduced.
+      - ``insufficient_stable_samples``-- fewer than MIN_SAMPLES_FOR_TREND stable
+        samples remain after population filtering.
+
+    * ``stable_sample_count``: how many samples survived the population filter.
+    * ``boot_ids_in_window``: list of unique boot_ids observed ([] if none tagged).
+    * ``epoch_mixed``: True when len(boot_ids) > 1.
+    * ``conditioned_drift``: per-trait drift computed on the stable subset (same
+      schema as ``trait_drift`` in the main history block).
+    * ``range_normalized_drift``: |delta|/range for *all* traits (raw window),
+      bypassing the percent-blowup problem.
+    * ``conditioned_selection_detected``: True if any conditioned trait has
+      |pct| >= TRAIT_DRIFT_SELECTION_PCT.
+    """
+    boot_ids = sorted(_boot_ids(all_samples))
+    epoch_mixed = len(boot_ids) > 1
+
+    # Range-normalized drift on the full raw window (immune to zero-baseline blowups)
+    rn_drift = _range_normalized_drift(raw_drift)
+
+    # Population-conditioned subset
+    stable = _stable_samples(all_samples)
+    stable_count = len(stable)
+
+    if stable_count < MIN_SAMPLES_FOR_TREND:
+        confidence = "epoch_confounded" if epoch_mixed else "insufficient_stable_samples"
+        return {
+            "confidence": confidence,
+            "stable_sample_count": stable_count,
+            "boot_ids_in_window": boot_ids,
+            "epoch_mixed": epoch_mixed,
+            "conditioned_drift": {},
+            "range_normalized_drift": rn_drift,
+            "conditioned_selection_detected": False,
+        }
+
+    cond_drift = _trait_drift(stable)
+    cond_sel = any(d["selection"] for d in cond_drift.values())
+    raw_sel = any(d["selection"] for d in raw_drift.values())
+
+    if epoch_mixed:
+        confidence = "epoch_confounded"
+    elif raw_sel and not cond_sel:
+        # Raw showed selection but it vanishes when bottlenecks are removed
+        confidence = "bottleneck_confounded"
+    else:
+        # Both agree (raw and conditioned both show selection, or both show none)
+        confidence = "high_confidence_selection" if cond_sel else "high_confidence_no_selection"
+
+    return {
+        "confidence": confidence,
+        "stable_sample_count": stable_count,
+        "boot_ids_in_window": boot_ids,
+        "epoch_mixed": epoch_mixed,
+        "conditioned_drift": cond_drift,
+        "range_normalized_drift": rn_drift,
+        "conditioned_selection_detected": cond_sel,
+    }
 
 
 def analyze_stats(stats: dict[str, Any]) -> dict[str, Any]:
@@ -579,6 +749,39 @@ def format_human(report: dict[str, Any]) -> str:
             )
     else:
         lines.append("  (no trait-mean history available - need >=2 samples with traits)")
+
+    sq = hist.get("selection_quality") or {}
+    if sq:
+        lines.append("")
+        lines.append("SELECTION QUALITY (Proposal #27 bottleneck-conditioned ruler)")
+        lines.append("-" * 78)
+        conf = sq.get("confidence", "?")
+        epoch_mixed = sq.get("epoch_mixed", False)
+        boot_ids = sq.get("boot_ids_in_window", [])
+        stable_n = sq.get("stable_sample_count", "?")
+        lines.append(f"  confidence            : {conf}")
+        lines.append(
+            f"  epoch mixed           : {epoch_mixed}"
+            + (f" (boot_ids={boot_ids})" if boot_ids else " (no boot_id tags in samples)")
+        )
+        lines.append(f"  stable samples used   : {stable_n}")
+        rn = sq.get("range_normalized_drift") or {}
+        if rn:
+            lines.append(
+                "  range-norm |drift|    : "
+                + ", ".join(f"{k}={v:.3f}" for k, v in sorted(rn.items()))
+            )
+        cond = sq.get("conditioned_drift") or {}
+        if cond:
+            lines.append("  conditioned drift (pop-filtered):")
+            for trait, d in cond.items():
+                mark = "  <- selection" if d["selection"] else ""
+                lines.append(
+                    f"    {trait:>18}: {d['start']:8.4f} -> {d['end']:8.4f} "
+                    f"({d['delta']:+.4f}, {d['pct']:+6.1f}%){mark}"
+                )
+        elif sq.get("stable_sample_count", 0) < 3:
+            lines.append("  conditioned drift     : (insufficient stable samples)")
 
     lines.append("")
     lines.append("FINDINGS")


### PR DESCRIPTION
Implemented Proposal #27 (with #28/#29 refinements) to harden trait_drift and selection_detected measurement metrics:
- Added a monotonic 'boot_id' field per MetricsHistory instance to detect code-epoch mixing across server restarts. Bumped MetricsHistory schema version to 3.
- Implemented a bottleneck-conditioned drift analyzer in evolution_report.py that filters out samples during population crashes (population < 20 or local CV >= 0.35) before calculating selection drift.
- Added range-normalized absolute drift calculations (|delta| / trait_range) for all behavioral and expressed traits to prevent near-zero-baseline percent blowups.
- Introduced confidence labeling to the selection quality metrics block (high_confidence_selection, high_confidence_no_selection, bottleneck_confounded, epoch_confounded, insufficient_stable_samples).
- Added comprehensive unit tests in tests/test_selection_quality_ruler.py covering all new filtering, normalization, labeling, and metrics serialization functions. Passed smoke gate, agent gate, and pre-PR gate verification suite.