### PR TITLE
Improvement backlog: fix stale doc entries, retire Any in code_pool, add connection status + render FPS

### DIFF
--- a/core/code_pool/pool.py
+++ b/core/code_pool/pool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import random
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -169,7 +170,9 @@ class CodePool:
 # =============================================================================
 
 
-def seek_nearest_food_policy(observation: dict[str, Any], rng: Any) -> tuple[float, float]:
+def seek_nearest_food_policy(
+    observation: dict[str, Any], rng: random.Random | None
+) -> tuple[float, float]:
     """Simple built-in movement policy that heads toward the nearest food vector.
 
     Args:
@@ -195,7 +198,9 @@ def seek_nearest_food_policy(observation: dict[str, Any], rng: Any) -> tuple[flo
     return (0.0, 0.0)
 
 
-def flee_from_threat_policy(observation: dict[str, Any], rng: Any) -> tuple[float, float]:
+def flee_from_threat_policy(
+    observation: dict[str, Any], rng: random.Random | None
+) -> tuple[float, float]:
     """Built-in movement policy that flees from the nearest threat.
 
     Args:
@@ -259,7 +264,7 @@ def _norm_angle(angle: float) -> float:
 
 
 def _scaled_param(
-    params: dict[str, Any],
+    params: dict[str, float],
     key: str,
     base: float,
     scale: float,
@@ -282,7 +287,7 @@ def _steer_action(
     stamina_floor: float,
     align_threshold: float = 0.25,
     commit_dist: float = 0.4,
-) -> dict[str, Any]:
+) -> dict[str, float]:
     """Turn toward, then dash at, the relative target (tx, ty).
 
     Turning is far more effective at low speed (RCSS divides the turn moment
@@ -318,7 +323,7 @@ def _steer_action(
     return {"turn": 0.0, "dash": dash, "kick_power": 0.0, "kick_angle": 0.0}
 
 
-def _soccer_policy_core(observation: dict[str, Any], role: str) -> dict[str, Any]:
+def _soccer_policy_core(observation: dict[str, Any], role: str) -> dict[str, float]:
     """Shared param-driven core for the builtin soccer policies.
 
     Roles differ only in off-ball positioning:
@@ -331,7 +336,7 @@ def _soccer_policy_core(observation: dict[str, Any], role: str) -> dict[str, Any
     teams and in both halves.
     """
     params_raw = observation.get("params")
-    params: dict[str, Any] = params_raw if isinstance(params_raw, dict) else {}
+    params: dict[str, float] = params_raw if isinstance(params_raw, dict) else {}
 
     self_pos = observation.get("position", {})
     sx = float(self_pos.get("x", 0.0))
@@ -426,7 +431,7 @@ def _soccer_policy_core(observation: dict[str, Any], role: str) -> dict[str, Any
 
 def default_soccer_policy_params(
     policy_id: str | None = None,
-    rng: Any = None,
+    rng: random.Random | None = None,
     jitter: float = 0.0,
 ) -> dict[str, float]:
     """Default (zero) values for all evolvable soccer policy params.
@@ -446,7 +451,9 @@ def default_soccer_policy_params(
     return values
 
 
-def chase_ball_soccer_policy(observation: dict[str, Any], rng: Any) -> dict[str, Any]:
+def chase_ball_soccer_policy(
+    observation: dict[str, Any], rng: random.Random | None
+) -> dict[str, float]:
     """Built-in soccer policy that intercepts the ball and works it toward goal.
 
     Args:
@@ -463,7 +470,9 @@ def chase_ball_soccer_policy(observation: dict[str, Any], rng: Any) -> dict[str,
         return {"turn": 0.0, "dash": 0.0, "kick_power": 0.0, "kick_angle": 0.0}
 
 
-def defensive_soccer_policy(observation: dict[str, Any], rng: Any) -> dict[str, Any]:
+def defensive_soccer_policy(
+    observation: dict[str, Any], rng: random.Random | None
+) -> dict[str, float]:
     """Built-in soccer policy that screens its own goal and clears the ball.
 
     Args:
@@ -480,7 +489,9 @@ def defensive_soccer_policy(observation: dict[str, Any], rng: Any) -> dict[str, 
         return {"turn": 0.0, "dash": 0.0, "kick_power": 0.0, "kick_angle": 0.0}
 
 
-def striker_soccer_policy(observation: dict[str, Any], rng: Any) -> dict[str, Any]:
+def striker_soccer_policy(
+    observation: dict[str, Any], rng: random.Random | None
+) -> dict[str, float]:
     """Built-in soccer policy that lurks upfield and presses in the offensive zone.
 
     Args:

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -240,11 +240,31 @@ The `# No overrides` line in `pyproject.toml`'s mypy section is where the
 per-module override block goes.
 
 ### 6.2 Retire `Any` in the hottest core modules — `S` · ★★
-Grep `core/` for `: Any`, `-> Any`, and `[Any]` (306 hits today) and replace
-the easy ones with real types — start with the entity/state modules a benchmark
-touches every frame (`core/entities/fish.py`, `backend/state_payloads.py`).
+Grep `core/` for `: Any`, `-> Any`, and `[Any]` (324 hits re-measured 2026-07;
+note this pattern misses generic-parameterized forms like `dict[str, Any]` -
+a plain `\bAny\b` count is ~900) and replace the easy ones with real types.
 Each PR: pick one module, remove its `Any`s, keep `mypy core/` green. Small,
 safe, and it compounds. **Layer 2.**
+
+**Progress / notes for the next agent:**
+- `core/entities/fish.py` — already `Any`-free, nothing to do.
+- `backend/state_payloads.py` — checked 2026-07; nearly every remaining `Any`
+  is `to_dict() -> dict[str, Any]` or a `dict[str, Any]` field on a payload
+  dataclass that generically mirrors heterogeneous wire data (genome blobs,
+  render hints, gene distributions). `Any` is the honest type there; making it
+  precise means per-payload `TypedDict`s, which is really option (a) of 7.1
+  (generate TS types from the Python models), not a small mechanical fix. Don't
+  pick this file for 6.2 - pick it up under 7.1 instead.
+- `core/code_pool/pool.py` (Completed) — `rng: Any` on the builtin
+  movement/soccer policies tightened to `random.Random | None` (verified
+  against every call site); `_scaled_param`/`_steer_action`/
+  `_soccer_policy_core`/the three soccer policy functions' `dict[str, Any]`
+  return/param tightened to `dict[str, float]`. Left `Callable[..., Any]`,
+  `exec_locals`, and `to_dict`/`from_dict`/`metadata` alone (dynamically
+  compiled callables and generic serialization - genuinely `Any`).
+- Next good candidates by hit count: `core/transfer/entity_transfer.py`,
+  `core/genetics/sanitization.py`, `core/services/stats/genetic_stats.py`,
+  `core/worlds/tank/backend.py` / `core/worlds/petri/backend.py`.
 
 ---
 

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -19,9 +19,8 @@ files to touch and a step-by-step plan, so you can pick one and follow it
 literally without holding the whole codebase in your head. Prefer the `S`
 (small) items tagged **Layer 2** — they don't change simulation results, so
 they can't regress a champion, and `pre_pr_gate` is enough to prove them safe.
-Good first picks right now: **4.3** (algorithm catalog), **1.5** (benchmark
-budgets), **6.2** (retire `Any` in one module), **4.4** (visible frontend
-connection status).
+Good first picks right now: **4.3** (algorithm catalog), **6.2** (retire `Any`
+in one module), **4.4** (visible frontend connection status).
 Follow the recipe in [AGENT_FIELD_GUIDE.md](AGENT_FIELD_GUIDE.md) — one focused
 change per PR.
 
@@ -130,19 +129,6 @@ a single short run, where natural variance dwarfs the improvement signal.
 to beat the champion in a majority of seeds. Run `pytest -x` and `mypy` on the
 edited files *before* committing so the agent never pushes a syntax/import
 break.
-
-### 1.5 Publish benchmark runtime budgets — `S` · ★★
-**Problem (external review, 2026-07).** A reviewer could not tell whether a
-benchmark was hanging or just slow: "could not complete the 5k survival
-benchmark in this sandbox, and the full suite timed out." For an evolution
-platform, benchmark reproducibility needs to be *boringly obvious*.
-
-**Plan.** Record an expected wall-clock budget for each live benchmark (short /
-medium / 5k) and surface it. Concretely: add a `expected_runtime_s` field (or a
-short table in `benchmarks/README.md`) for `survival_5k`,
-`ecosystem_health_10k`, and the soccer trainings, measured on a known machine,
-and have `tools/run_bench.py` print `elapsed 41.2s (budget ~45s)` when it
-finishes. No scoring change — pure "is this normal?" visibility. **Layer 2.**
 
 ### 1.6 One health command that works from a clean checkout — `M` · ★★
 **Problem (external review, 2026-07).** The review's #1 next move: "make one
@@ -331,6 +317,11 @@ goals, assists, wins, tank identity, and net energy.
 
 ## Shipped
 
+- **1.5 Benchmark runtime budgets.** Every live benchmark declares
+  `EXPECTED_RUNTIME_SECONDS`; `tools/run_bench.py` prints `Runtime: <elapsed>s
+  (budget ~<budget>s)` after each run, and `benchmarks/README.md` documents the
+  budget table with reference champion runtimes. Pure visibility — no scoring
+  change.
 - **4.2 `scripts/diagnose.py` health check.** A setup-oriented diagnosis command
   now checks core/backend imports, NumPy/FastAPI availability, a deterministic
   100-frame headless sim, black/ruff/mypy resolution, and frontend dependencies.

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -19,8 +19,8 @@ files to touch and a step-by-step plan, so you can pick one and follow it
 literally without holding the whole codebase in your head. Prefer the `S`
 (small) items tagged **Layer 2** — they don't change simulation results, so
 they can't regress a champion, and `pre_pr_gate` is enough to prove them safe.
-Good first picks right now: **6.2** (retire `Any` in one module), **4.4**
-(visible frontend connection status).
+Good first pick right now: **6.2** (retire `Any` in one module - see the
+"Progress / notes for the next agent" list under it before picking a file).
 Follow the recipe in [AGENT_FIELD_GUIDE.md](AGENT_FIELD_GUIDE.md) — one focused
 change per PR.
 
@@ -184,14 +184,6 @@ consolidation so the ecosystem only pays the re-baseline cost once.
 
 This is where "fun to use" and "excellent example of software design" are won.
 
-### 4.4 Frontend connection status + FPS counter — `S` · ★★
-`frontend/src/hooks/useWebSocket.ts` already reconnects on drop; what's still
-missing is the *visible* half. Add (a) a small connection-status indicator
-driven by the hook's state (connecting / live / reconnecting), and (b) an FPS
-overlay on the render loop. Makes the live UI trustworthy and exposes rendering
-bottlenecks (fractal plants are the prime suspect). Upgrade the reconnect to
-true exponential backoff if it isn't already. **Layer 2.**
-
 ### 4.5 Debug-frame / debug-entity tracing — `M` · ★★
 Add `--debug-frame N` and `--debug-entity ID` flags to the headless runner that
 dump every energy delta and event for the targeted frame/entity. Cuts
@@ -350,6 +342,17 @@ goals, assists, wins, tank identity, and net energy.
 - **4.1 One-command startup.** `start.py` launches backend + frontend together
   with sane defaults and a single Ctrl-C shutdown; the two-terminal onboarding
   friction is gone.
+- **4.4 Frontend connection status + FPS counter.** `useWebSocket` exposes a
+  `connectionStatus` of `'connecting' | 'live' | 'reconnecting'` (alongside the
+  existing `isConnected` boolean) and reconnects with real exponential backoff
+  (`computeReconnectDelay`, 3s/6s/12s/24s capped at 30s) instead of a fixed
+  3s retry. `Canvas` tracks its own render-loop FPS independent of simulation
+  data and reports it via `onRenderFps`. `TankView` wires both into the
+  `canvas-hud`/`hud-group`/`hud-item` CSS in `App.css`, which already existed
+  but had no consumer. Manually verified: killing the backend flips the
+  indicator to RECONNECTING (pulsing) and disables controls; the FPS badge
+  measurably dropped when the browser tab lost focus (rAF throttling) and
+  recovered on refocus, confirming it reflects real render health.
 - **3.1 stage 1: monolithic food-seekers benchmarked and triaged (ADR-006).**
   `tools/benchmark_algorithms.py` pins every fish to one algorithm and runs
   seeded headless worlds; 14 monoliths + composable baseline x 3 seeds.

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -19,8 +19,8 @@ files to touch and a step-by-step plan, so you can pick one and follow it
 literally without holding the whole codebase in your head. Prefer the `S`
 (small) items tagged **Layer 2** — they don't change simulation results, so
 they can't regress a champion, and `pre_pr_gate` is enough to prove them safe.
-Good first picks right now: **4.3** (algorithm catalog), **6.2** (retire `Any`
-in one module), **4.4** (visible frontend connection status).
+Good first picks right now: **6.2** (retire `Any` in one module), **4.4**
+(visible frontend connection status).
 Follow the recipe in [AGENT_FIELD_GUIDE.md](AGENT_FIELD_GUIDE.md) — one focused
 change per PR.
 
@@ -184,12 +184,6 @@ consolidation so the ecosystem only pays the re-baseline cost once.
 
 This is where "fun to use" and "excellent example of software design" are won.
 
-### 4.3 Algorithm catalog doc — `S` · ★★
-Generate `docs/ALGORITHM_CATALOG.md` from the registry: each algorithm's file,
-tunable parameters, the niche it wins, and its known weakness. This is the map
-an AI agent needs to target improvements instead of guessing. Generate it from
-code so it never goes stale.
-
 ### 4.4 Frontend connection status + FPS counter — `S` · ★★
 `frontend/src/hooks/useWebSocket.ts` already reconnects on drop; what's still
 missing is the *visible* half. Add (a) a small connection-status indicator
@@ -317,6 +311,12 @@ goals, assists, wins, tank identity, and net energy.
 
 ## Shipped
 
+- **4.3 Algorithm catalog doc.** `tools/generate_algorithm_catalog.py`
+  introspects `ALL_ALGORITHMS`/`ALGORITHM_PARAMETER_BOUNDS` and regenerates
+  `docs/ALGORITHM_CATALOG.md` (file, tunable parameters + bounds coverage,
+  deprecation status). A freshness test in `test_docs_agent_onboarding.py`
+  (part of the smoke gate) fails if the checked-in doc drifts from the
+  generator's output.
 - **1.5 Benchmark runtime budgets.** Every live benchmark declares
   `EXPECTED_RUNTIME_SECONDS`; `tools/run_bench.py` prints `Runtime: <elapsed>s
   (budget ~<budget>s)` after each run, and `benchmarks/README.md` documents the

--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -20,13 +20,19 @@ interface CanvasProps {
     style?: CSSProperties;
     viewMode?: ViewMode;
     worldType?: string;  // Optional override for renderer selection (e.g., 'petri' for circular dish)
+    /** Reports the render loop's own draw rate (~2x/sec), independent of simulation FPS. */
+    onRenderFps?: (fps: number) => void;
 }
+
+// How often to report the render-loop FPS sample (ms). Frequent enough to feel
+// live, coarse enough that it never itself becomes the render bottleneck.
+const FPS_REPORT_INTERVAL_MS = 500;
 
 // Tank world dimensions (from core/constants.py)
 const WORLD_WIDTH = 1088;
 const WORLD_HEIGHT = 612;
 
-export function Canvas({ state, width = 800, height = 600, onEntityClick, selectedEntityId, showEffects = true, showSoccer = true, style, viewMode = "side", worldType: worldTypeProp }: CanvasProps) {
+export function Canvas({ state, width = 800, height = 600, onEntityClick, selectedEntityId, showEffects = true, showSoccer = true, style, viewMode = "side", worldType: worldTypeProp, onRenderFps }: CanvasProps) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const rendererRef = useRef<Renderer | null>(null);
     const [imagesLoaded, setImagesLoaded] = useState(false);
@@ -91,6 +97,7 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
     const showSoccerRef = useRef(showSoccer);
     const viewModeRef = useRef(viewMode);
     const worldTypePropRef = useRef(worldTypeProp);
+    const onRenderFpsRef = useRef(onRenderFps);
 
     useEffect(() => {
         stateRef.current = state;
@@ -100,7 +107,8 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
         showSoccerRef.current = showSoccer;
         viewModeRef.current = viewMode;
         worldTypePropRef.current = worldTypeProp;
-    }, [state, imagesLoaded, selectedEntityId, showEffects, showSoccer, viewMode, worldTypeProp]);
+        onRenderFpsRef.current = onRenderFps;
+    }, [state, imagesLoaded, selectedEntityId, showEffects, showSoccer, viewMode, worldTypeProp, onRenderFps]);
 
     useEffect(() => {
         const canvas = canvasRef.current;
@@ -143,7 +151,26 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
 
         let animationFrameId: number;
 
+        // Render-loop FPS tracking: counts actual requestAnimationFrame calls,
+        // independent of whether there's simulation data to draw. This exposes
+        // rendering bottlenecks (e.g. fractal plants) even when the backend
+        // itself is ticking at full speed.
+        let fpsFrameCount = 0;
+        let fpsWindowStart = 0;
+
         const renderLoop = () => {
+            const nowMs = performance.now();
+            if (fpsWindowStart === 0) {
+                fpsWindowStart = nowMs;
+            }
+            fpsFrameCount += 1;
+            const fpsWindowElapsed = nowMs - fpsWindowStart;
+            if (fpsWindowElapsed >= FPS_REPORT_INTERVAL_MS) {
+                onRenderFpsRef.current?.((fpsFrameCount * 1000) / fpsWindowElapsed);
+                fpsFrameCount = 0;
+                fpsWindowStart = nowMs;
+            }
+
             const currentState = stateRef.current;
 
             if (currentState && !error) {
@@ -197,7 +224,7 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
                         canvas,
                         ctx,
                         dpr: window.devicePixelRatio || 1,
-                        nowMs: performance.now()
+                        nowMs
                     });
                 } catch (err) {
                     console.error("Render loop error:", err);

--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -8,7 +8,7 @@ import {
     type ChangeEvent,
     type ReactNode,
 } from 'react';
-import { useWebSocket } from '../hooks/useWebSocket';
+import { useWebSocket, type ConnectionStatus } from '../hooks/useWebSocket';
 import { useVisiblePanels, type PanelId } from '../hooks/useVisiblePanels';
 import { Canvas } from './Canvas';
 import { CommentaryFeed } from './CommentaryFeed';
@@ -51,9 +51,16 @@ const PANEL_CONFIG: { id: PanelId; label: string; icon: string }[] = [
     { id: 'genetics', label: 'Genetics', icon: '🧬' },
 ];
 
+const CONNECTION_STATUS_DISPLAY: Record<ConnectionStatus, { label: string; color: string }> = {
+    live: { label: 'LIVE', color: 'var(--color-success)' },
+    connecting: { label: 'CONNECTING', color: 'var(--color-primary)' },
+    reconnecting: { label: 'RECONNECTING', color: 'var(--color-warning)' },
+};
+
 export function TankView({ worldId }: TankViewProps) {
-    const { state, isConnected, sendCommand, sendCommandWithResponse, connectedWorldId, schemaError } =
+    const { state, isConnected, connectionStatus, sendCommand, sendCommandWithResponse, connectedWorldId, schemaError } =
         useWebSocket(worldId);
+    const [renderFps, setRenderFps] = useState<number | null>(null);
     const [showEffects, setShowEffects] = useState(true);
     const [showSoccer, setShowSoccer] = useState<boolean | null>(null);  // null = not yet synced from server
     const userToggledSoccer = useRef(false);  // Track if user manually toggled
@@ -190,13 +197,15 @@ export function TankView({ worldId }: TankViewProps) {
                 >
                     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                         <span
-                            className={`status-dot ${isConnected ? 'online' : 'offline'}`}
+                            className={`status-dot ${connectionStatus}${connectionStatus !== 'live' ? ' animate-pulse' : ''}`}
                             style={{
                                 width: 8,
                                 height: 8,
                                 borderRadius: '50%',
-                                background: isConnected ? 'var(--color-success)' : 'var(--color-warning)',
-                                boxShadow: isConnected ? '0 0 8px var(--color-success)' : 'none',
+                                background: CONNECTION_STATUS_DISPLAY[connectionStatus].color,
+                                boxShadow: connectionStatus === 'live'
+                                    ? '0 0 8px var(--color-success)'
+                                    : 'none',
                             }}
                         />
                         <span
@@ -207,7 +216,7 @@ export function TankView({ worldId }: TankViewProps) {
                                 letterSpacing: '0.05em',
                             }}
                         >
-                            {isConnected ? 'LIVE' : 'OFFLINE'}
+                            {CONNECTION_STATUS_DISPLAY[connectionStatus].label}
                         </span>
                     </div>
 
@@ -371,8 +380,31 @@ export function TankView({ worldId }: TankViewProps) {
                         showSoccer={effectiveShowSoccer}
                         viewMode={effectiveViewMode as 'side' | 'topdown'}
                         worldType={effectiveWorldType}
+                        onRenderFps={setRenderFps}
                     />
                     <div className="canvas-glow" aria-hidden />
+                    <div className="canvas-hud">
+                        <div className="hud-group">
+                            <div className="hud-item">
+                                <span
+                                    className={`status-dot ${connectionStatus}${connectionStatus !== 'live' ? ' animate-pulse' : ''}`}
+                                    style={{
+                                        width: 6,
+                                        height: 6,
+                                        borderRadius: '50%',
+                                        background: CONNECTION_STATUS_DISPLAY[connectionStatus].color,
+                                    }}
+                                />
+                                {CONNECTION_STATUS_DISPLAY[connectionStatus].label}
+                            </div>
+                        </div>
+                        <div className="hud-group">
+                            <div className="hud-item">
+                                <span className="hud-label">Render</span>
+                                {renderFps !== null ? `${Math.round(renderFps)} fps` : '—'}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/frontend/src/hooks/useWebSocket.test.ts
+++ b/frontend/src/hooks/useWebSocket.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { SimulationUpdate, StatsData } from '../types/simulation';
-import { applyFullUpdate, routeCommandResponse } from './useWebSocket';
+import { applyFullUpdate, routeCommandResponse, computeReconnectDelay } from './useWebSocket';
 
 /**
  * Pure function to normalize a WorldUpdatePayload into SimulationUpdate format.
@@ -184,6 +184,26 @@ describe('WebSocket Update Normalization', () => {
         expect(result.metrics_history).toBe(history);
     });
 
+});
+
+describe('computeReconnectDelay', () => {
+    it('returns the base delay for the first attempt', () => {
+        expect(computeReconnectDelay(0, 3000)).toBe(3000);
+    });
+
+    it('doubles the delay for each subsequent attempt', () => {
+        expect(computeReconnectDelay(1, 3000)).toBe(6000);
+        expect(computeReconnectDelay(2, 3000)).toBe(12000);
+        expect(computeReconnectDelay(3, 3000)).toBe(24000);
+    });
+
+    it('caps the delay at maxDelayMs', () => {
+        expect(computeReconnectDelay(10, 3000, 30000)).toBe(30000);
+    });
+
+    it('treats negative attempts as the first attempt', () => {
+        expect(computeReconnectDelay(-1, 3000)).toBe(3000);
+    });
 });
 
 describe('Command response routing', () => {

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -10,9 +10,28 @@ import { config, EXPECTED_SCHEMA_VERSION } from '../config';
 // At 30fps over long sessions, this prevents 100k+ short-lived allocations per hour.
 const sharedTextDecoder = new TextDecoder();
 
+/** Connection lifecycle as seen from outside the hook: first attempt, live, or
+ * retrying after a drop. Distinct from `isConnected` (a plain boolean) so the
+ * UI can tell "never connected yet" apart from "was live, now recovering". */
+export type ConnectionStatus = 'connecting' | 'live' | 'reconnecting';
+
+// Cap exponential backoff so a long outage still retries periodically instead
+// of growing unbounded.
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+/** Exponential backoff delay for reconnect attempt N (0-indexed), capped at maxDelayMs. */
+export function computeReconnectDelay(
+    attempt: number,
+    baseDelayMs: number,
+    maxDelayMs: number = MAX_RECONNECT_DELAY_MS
+): number {
+    return Math.min(baseDelayMs * 2 ** Math.max(0, attempt), maxDelayMs);
+}
+
 export function useWebSocket(worldId?: string) {
     const [state, setState] = useState<SimulationUpdate | null>(null);
     const [isConnected, setIsConnected] = useState(false);
+    const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connecting');
     const [schemaError, setSchemaError] = useState<string | null>(null);
     const [connectedWorldId, setConnectedWorldId] = useState<string | null>(worldId ?? null);
     const wsRef = useRef<WebSocket | null>(null);
@@ -22,6 +41,8 @@ export function useWebSocket(worldId?: string) {
     const schemaMismatchRef = useRef(false);
     const responseCallbacksRef = useRef<Map<string, (data: CommandResponse) => void>>(new Map());
     const unmountedRef = useRef(false);  // Track if component is unmounted
+    const hasConnectedOnceRef = useRef(false);
+    const reconnectAttemptRef = useRef(0);
 
     const handleSchemaMismatch = useCallback((receivedVersion: unknown) => {
         if (schemaMismatchRef.current) return;
@@ -105,6 +126,9 @@ export function useWebSocket(worldId?: string) {
                     return;
                 }
                 setIsConnected(true);
+                setConnectionStatus('live');
+                hasConnectedOnceRef.current = true;
+                reconnectAttemptRef.current = 0;
             };
 
             ws.onmessage = (event) => {
@@ -150,11 +174,14 @@ export function useWebSocket(worldId?: string) {
 
                 // Only attempt to reconnect if component is still mounted
                 if (!unmountedRef.current && !schemaMismatchRef.current) {
+                    setConnectionStatus(hasConnectedOnceRef.current ? 'reconnecting' : 'connecting');
+                    const delay = computeReconnectDelay(reconnectAttemptRef.current, config.wsReconnectDelay);
+                    reconnectAttemptRef.current += 1;
                     reconnectTimeoutRef.current = window.setTimeout(() => {
                         if (connectRef.current && !unmountedRef.current) {
                             connectRef.current();
                         }
-                    }, config.wsReconnectDelay);
+                    }, delay);
                 }
             };
 
@@ -231,6 +258,7 @@ export function useWebSocket(worldId?: string) {
     return {
         state,
         isConnected,
+        connectionStatus,
         schemaError,
         sendCommand,
         sendCommandWithResponse,


### PR DESCRIPTION
## What changed
Four independent, self-contained items picked from `docs/IMPROVEMENT_PROPOSALS.md`, each its own commit so it can be reviewed/reverted independently:

1. **Docs: mark 1.5 (benchmark runtime budgets) shipped.** Re-measured and confirmed `EXPECTED_RUNTIME_SECONDS`, the `run_bench.py` elapsed-vs-budget print, and the `benchmarks/README.md` table already existed - the proposal just hadn't been checked off.
2. **Docs: mark 4.3 (algorithm catalog doc) shipped.** Confirmed `tools/generate_algorithm_catalog.py` already regenerates `docs/ALGORITHM_CATALOG.md` byte-for-byte, with a freshness test already wired into the smoke gate.
3. **6.2: retire easy `Any` usages in `core/code_pool/pool.py`.** `rng: Any` on the builtin movement/soccer policies is now `random.Random | None` (verified against every call site in `core/genetics/genome.py`, `code_policy_traits.py`, and `core/minigames/soccer/policy_adapter.py`); `_scaled_param`/`_steer_action`/`_soccer_policy_core`/the three soccer policy functions' `dict[str, Any]` return/param is now `dict[str, float]` (always plain floats). Left `Callable[..., Any]`, `exec_locals`, and generic `to_dict`/`from_dict`/`metadata` untouched - genuinely heterogeneous. Also recorded notes in the proposal doc steering future agents away from `backend/state_payloads.py` (mostly honest `Any` usage, not an easy win - that belongs under 7.1 instead).
4. **4.4: frontend connection status + render-loop FPS overlay.** `useWebSocket` now exposes `connectionStatus: 'connecting' | 'live' | 'reconnecting'` alongside the existing `isConnected` boolean, with real exponential backoff (`computeReconnectDelay`, 3s/6s/12s/24s capped at 30s) replacing the old fixed 3s retry. `Canvas` tracks its own `requestAnimationFrame` cadence independent of simulation data and reports it via `onRenderFps`. `TankView` wires both into the `canvas-hud`/`hud-group`/`hud-item` CSS that already existed in `App.css` but had no consumer, and upgrades the stats-bar dot from binary LIVE/OFFLINE to the tri-state status with a pulse animation (also previously-unused CSS).

## Layer
- [x] Layer 2 (docs / tests / tooling / dev-experience - does not affect simulation results)
- [ ] Layer 1

None of this touches `core/algorithms`, `core/config`, or anything in the simulation hot path that would change benchmark trajectories.

## Why
Working through the "good first picks" in `docs/IMPROVEMENT_PROPOSALS.md`. Two of the four suggested picks (1.5, 4.3) turned out to already be implemented - re-measured and moved to Shipped rather than redone. The other two (6.2, 4.4) were real, unstarted work.

## Proof
- `mypy core/` clean (332 files); `python tools/agent_gate.py` green (635 tests across smoke + curated suites).
- `tools/run_bench.py benchmarks/soccer/training_3k.py --seed 42 --verify-determinism` passes (pool.py change is annotations-only, no logic touched).
- Frontend: `npx tsc -b`, `npx eslint .`, `npx vitest run` (54 passed, incl. 4 new tests for `computeReconnectDelay`), and `npm run build` all green.
- Manually verified in-browser (backend + frontend dev servers): killing the backend flips the indicator to pulsing RECONNECTING and disables controls; restarting + reloading returns to LIVE; the render-FPS badge measurably dropped when the browser tab lost focus (rAF throttling) and recovered on refocus, confirming it reflects real render health rather than a canned number.

## No regressions
`python tools/agent_gate.py` green. Pre-existing, unrelated finding (not caused by this branch, reproduced identically on master before these commits via `git stash`): the soccer `training_3k` champion config-hash check fails locally, most likely a Python 3.14 (local) vs 3.10 (CI) environment difference - related to the already-tracked "1.0 cross-machine trajectory divergence" theme, not something this PR introduces or fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)