### PR TITLE
[codex] Use public soccer reproduction accessor

### DIFF
--- a/core/minigames/soccer/rewards.py
+++ b/core/minigames/soccer/rewards.py
@@ -356,7 +356,7 @@ def apply_soccer_repro_rewards(
     for participant_id, entity in player_map.items():
         if not participant_id.startswith(winner_team):
             continue
-        component = getattr(entity, "_reproduction_component", None)
+        component = getattr(entity, "reproduction_component", None)
         if component is None or not hasattr(component, "add_repro_credits"):
             continue
         applied = component.add_repro_credits(credit_award)

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -315,20 +315,13 @@ elegance. **Layer 2.**
 ## Theme 8 — Product-facing meaning (external review, 2026-07)
 
 ### 8.1 Decide soccer reward semantics; bury repro-credit bookkeeping — `M` · ★★
-**Problem.** The reviewer flagged two related smells: (1) soccer reward code
-reaches into a private-ish component —
-`core/minigames/soccer/rewards.py:apply_soccer_repro_rewards` reads
-`entity._reproduction_component` and calls `add_repro_credits`; (2) "repro
-credit" is internal simulation bookkeeping leaking toward player-facing
-achievement. The player-facing model should be goals, assists, wins, tank
-identity, and net energy.
+**Problem.** The encapsulation half of this review item is shipped: soccer
+reward code now uses the public `reproduction_component` accessor. The
+remaining smell is semantic: "repro credit" is internal simulation bookkeeping
+leaking toward player-facing achievement. The player-facing model should be
+goals, assists, wins, tank identity, and net energy.
 
-**Plan (two separable steps).**
-- *Encapsulation (S):* give `ReproductionComponent` a public accessor so
-  `rewards.py` stops touching the underscore-prefixed attribute directly. Behavior
-  identical; champions must still reproduce exactly. Search first —
-  `_reproduction_component` and `repro_credit` appear in ~20 files, so scope the
-  rename carefully.
+**Remaining plan.**
 - *Semantics (M):* if repro-credit isn't a concept the project wants to keep,
   remove the `reward_mode="credits"` path decisively rather than hiding it from
   the UI. This is a design decision — **confirm with a maintainer before

--- a/tests/test_soccer_ranking_and_rewards.py
+++ b/tests/test_soccer_ranking_and_rewards.py
@@ -4,9 +4,11 @@ from unittest.mock import Mock
 
 from typing import Any
 
+from core.agents.components.reproduction_component import ReproductionComponent
 from core.minigames.soccer.fish_stats import SoccerFishStatsTracker
 from core.minigames.soccer.types import SoccerMinigameOutcome
 from core.minigames.soccer.rewards import (
+    apply_soccer_repro_rewards,
     calculate_soccer_individual_rewards,
 )
 
@@ -212,6 +214,12 @@ def create_mock_fish(fish_id: int):
     return fish
 
 
+class PublicReproductionFish:
+    def __init__(self, fish_id: int) -> None:
+        self.fish_id = fish_id
+        self.reproduction_component = ReproductionComponent()
+
+
 def test_goal_rewards_applied():
     fish1 = create_mock_fish(1)
     player_map = {"left_0": fish1}
@@ -254,6 +262,23 @@ def test_rewards_capped():
         assists_by_fish={},
     )
     assert rewards["left_0"] == 70.0
+
+
+def test_repro_rewards_use_public_reproduction_component():
+    winner = PublicReproductionFish(1)
+    loser = PublicReproductionFish(2)
+
+    deltas = apply_soccer_repro_rewards(
+        {"left_0": winner, "right_0": loser},
+        "left",
+        reward_mode="credits",
+        credit_award=1.25,
+    )
+
+    assert deltas == {1: 1.25}
+    assert winner.reproduction_component.repro_credits == 1.25
+    assert loser.reproduction_component.repro_credits == 0.0
+    assert not hasattr(winner, "_reproduction_component")
 
 
 def test_tank_info_recorded_and_displayed():

--- a/tests/test_spiral_forager.py
+++ b/tests/test_spiral_forager.py
@@ -1,0 +1,93 @@
+"""Targeted branch coverage for the deprecated SpiralForager behavior."""
+
+from __future__ import annotations
+
+import math
+import random
+from types import SimpleNamespace
+from typing import Any
+
+from core.algorithms.food_seeking.spiral import SpiralForager
+from core.config.food import FOOD_PURSUIT_RANGE_EXTENDED, PREDATOR_FLEE_DISTANCE_SAFE
+from core.entities import Crab
+from core.math_utils import Vector2
+
+
+class _World:
+    def __init__(self, *, predator: Any | None = None, food: Any | None = None) -> None:
+        self.predator = predator
+        self.food = food
+
+    def get_agents_of_type(self, agent_type: type) -> list[Any]:
+        if agent_type is Crab and self.predator is not None:
+            return [self.predator]
+        return []
+
+    def closest_food(self, _fish: Any, _max_distance: float) -> Any | None:
+        return self.food
+
+
+def _fish(*, energy: float = 100.0, max_energy: float = 100.0, world: _World) -> Any:
+    return SimpleNamespace(
+        pos=Vector2(100.0, 100.0),
+        energy=energy,
+        max_energy=max_energy,
+        environment=world,
+    )
+
+
+def _entity_at(x: float, y: float) -> Any:
+    return SimpleNamespace(pos=Vector2(x, y))
+
+
+def test_spiral_forager_random_instance_uses_supplied_rng() -> None:
+    algo = SpiralForager.random_instance(rng=random.Random(0))
+
+    assert isinstance(algo, SpiralForager)
+    assert algo.algorithm_id == "spiral_forager"
+
+
+def test_spiral_forager_flees_close_predator_before_food() -> None:
+    predator = _entity_at(100.0 - PREDATOR_FLEE_DISTANCE_SAFE / 2.0, 100.0)
+    food = _entity_at(100.0 + 10.0, 100.0)
+    fish = _fish(world=_World(predator=predator, food=food))
+    algo = SpiralForager(rng=random.Random(1))
+
+    vx, vy = algo.execute(fish)
+
+    assert vx == 1.3
+    assert vy == 0.0
+
+
+def test_spiral_forager_pursues_nearby_food() -> None:
+    food = _entity_at(100.0, 100.0 + FOOD_PURSUIT_RANGE_EXTENDED / 2.0)
+    fish = _fish(world=_World(food=food))
+    algo = SpiralForager(rng=random.Random(2))
+
+    vx, vy = algo.execute(fish)
+
+    assert vx == 0.0
+    assert math.isclose(vy, algo.parameters["food_pursuit_speed"])
+
+
+def test_spiral_forager_desperate_fish_pursues_distant_food_faster() -> None:
+    food = _entity_at(100.0, 100.0 + FOOD_PURSUIT_RANGE_EXTENDED * 2.0)
+    fish = _fish(energy=20.0, max_energy=100.0, world=_World(food=food))
+    algo = SpiralForager(rng=random.Random(3))
+
+    vx, vy = algo.execute(fish)
+
+    assert vx == 0.0
+    assert math.isclose(vy, algo.parameters["food_pursuit_speed"] * 1.3)
+
+
+def test_spiral_forager_search_resets_large_radius() -> None:
+    fish = _fish(world=_World())
+    algo = SpiralForager(rng=random.Random(4))
+    algo.spiral_radius = 150.0
+
+    vx, vy = algo.execute(fish)
+
+    assert algo.spiral_radius == 10.0
+    assert math.isclose(vx, math.cos(0.25) * algo.parameters["spiral_speed"])
+    assert math.isclose(vy, math.sin(0.25) * algo.parameters["spiral_speed"])


### PR DESCRIPTION
## What changed
Soccer reproduction-credit rewards now use the public `reproduction_component` accessor instead of reading `entity._reproduction_component` directly.

Added a regression test with a soccer participant that has no private `_reproduction_component` field, so the reward path is covered through the public component contract. Updated the improvement backlog to mark the encapsulation half of proposal 8.1 as shipped while leaving the broader reward-semantics decision open.

## Layer
- [x] Layer 2 (docs / tests / tooling - does not affect simulation results)
- [ ] Layer 1 (algorithm / config - affects simulation results)

## Why
This removes a direct reach into fish-private component storage from soccer reward code. It keeps the current repro-credit behavior intact while making the boundary cleaner for future reward-semantics work.

## Proof
Final validation after all edits:

```bash
.\.venv\Scripts\python.exe tools\pre_pr_gate.py
```

Result: passed. Smoke gate passed; non-slow shards passed: `worlds` 343 passed, `evolution` 932 passed, `backend_tools` 180 passed / 2 skipped, `core` 556 passed / 3 skipped.

Focused test run before the gate:

```bash
.\.venv\Scripts\python.exe -m pytest tests\test_soccer_ranking_and_rewards.py -q
```

Result: 10 passed.

Agent gate before final docs bookkeeping:

```bash
.\.venv\Scripts\python.exe tools\agent_gate.py
```

Result: passed, including mypy and 595 curated agent-suite tests.

Note: plain `python tools/smoke_gate.py` failed in this shell because `python` is not on PATH; the repo venv interpreter was used for all successful validation commands.