### PR TITLE
Fix stale skipped protocol-conformance tests

### DIFF
--- a/core/entities/mixins/reproduction_mixin.py
+++ b/core/entities/mixins/reproduction_mixin.py
@@ -62,6 +62,11 @@ class ReproductionMixin:
     pos: Vector2
     visual_state: FishVisualState
 
+    @property
+    def reproduction_cooldown(self) -> int:
+        """Frames until this fish can reproduce again (Reproducible protocol)."""
+        return self._reproduction_component.reproduction_cooldown
+
     def can_reproduce(self) -> bool:
         """Check if fish can reproduce (delegates to ReproductionComponent)."""
         fish = cast("Fish", self)

--- a/core/entities/resources.py
+++ b/core/entities/resources.py
@@ -162,6 +162,10 @@ class Food(MobileEntity):
         """Check if food is fully consumed."""
         return self.energy <= 0.1  # Small threshold for float comparison
 
+    def is_consumed(self) -> bool:
+        """Check if food has been consumed (Consumable protocol)."""
+        return self.is_fully_consumed()
+
     def update(
         self, frame_count: int, time_modifier: float = 1.0, time_of_day: float | None = None
     ) -> "EntityUpdateResult":

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -578,6 +578,7 @@ class Mortal(Protocol):
         ...
 
 
+@runtime_checkable
 class Reproducible(Protocol):
     """Any entity that can reproduce.
 

--- a/tests/test_god_class_limits.py
+++ b/tests/test_god_class_limits.py
@@ -39,7 +39,7 @@ LEGACY_MAX_LINES: dict[str, int] = {
     "core/entities/fish.py": 773,
     "core/entities/plant.py": 728,
     "core/genetics/plant_genome.py": 761,
-    "core/interfaces.py": 663,
+    "core/interfaces.py": 664,
     "core/minigames/soccer/engine.py": 778,
     "core/mixed_poker/interaction.py": 728,
     "core/poker/evaluation/auto_evaluate_poker.py": 594,

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -55,25 +55,16 @@ class TestProtocolConformance:
         # Initially alive
         assert not fish.is_dead()
 
-    @pytest.mark.skip(reason="Fish exposes _reproduction_component as private, not public")
     def test_fish_implements_reproducible(self, sample_fish):
-        """Fish should satisfy the Reproducible protocol.
-
-        NOTE: Currently fails because Fish stores reproduction_component as
-        _reproduction_component (private). To fully implement Reproducible protocol,
-        Fish would need a @property reproduction_component getter.
-
-        This demonstrates how protocols help identify interface gaps!
-        """
+        """Fish should satisfy the Reproducible protocol."""
         fish = sample_fish()
 
         assert isinstance(fish, Reproducible)
-        assert hasattr(fish, "reproduction_component")
+        assert callable(fish.can_reproduce)
+        assert callable(fish.try_mate)
 
-        # Can access reproduction state
-        component = fish.reproduction_component
-        assert hasattr(component, "reproduction_cooldown")
-        assert hasattr(component, "repro_credits")
+        # Freshly created fish are off cooldown
+        assert fish.reproduction_cooldown == 0
 
     def test_fish_implements_movable(self, sample_fish):
         """Fish should satisfy the Movable protocol."""
@@ -106,14 +97,8 @@ class TestProtocolConformance:
 
         assert isinstance(fish.life_stage, LifeStage)
 
-    @pytest.mark.skip(reason="Food doesn't have is_consumed() method (has is_fully_consumed)")
     def test_food_implements_consumable(self, sample_food):
-        """Food should satisfy the Consumable protocol.
-
-        NOTE: Food has is_fully_consumed() but not is_consumed().
-        The protocol could be refined to match actual Food interface,
-        or Food could be updated to implement both methods.
-        """
+        """Food should satisfy the Consumable protocol."""
         food = sample_food()
 
         assert isinstance(food, Consumable)
@@ -121,13 +106,8 @@ class TestProtocolConformance:
         assert callable(food.is_fully_consumed)
         assert callable(food.get_eaten)
 
-    @pytest.mark.skip(reason="Crab constructor signature differs from test assumptions")
     def test_crab_implements_predator(self, sample_crab):
-        """Crab should satisfy the Predator protocol.
-
-        NOTE: Test fixture needs updating to match actual Crab constructor.
-        Once fixed, this test should verify Predator protocol conformance.
-        """
+        """Crab should satisfy the Predator protocol."""
         crab = sample_crab()
 
         assert isinstance(crab, Predator)


### PR DESCRIPTION
## What changed
`tests/test_protocols.py` had three permanently-skipped tests whose stated skip reasons no longer matched reality:

- **`test_crab_implements_predator`**: reason claimed the `Crab` constructor didn't match test assumptions. It already does (`environment, x, y` are the only params the fixture uses) — `Crab` already fully satisfies `Predator`. Un-skipped as-is, no production change needed.
- **`test_food_implements_consumable`**: reason was accurate (`Food` had `is_fully_consumed()`/`get_eaten()` but not `is_consumed()`). Added `Food.is_consumed()` as a thin alias for `is_fully_consumed()`, closing the gap the module's own docstring already claimed (`"Food: Positionable + Consumable"`).
- **`test_fish_implements_reproducible`**: reason named the wrong gap (`reproduction_component` being private). The real issues: `Reproducible` wasn't `@runtime_checkable` (`isinstance()` raises `TypeError`, not a clean assertion failure), and the protocol's actual members are `can_reproduce()`/`try_mate()`/`reproduction_cooldown` — not `reproduction_component`. Fish already had the first two; added a public `reproduction_cooldown` property to `ReproductionMixin` delegating to `_reproduction_component.reproduction_cooldown`, marked `Reproducible` `@runtime_checkable`, and rewrote the test against the protocol's real contract.

Also re-pins `core/interfaces.py`'s god-class limit from 663 to 664 lines (the `@runtime_checkable` addition) per `tests/test_god_class_limits.py`'s own re-pin procedure.

## Layer
- [ ] Layer 1 (algorithm / config — affects simulation results)
- [x] Layer 2 (docs / tests / tooling — does not affect simulation results)

## Why
A test suite that permanently skips its own conformance checks with stale reasons stops doing its job. Verified each gap by hand before touching anything (see PR diff for the exact repro used).

## Proof
- `python -m pytest tests/test_protocols.py -v` → 13 passed (0 skipped, was 3 skipped)
- `python -m mypy core/` → `Success: no issues found in 333 source files`
- `python tools/agent_gate.py` → PASS
- `python tools/pre_pr_gate.py --no-xdist` → PASS (564 passed, 15 deselected)

## No regressions
The new `reproduction_cooldown` property and `Food.is_consumed()` are purely additive (new public members); `@runtime_checkable` only affects `isinstance()` behavior for `Reproducible`, which no other code in the repo currently relies on being absent (grepped for all `Reproducible`/`reproduction_cooldown` usages). Full pre-PR gate green on this branch in isolation.