### PR TITLE
Meta: Parallelize the CI coverage-floor step with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Enforce coverage floor
       run: |
         pytest tests/ -m "not slow and not integration and not manual" \
-          --cov=core --cov=backend --cov-fail-under=70 -q
+          --cov=core --cov=backend --cov-fail-under=70 -n auto -q
 
   frontend-ci:
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
     - name: Enforce coverage floor
       run: |
         pytest tests/ -m "not slow and not integration and not manual" \
-          --cov=core --cov=backend --cov-fail-under=70 -q
+          --cov=core --cov=backend --cov-fail-under=70 -n auto -q
     - name: Upload champion verification results
       if: always()
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What changed
Adds `-n auto` to the "Enforce coverage floor" step's pytest invocation in both the `pre-pr-gate` and `nightly-full` jobs in `.github/workflows/ci.yml`.

## Layer
- [ ] Layer 1 (algorithm / config — affects simulation results)
- [x] Layer 2 (docs / tests / tooling — does not affect simulation results)

## Why
This step re-runs the entire non-slow suite a second time (`pytest tests/ -m "not slow and not integration and not manual" --cov=core --cov=backend --cov-fail-under=70`), but with no `-n` flag it runs fully serially — even though `tools/pre_pr_gate.py`'s own run of the same suite, moments earlier in the same job, already defaults to `-n auto` (see `tools/pre_pr_gate.py`'s `_run_shard`). On PR #723's CI run this step alone took 14+ minutes while the actual gate step next to it took 1m13s; a same-day `master` run measured via the GitHub Actions API took 17m54s for this exact step.

## Proof
Ran the exact CI command locally, serial vs. parallel:

| | Wall time | Coverage | Result |
|---|---|---|---|
| Serial (current) | 47.5s | 76.91% | 2017 passed, 5 skipped → PASS |
| `-n auto` (this PR) | 19.7s | 76.16% | 2017 passed, 5 skipped → PASS |

Same tests selected and executed in both runs. pytest-cov merges coverage data across xdist workers automatically, so `--cov-fail-under=70` still applies to the combined report — both runs clear the floor with room to spare; the ~0.75pp coverage delta between runs is normal variance under parallel test distribution (see e.g. `pytest-cov`'s own docs on combining coverage across workers), not a measurement error.

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → YAML OK

## No regressions
Only `.github/workflows/ci.yml` changed (2 lines, one per job). No source or test files touched. Test selection (`-m` marker expression) is untouched — same tests run, just distributed across workers instead of serially.