### PR TITLE
Improve benchmarks: Add score breakdowns and display weakest component

### DIFF
--- a/benchmarks/soccer/training_3k.py
+++ b/benchmarks/soccer/training_3k.py
@@ -180,6 +180,10 @@ def run(
         "benchmark_id": BENCHMARK_ID,
         "seed": seed,
         "score": score,
+        "score_breakdown": {
+            "avg_fitness": base_seed_normal.get("avg_fitness", 0.0),
+            "total_goals": base_seed_normal.get("total_goals", 0.0),
+        },
         "runtime_seconds": runtime,
         "metadata": {
             # Legacy fields required for champion reproduction checks.

--- a/benchmarks/soccer/training_5k.py
+++ b/benchmarks/soccer/training_5k.py
@@ -180,6 +180,10 @@ def run(
         "benchmark_id": BENCHMARK_ID,
         "seed": seed,
         "score": score,
+        "score_breakdown": {
+            "avg_fitness": base_seed_normal.get("avg_fitness", 0.0),
+            "total_goals": base_seed_normal.get("total_goals", 0.0),
+        },
         "runtime_seconds": runtime,
         "metadata": {
             # Legacy fields required for champion reproduction checks.

--- a/benchmarks/tank/ecosystem_health_10k.py
+++ b/benchmarks/tank/ecosystem_health_10k.py
@@ -161,6 +161,12 @@ def run(
         "benchmark_id": BENCHMARK_ID,
         "seed": seed,
         "score": score,
+        "score_breakdown": {
+            "generation_rate": generation_rate,
+            "diversity_bonus": round(diversity_bonus, 4),
+            "stability_bonus": round(stability_bonus, 4),
+            "starvation_penalty": round(starvation_penalty, 4),
+        },
         "runtime_seconds": runtime,
         "metadata": {
             "frames": FRAMES,

--- a/benchmarks/tank/selection_response_10k.py
+++ b/benchmarks/tank/selection_response_10k.py
@@ -141,6 +141,12 @@ def score_samples(
         "benchmark_id": BENCHMARK_ID,
         "seed": seed,
         "score": score,
+        "score_breakdown": {
+            "selection_component": round(selection_component, 4),
+            "selected_trait_fraction": round(selected_fraction, 4),
+            "diversity_component": round(diversity_component, 4),
+            "quality_per_generation": round(quality_per_generation, 4),
+        },
         "runtime_seconds": runtime_seconds,
         "metadata": {
             "frames": FRAMES,

--- a/benchmarks/tank/survival_5k.py
+++ b/benchmarks/tank/survival_5k.py
@@ -126,6 +126,10 @@ def run(
         "benchmark_id": BENCHMARK_ID,
         "seed": seed,
         "score": score,
+        "score_breakdown": {
+            "avg_energy": avg_fish_energy,
+            "avg_pop": avg_fish_pop,
+        },
         "runtime_seconds": runtime,
         "metadata": {
             "frames": FRAMES,

--- a/tests/test_evolution_tools.py
+++ b/tests/test_evolution_tools.py
@@ -54,6 +54,7 @@ class TestValidateImprovement(unittest.TestCase):
             "runtime_seconds": 10.0,
             "seed": 42,
             "benchmark_id": "test/bench",
+            "score_breakdown": {"metric_a": 10.5, "metric_b": 20.0},
         }
 
         updated = validate_improvement.update_champion_data(champion_data, new_result)
@@ -63,3 +64,6 @@ class TestValidateImprovement(unittest.TestCase):
         self.assertEqual(len(updated["history"]), 1)
         self.assertEqual(updated["history"][0]["score"], 100.0)
         self.assertEqual(updated["history"][0]["commit"], "old_commit")
+        self.assertEqual(
+            updated["champion"]["score_breakdown"], {"metric_a": 10.5, "metric_b": 20.0}
+        )

--- a/tools/validate_improvement.py
+++ b/tools/validate_improvement.py
@@ -105,6 +105,8 @@ def update_champion_data(
         "timestamp": new_result.get("timestamp", time.time()),
         "metadata": new_result.get("metadata", {}),
     }
+    if "score_breakdown" in new_result:
+        new_champion["score_breakdown"] = new_result["score_breakdown"]
     if "config_hash" in new_result:
         new_champion["config_hash"] = new_result["config_hash"]
 
@@ -174,13 +176,74 @@ def main():
             print(f"Re-baselined {args.champion_path}: {old} -> {new_score:.6f}")
             return
 
+        new_breakdown = result.get("score_breakdown")
         if champion:
-            old_score = get_champion_record(champion)["score"]
+            old_record = get_champion_record(champion)
+            old_score = old_record["score"]
             diff = new_score - float(old_score)
 
             print(f"New Score: {new_score:.6f}")
             print(f"Old Score: {old_score:.6f}")
             print(f"Diff:      {diff:+.6f}")
+
+            # Extract old breakdown
+            old_breakdown = old_record.get("score_breakdown")
+            if not old_breakdown:
+                old_breakdown = old_record.get("metadata", {}).get("score_breakdown")
+            if not new_breakdown:
+                new_breakdown = result.get("metadata", {}).get("score_breakdown")
+
+            if new_breakdown or old_breakdown:
+                print("\nScore Breakdown:")
+                keys = sorted(set((new_breakdown or {}).keys()) | set((old_breakdown or {}).keys()))
+
+                weakest_key = None
+                weakest_pct = float("inf")
+                weakest_new = None
+                weakest_old = None
+
+                for key in keys:
+                    new_val = (new_breakdown or {}).get(key)
+                    old_val = (old_breakdown or {}).get(key)
+
+                    new_str = (
+                        f"{new_val:.4f}" if isinstance(new_val, (int, float)) else str(new_val)
+                    )
+                    old_str = (
+                        f"{old_val:.4f}" if isinstance(old_val, (int, float)) else str(old_val)
+                    )
+
+                    if new_val is not None and old_val is not None:
+                        if isinstance(new_val, (int, float)) and isinstance(old_val, (int, float)):
+                            diff_val = new_val - old_val
+                            diff_str = f" ({diff_val:+.4f})"
+                            # Track weakest component (lowest % change, or absolute diff if old_val is 0)
+                            if old_val != 0:
+                                pct_change = (new_val - old_val) / abs(old_val)
+                            else:
+                                pct_change = new_val - old_val
+                            if pct_change < weakest_pct:
+                                weakest_pct = pct_change
+                                weakest_key = key
+                                weakest_new = new_val
+                                weakest_old = old_val
+                        else:
+                            diff_str = ""
+                        print(f"  {key}: {new_str} (champion: {old_str}){diff_str}")
+                    elif new_val is not None:
+                        print(f"  {key}: {new_str} (champion: N/A)")
+                    elif old_val is not None:
+                        print(f"  {key}: N/A (champion: {old_str})")
+
+                if weakest_key is not None:
+                    if weakest_old != 0:
+                        pct_change_str = f"{weakest_pct * 100:+.2f}%"
+                    else:
+                        pct_change_str = f"{weakest_pct:+.4f}"
+                    print(
+                        f"Weakest component: {weakest_key} ({weakest_new:.4f} vs champion {weakest_old:.4f}, {pct_change_str})"
+                    )
+                print("")
 
             if diff < -args.tolerance:
                 print("FAILURE: Regression detected.")
@@ -191,6 +254,12 @@ def main():
                 print("SUCCESS: Improvement detected!")
         else:
             print(f"New Score: {new_score:.6f} (Initial Champion)")
+            if new_breakdown:
+                print("\nScore Breakdown:")
+                for key, val in sorted(new_breakdown.items()):
+                    val_str = f"{val:.4f}" if isinstance(val, (int, float)) else str(val)
+                    print(f"  {key}: {val_str}")
+                print("")
 
         # Update champion logic
         if args.update_champion:


### PR DESCRIPTION
Implemented proposal 1.2 from IMPROVEMENT_PROPOSALS.md. Benchmarks now return a 'score_breakdown' dictionary of their core sub-metrics. validate_improvement.py displays component-level differences and highlights the weakest component relative to the champion.

Reproduction:
  python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42 --out result.json
  python tools/validate_improvement.py result.json champions/tank/survival_5k.json

- Return score_breakdown from survival_5k, ecosystem_health_10k, selection_response_10k, training_3k, and training_5k.
- Compare score breakdowns, show diffs, and print weakest component in validate_improvement.py.
- Support legacy champions gracefully.
- Add unit tests for score breakdown validation.
- All gates (smoke_gate, agent_gate, pre_pr_gate) are green.