### PR TITLE
[codex] Tighten core typing annotations

### DIFF
--- a/core/entities/fish.py
+++ b/core/entities/fish.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from random import Random
+from typing import TYPE_CHECKING, TypedDict
 
 from core.config.fish import (
     ENERGY_MAX_DEFAULT,
@@ -27,6 +29,15 @@ from core.util.rng import require_rng
 from core.util.stable_hash import stable_algorithm_id
 
 logger = logging.getLogger(__name__)
+
+MovementPolicyOverride = Callable[[dict[str, object], Random], tuple[float, float]]
+
+
+class SoccerEffectState(TypedDict):
+    type: str
+    amount: float
+    timer: int
+
 
 if TYPE_CHECKING:
     from core.ecosystem import EcosystemManager
@@ -226,7 +237,7 @@ class Fish(EnergyManagementMixin, MortalityMixin, ReproductionMixin, GenericAgen
         # Size is now managed by lifecycle component, but keep reference for rendering
         self.base_width: int = FISH_BASE_WIDTH  # Will be updated by sprite adapter
         self.base_height: int = FISH_BASE_HEIGHT
-        self.soccer_effect_state: dict[str, Any] | None = None
+        self.soccer_effect_state: SoccerEffectState | None = None
 
         # Behavior execution - coordinates movement, turn costs, and cooldowns
         self._behavior_executor = BehaviorExecutor(movement_strategy)
@@ -270,15 +281,15 @@ class Fish(EnergyManagementMixin, MortalityMixin, ReproductionMixin, GenericAgen
         self.visual_state = FishVisualState()
 
         # Optional: Override movement policy (if set, used instead of genome behavior)
-        self._movement_policy: Any | None = None
+        self._movement_policy: MovementPolicyOverride | None = None
 
     @property
-    def movement_policy(self) -> Any | None:
+    def movement_policy(self) -> MovementPolicyOverride | None:
         """Get the override movement policy, if any."""
         return self._movement_policy
 
     @movement_policy.setter
-    def movement_policy(self, policy: Any | None) -> None:
+    def movement_policy(self, policy: MovementPolicyOverride | None) -> None:
         """Set an override movement policy.
 
         If set, this policy will be used instead of the genome-based behavior.

--- a/core/simulation/engine.py
+++ b/core/simulation/engine.py
@@ -58,7 +58,9 @@ from core.time_system import TimeSystem
 if TYPE_CHECKING:
     from core import entities, environment
     from core.collision_system import CollisionSystem
+    from core.code_pool import GenomeCodePool
     from core.ecosystem import EcosystemManager
+    from core.events import EventBus
     from core.object_pool import FoodPool
     from core.plant_manager import PlantManager
     from core.poker.evaluation.periodic_benchmark import PeriodicBenchmarkEvaluator
@@ -127,8 +129,8 @@ class SimulationEngine:
         self.view_mode: str = "side"
 
         # Optional wiring points populated by SystemPacks (typed for mypy)
-        self.event_bus: Any | None = None
-        self.genome_code_pool: Any | None = None
+        self.event_bus: EventBus | None = None
+        self.genome_code_pool: GenomeCodePool | None = None
 
         # Components (delegated to managers)
         self._entity_manager = EntityManager(
@@ -210,7 +212,6 @@ class SimulationEngine:
     # =========================================================================
     # Compatibility Properties
     # =========================================================================
-
     @property
     def entities_list(self) -> list[entities.Entity]:
         """All entities in the simulation (delegates to EntityManager)."""
@@ -269,7 +270,6 @@ class SimulationEngine:
     # =========================================================================
     # Setup (assembly sequence lives in core.simulation.engine_setup)
     # =========================================================================
-
     def setup(self, pack: SystemPack | None = None) -> None:
         """Setup the simulation using the provided SystemPack."""
         setup_engine(self, pack)
@@ -305,7 +305,7 @@ class SimulationEngine:
         """Get a system by name."""
         return self._system_registry.get(name)
 
-    def get_systems_debug_info(self) -> dict[str, Any]:
+    def get_systems_debug_info(self) -> dict[str, object]:
         """Get debug information from all registered systems."""
         return self._system_registry.get_debug_info()
 

--- a/core/simulation/system_registry.py
+++ b/core/simulation/system_registry.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from core.systems.base import BaseSystem
@@ -133,7 +133,7 @@ class SystemRegistry:
             return True
         return False
 
-    def get_debug_info(self) -> dict[str, Any]:
+    def get_debug_info(self) -> dict[str, object]:
         """Get debug information from all registered systems.
 
         Returns:


### PR DESCRIPTION
## What changed
Tightened a small set of core type annotations without changing runtime behavior.

- Replaced `Any` in `Fish` movement-policy override state with a concrete callable alias.
- Added a `TypedDict` for fish soccer HUD effect state.
- Typed `SimulationEngine.event_bus` and `SimulationEngine.genome_code_pool` with their concrete setup-populated classes.
- Narrowed system debug info delegation to `dict[str, object]`.

## Layer
- [x] Layer 2 (typing/tooling guardrail - does not affect simulation results)

## Why
This follows proposal 6.2 in `docs/IMPROVEMENT_PROPOSALS.md`: retire easy `Any` annotations in hot/core modules so future edits get better static feedback.

## Validation
- `py -3 -m mypy core/simulation/engine.py core/simulation/system_registry.py core/entities/fish.py` - passed
- focused nearby pytest set - 67 passed
- `py -3 tools/smoke_gate.py` - 40 passed
- `py -3 tools/agent_gate.py` - passed, including full mypy over 430 sources and 595 curated tests
- `py -3 -m pytest tests/test_god_class_limits.py -q` - 2 passed
- `py -3 tools/pre_pr_gate.py --shard core` - 561 passed, 3 skipped
- `py -3 tools/pre_pr_gate.py` - passed all shards, 2016 selected tests total, 5 skipped

No champion files, benchmark scoring, algorithms, or configs were changed.