### PR TITLE
[codex] Retire Any from genetic stats

### DIFF
--- a/core/services/stats/genetic_stats.py
+++ b/core/services/stats/genetic_stats.py
@@ -6,7 +6,7 @@ for the simulation, extracting this logic from the main StatsCalculator.
 
 import logging
 import statistics
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ from core.config.fish import (
 )
 from core.genetics.behavioral import BEHAVIORAL_TRAIT_SPECS
 from core.genetics.physical import PHYSICAL_TRAIT_SPECS
-from core.genetics.trait import GeneticTrait, TraitSpec
+from core.genetics.trait import TraitSpec
 from core.services.stats.utils import humanize_gene_label
 from core.statistics_utils import GeneDistribution, compute_meta_stats, create_histogram
 
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 # Values that flow into the flat (dynamically-keyed) stats dict, e.g.
 # "adult_size_min", "adult_size_bins", ...
 StatValue = float | list[int] | list[float]
-GeneStatsValue = StatValue | dict[str, list[dict[str, Any]]]
+GeneStatsValue = StatValue | dict[str, list[dict[str, object]]]
 
 
 def get_genetic_distribution_stats(fish_list: list["Fish"]) -> dict[str, GeneStatsValue]:
@@ -212,7 +212,7 @@ def _build_gene_distributions(fish_list: list["Fish"]) -> dict[str, list[GeneDis
 
         for spec in specs:
             # Collect traits
-            traits: list[GeneticTrait[Any]] = []
+            traits: list[object] = []
             for f in fish_list:
                 if not hasattr(f, "genome"):
                     continue
@@ -266,7 +266,7 @@ def _build_gene_distributions(fish_list: list["Fish"]) -> dict[str, list[GeneDis
         allowed_min = float(FISH_ADULT_SIZE * FISH_SIZE_MODIFIER_MIN)
         allowed_max = float(FISH_ADULT_SIZE * FISH_SIZE_MODIFIER_MAX)
 
-        size_traits: list[GeneticTrait[Any]] = []
+        size_traits: list[object] = []
         adult_sizes = []
         for f in fish_list:
             if (
@@ -327,7 +327,7 @@ def _get_composable_behavior_distributions(fish_list: list["Fish"]) -> list[Gene
 
     # 1. Threat Response
     threat_vals = []
-    threat_traits: list[GeneticTrait[Any]] = []
+    threat_traits: list[object] = []
 
     for f in fish_list:
         if not hasattr(f, "genome"):
@@ -364,7 +364,7 @@ def _get_composable_behavior_distributions(fish_list: list["Fish"]) -> list[Gene
 
     # 2. Food Approach
     food_vals = []
-    food_traits: list[GeneticTrait[Any]] = []
+    food_traits: list[object] = []
 
     for f in fish_list:
         if not hasattr(f, "genome"):
@@ -415,7 +415,7 @@ def _get_poker_strategy_distributions(fish_list: list["Fish"]) -> list[GeneDistr
     betting_vals: list[int] = []
     hand_vals: list[int] = []
     bluff_vals: list[int] = []
-    traits: list[GeneticTrait[Any]] = []
+    traits: list[object] = []
 
     for f in fish_list:
         if not hasattr(f, "genome"):

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -245,8 +245,12 @@ safe, and it compounds. **Layer 2.**
   return/param tightened to `dict[str, float]`. Left `Callable[..., Any]`,
   `exec_locals`, and `to_dict`/`from_dict`/`metadata` alone (dynamically
   compiled callables and generic serialization - genuinely `Any`).
-- Next good candidates by hit count: `core/services/stats/genetic_stats.py`,
-  `core/worlds/tank/backend.py` / `core/worlds/petri/backend.py`. (Note: `core/transfer/entity_transfer.py` and `core/genetics/sanitization.py` are completed)
+- `core/services/stats/genetic_stats.py` (Completed) — replaced opaque
+  `GeneticTrait[Any]` lists with `list[object]` for meta-stat aggregation and
+  tightened the `gene_distributions` payload alias to `dict[str, object]`.
+- Next good candidates by hit count: `core/worlds/tank/backend.py` /
+  `core/worlds/petri/backend.py`. (Note: `core/transfer/entity_transfer.py` and
+  `core/genetics/sanitization.py` are completed)
 
 ---
 


### PR DESCRIPTION
## What changed
Retired the remaining annotation-level `Any` usage from `core/services/stats/genetic_stats.py` by treating meta-stat trait collections as opaque `list[object]` and tightening the serialized `gene_distributions` alias to `dict[str, object]`.

Also updated `docs/IMPROVEMENT_PROPOSALS.md` so Theme 6.2 marks `core/services/stats/genetic_stats.py` as completed and points future cleanup work at the next candidate modules.

## Layer
- [x] Layer 2 (docs / tests / tooling - does not affect simulation results)
- [ ] Layer 1 (algorithm / config - affects simulation results)

## Why
Theme 6.2 asks agents to retire easy `Any` usage one module at a time. In this module the trait lists are only passed to meta-stat aggregation, so the specific gene value type is intentionally opaque and does not need `GeneticTrait[Any]`.

## Validation
Commands run:

```bash
py tools/smoke_gate.py
py -m pytest tests\test_genetic_stats.py -q
py -m mypy core\services\stats\genetic_stats.py
py tools\agent_gate.py
py tools\pre_pr_gate.py
```

Results:
- Smoke gate passed: 40 tests.
- Focused genetic stats tests passed: 3 tests.
- Mypy passed for `core/services/stats/genetic_stats.py`.
- Agent gate passed: smoke + mypy over 431 source files + 595 selected tests.
- Pre-PR gate passed: smoke, worlds, evolution, backend_tools, and core shards all green.

## Notes
No champion files or Layer 1 behavior/config code were changed.