### PR TITLE
Implement multi-seed benchmark matrix tooling

### DIFF
--- a/core/research/attempt_ledger.py
+++ b/core/research/attempt_ledger.py
@@ -144,10 +144,16 @@ def log_attempt(
     }
 
     if ledger_path is None:
-        project_root = Path(__file__).resolve().parents[2]
-        research_dir = project_root / "research"
-        research_dir.mkdir(exist_ok=True)
-        final_ledger_path = research_dir / "attempts.jsonl"
+        env_path = os.environ.get("ATTEMPT_LEDGER_PATH")
+        if env_path:
+            final_ledger_path = Path(env_path)
+            if final_ledger_path.parent:
+                final_ledger_path.parent.mkdir(exist_ok=True, parents=True)
+        else:
+            project_root = Path(__file__).resolve().parents[2]
+            research_dir = project_root / "research"
+            research_dir.mkdir(exist_ok=True)
+            final_ledger_path = research_dir / "attempts.jsonl"
     else:
         final_ledger_path = Path(ledger_path)
         if final_ledger_path.parent:

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -411,15 +411,7 @@ commit/branch or diff stat if available. Wire the *writing* of records into
 that only sees wins is worthless, so log at the point of *evaluation*, not the
 point of merge.
 
-### 10.2 Multi-seed benchmark matrix tooling — `M` · ★★★
-Single-seed wins are too fragile for ALife claims (CLAUDE.md already warns
-seed-42 ecosystem scores swing several percent on trajectory noise). Add
-`tools/run_bench_matrix.py`: run one benchmark across a seed list (default e.g.
-42, 7, 123, plus N more), emit mean ± stddev and per-seed scores as one JSON
-summary, and exit nonzero if the candidate doesn't beat the champion on a
-majority of seeds. Then let `validate_improvement.py` accept a matrix summary
-as evidence. Complements 1.4 (which wires multi-seed into the agent script) —
-this is the shared tool both should call.
+
 
 ### 10.3 Held-out evaluators agents cannot edit — `L` · ★★★
 Agents can currently modify every benchmark they are scored against — the
@@ -541,6 +533,7 @@ budget" is the paper's headline figure. Depends on 10.1 and 10.2.
 - **6.1 Strict type checking for core/simulation, core/worlds, and core/genetics.** Enabled mypy strictness overrides (`disallow_untyped_defs = true`, `disallow_incomplete_defs = true`) for the `core/simulation`, `core/worlds` (excluding internal tests), and `core/genetics` packages. Resolved untyped functions, arguments, and annotations across these packages, keeping all CI gates green.
 - **1.2 Score decomposition in benchmark output.** Verified that benchmarks (`survival_5k`, `ecosystem_health_10k`, `selection_response_10k`, and `training_3k/5k`) emit a `score_breakdown` dict, and `validate_improvement.py` dynamically extracts it, displays side-by-side comparison, and reports the weakest component.
 - **6.2 Retired Any in core/transfer/entity_transfer.py and core/genetics/sanitization.py.** Tightened typing by removing generic `Any` annotations, introducing concrete entity classes, parameterizing generic `TransferOutcome[T]`, and utilizing generic `object` types for external untrusted inputs. Enabled strict typing checks override in `pyproject.toml` for `core/transfer/`.
+- **10.2 Multi-seed benchmark matrix tooling.** Created [run_bench_matrix.py](file:///c:/Users/mike/sandbox/tank/tools/run_bench_matrix.py) to run a benchmark across a seed list (default `42, 7, 123`), compute statistics (mean, min, max, stdev, n), support seed-by-seed comparison, and exit nonzero if the candidate doesn't beat the champion on a majority of seeds. Updated [validate_improvement.py](file:///c:/Users/mike/sandbox/tank/tools/validate_improvement.py) to support matrix-seed results and champion updates.
 
 - **Docs: fixed stale algorithm count (48 → 58) and completed the docs index.**
   Verified the count against `core/algorithms/registry.py` and added the missing

--- a/tests/test_run_bench_matrix.py
+++ b/tests/test_run_bench_matrix.py
@@ -1,0 +1,213 @@
+"""Tests for benchmark matrix runner toolchain and validation."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_BENCH_MATRIX = REPO_ROOT / "tools" / "run_bench_matrix.py"
+VALIDATE_IMPROVEMENT = REPO_ROOT / "tools" / "validate_improvement.py"
+
+
+def create_fake_benchmark(tmp_path: Path, scores_dict=None) -> Path:
+    bench_path = tmp_path / "fake_bench.py"
+    scores_dict = scores_dict or {42: 10.0, 7: 20.0, 123: 30.0}
+    content = f"""
+BENCHMARK_ID = "tank/survival_5k"
+CONFIG = {{"frames": 2, "world_config": {{}}}}
+EXPECTED_RUNTIME_SECONDS = 3.5
+
+SCORES = {scores_dict}
+
+def run(seed, fingerprint_callback=None):
+    score = SCORES.get(seed, 15.0)
+    return {{
+        "benchmark_id": BENCHMARK_ID,
+        "seed": seed,
+        "score": score,
+        "runtime_seconds": 0.01,
+        "metadata": {{
+            "frames": 2,
+            "avg_energy": 100.0,
+            "avg_pop": 10.0,
+        }}
+    }}
+"""
+    bench_path.write_text(content, encoding="utf-8")
+    return bench_path
+
+
+class TestRunBenchMatrix:
+    """Tests for tools/run_bench_matrix.py and matrix validation."""
+
+    def test_run_bench_matrix_basic(self, tmp_path):
+        """Test running benchmark matrix and verifying output JSON structure."""
+        fake_bench = create_fake_benchmark(tmp_path)
+        out_path = tmp_path / "matrix_result.json"
+        test_ledger = tmp_path / "attempts_test.jsonl"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(RUN_BENCH_MATRIX),
+                str(fake_bench),
+                "--seeds",
+                "42,7,123",
+                "--out",
+                str(out_path),
+            ],
+            cwd=str(REPO_ROOT),
+            env={**os.environ, "ATTEMPT_LEDGER_PATH": str(test_ledger)},
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+        # Verify JSON
+        assert out_path.exists()
+        with open(out_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert data["benchmark_id"] == "tank/survival_5k"
+        assert data["seeds"] == [42, 7, 123]
+        assert data["scores"] == [10.0, 20.0, 30.0]
+        assert data["mean"] == 20.0
+        assert data["min"] == 10.0
+        assert data["max"] == 30.0
+        assert data["n"] == 3
+        assert abs(data["stdev"] - 10.0) < 1e-6
+        assert "per_seed" in data
+        assert "42" in data["per_seed"]
+        assert data["per_seed"]["42"]["score"] == 10.0
+
+    def test_compare_and_validate_matrix(self, tmp_path):
+        """Test validating matrix results against single-seed and matrix champions."""
+        test_ledger = tmp_path / "attempts_test.jsonl"
+
+        # 1. Create a single-seed champion file
+        champ_path = tmp_path / "champion.json"
+        champ_data = {
+            "benchmark_id": "tank/survival_5k",
+            "version": 1,
+            "champion": {
+                "score": 15.0,
+                "seed": 42,
+                "timestamp": 1234567.0,
+                "config_hash": "0123456789abcdef",
+            },
+        }
+        champ_path.write_text(json.dumps(champ_data, indent=2), encoding="utf-8")
+
+        # 2. Run a matrix that beats the champion on seed 42 (e.g. seed 42 score is 16.0)
+        fake_bench_better = create_fake_benchmark(
+            tmp_path, scores_dict={42: 16.0, 7: 20.0, 123: 30.0}
+        )
+        res_better_path = tmp_path / "better.json"
+
+        # Run run_bench_matrix
+        subprocess.run(
+            [
+                sys.executable,
+                str(RUN_BENCH_MATRIX),
+                str(fake_bench_better),
+                "--seeds",
+                "42,7,123",
+                "--out",
+                str(res_better_path),
+            ],
+            cwd=str(REPO_ROOT),
+            env={**os.environ, "ATTEMPT_LEDGER_PATH": str(test_ledger)},
+        )
+
+        # Patch the config_hash of better.json to match the champion's config_hash to bypass check
+        with open(res_better_path, encoding="utf-8") as f:
+            res_data = json.load(f)
+        res_data["config_hash"] = "0123456789abcdef"
+        with open(res_better_path, "w", encoding="utf-8") as f:
+            json.dump(res_data, f, indent=2)
+
+        # Validate improvement
+        val_res = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATE_IMPROVEMENT),
+                str(res_better_path),
+                str(champ_path),
+                "--update-champion",
+            ],
+            cwd=str(REPO_ROOT),
+            env={**os.environ, "ATTEMPT_LEDGER_PATH": str(test_ledger)},
+            capture_output=True,
+            text=True,
+        )
+        assert val_res.returncode == 0, f"stdout: {val_res.stdout}\nstderr: {val_res.stderr}"
+        assert "SUCCESS: Improvement detected!" in val_res.stdout
+
+        # Verify champion is now updated to a matrix format
+        with open(champ_path, encoding="utf-8") as f:
+            updated_champ = json.load(f)
+
+        assert updated_champ["version"] == 2
+        champ_rec = updated_champ["champion"]
+        assert champ_rec["mean"] == 22.0
+        assert champ_rec["seeds"] == [42, 7, 123]
+        assert "per_seed" in champ_rec
+        assert champ_rec["per_seed"]["42"]["score"] == 16.0
+
+        # 3. Test running run_bench_matrix with --champion directly
+        # Let's run a matrix that is worse on seed 42 (score 14.0) against the updated champion
+        fake_bench_worse = create_fake_benchmark(
+            tmp_path, scores_dict={42: 14.0, 7: 15.0, 123: 15.0}
+        )
+        res_worse_path = tmp_path / "worse.json"
+
+        # Execute run_bench_matrix first
+        subprocess.run(
+            [
+                sys.executable,
+                str(RUN_BENCH_MATRIX),
+                str(fake_bench_worse),
+                "--seeds",
+                "42,7,123",
+                "--out",
+                str(res_worse_path),
+            ],
+            cwd=str(REPO_ROOT),
+            env={**os.environ, "ATTEMPT_LEDGER_PATH": str(test_ledger)},
+            capture_output=True,
+            text=True,
+        )
+
+        # Patch the champion's config_hash to match the new run's computed config_hash
+        with open(res_worse_path, encoding="utf-8") as f:
+            worse_data = json.load(f)
+        new_hash = worse_data["config_hash"]
+
+        with open(champ_path, encoding="utf-8") as f:
+            champ_data = json.load(f)
+        champ_data["champion"]["config_hash"] = new_hash
+        with open(champ_path, "w", encoding="utf-8") as f:
+            json.dump(champ_data, f, indent=2)
+
+        # Run comparison directly using --champion flag on run_bench_matrix
+        compare_res = subprocess.run(
+            [
+                sys.executable,
+                str(RUN_BENCH_MATRIX),
+                str(fake_bench_worse),
+                "--seeds",
+                "42,7,123",
+                "--champion",
+                str(champ_path),
+            ],
+            cwd=str(REPO_ROOT),
+            env={**os.environ, "ATTEMPT_LEDGER_PATH": str(test_ledger)},
+            capture_output=True,
+            text=True,
+        )
+        # Should fail because candidate is worse on all seeds (14 vs 16, 15 vs 20, 15 vs 30)
+        assert compare_res.returncode == 1
+        assert "FAILURE: Candidate failed to improve on the champion" in compare_res.stdout

--- a/tools/run_bench_matrix.py
+++ b/tools/run_bench_matrix.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Run a benchmark across a seed list and output matrix results JSON.
+
+Usage:
+    python tools/run_bench_matrix.py path/to/benchmark.py --seeds 42,7,123 --out result.json
+"""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# Add repo root to sys.path so we can import tools and core
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.run_bench import load_benchmark_module, run_benchmark, expected_runtime_seconds
+from tools.validate_improvement import get_champion_record, check_config_compatibility
+from core.solutions.config_hash import compute_config_hash
+from core.research.attempt_ledger import log_attempt
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a benchmark matrix")
+    parser.add_argument("benchmark_path", help="Path to benchmark python file")
+    parser.add_argument(
+        "--seeds",
+        default="42,7,123",
+        help="Comma-separated list of random seeds (default: 42,7,123)",
+    )
+    parser.add_argument("--out", help="Output JSON path")
+    parser.add_argument(
+        "--champion",
+        help="Path to champion JSON to compare against and decide exit status",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=1e-9,
+        help="Floating point tolerance for score comparison",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        seeds = [int(s.strip()) for s in args.seeds.split(",") if s.strip()]
+    except ValueError:
+        print("Error: --seeds must be a comma-separated list of integers.")
+        sys.exit(1)
+
+    if not seeds:
+        print("Error: No seeds specified.")
+        sys.exit(1)
+
+    try:
+        bench_module = load_benchmark_module(args.benchmark_path)
+    except Exception as e:
+        print(f"Error loading benchmark: {e}")
+        sys.exit(1)
+
+    if not hasattr(bench_module, "run") or not hasattr(bench_module, "BENCHMARK_ID"):
+        print(
+            f"Error: {args.benchmark_path} does not match benchmark contract (needs run() and BENCHMARK_ID)"
+        )
+        sys.exit(1)
+
+    benchmark_id = bench_module.BENCHMARK_ID
+    print(f"Running benchmark matrix: {benchmark_id}")
+    print(f"Seeds to evaluate: {seeds}")
+
+    per_seed = {}
+    scores = []
+    runtimes = []
+    start_total = time.time()
+
+    for idx, seed in enumerate(seeds):
+        print(f"[{idx+1}/{len(seeds)}] Running seed {seed}...")
+        start_run = time.time()
+        try:
+            res = run_benchmark(bench_module, seed)
+            run_elapsed = time.time() - start_run
+            if "runtime_seconds" not in res:
+                res["runtime_seconds"] = run_elapsed
+            scores.append(res["score"])
+            runtimes.append(res["runtime_seconds"])
+            per_seed[str(seed)] = res
+        except Exception as e:
+            print(f"Seed {seed} failed: {e}")
+            import traceback
+
+            traceback.print_exc()
+            sys.exit(1)
+
+    total_elapsed = time.time() - start_total
+    n = len(seeds)
+    mean_score = sum(scores) / n
+    min_score = min(scores)
+    max_score = max(scores)
+    stdev_score = statistics.stdev(scores) if n >= 2 else 0.0
+
+    print("\nMatrix Results Summary:")
+    print(f"  Seeds: {seeds}")
+    print(f"  Scores: {[round(s, 6) for s in scores]}")
+    print(f"  Mean:   {mean_score:.6f}")
+    print(f"  Min:    {min_score:.6f}")
+    print(f"  Max:    {max_score:.6f}")
+    print(f"  Stdev:  {stdev_score:.6f}")
+    print(f"  Total Runtime: {total_elapsed:.1f}s")
+
+    primary_seed = seeds[0]
+    config_hash = compute_config_hash(
+        benchmark_id, primary_seed, getattr(bench_module, "CONFIG", None)
+    )
+
+    # Construct the matrix result structure
+    result = {
+        "benchmark_id": benchmark_id,
+        "score": mean_score,  # Standard key
+        "seed": primary_seed,  # Standard key (integer)
+        "seeds": seeds,
+        "scores": scores,
+        "mean": mean_score,
+        "min": min_score,
+        "max": max_score,
+        "stdev": stdev_score,
+        "n": n,
+        "runtime_seconds": total_elapsed,
+        "expected_runtime_seconds": expected_runtime_seconds(bench_module),
+        "config_hash": config_hash,
+        "per_seed": per_seed,
+        "timestamp": time.time(),
+    }
+
+    if args.out:
+        print(f"Writing matrix results to {args.out}...")
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=2)
+        print(f"Matrix results written to {args.out}")
+
+    # If champion comparison is requested
+    if args.champion:
+        try:
+            with open(args.champion, encoding="utf-8") as f:
+                champion_data = json.load(f)
+            champion_record = get_champion_record(champion_data)
+        except FileNotFoundError:
+            print(
+                f"No existing champion found at {args.champion}. Treating candidate as new champion."
+            )
+            sys.exit(0)
+
+        # Check configuration compatibility for the primary seed
+        config_error = check_config_compatibility(result, champion_data)
+        if config_error:
+            print(config_error)
+            # Log config error to ledger
+            log_attempt(
+                benchmark_id=benchmark_id,
+                verdict="error",
+                candidate_score=mean_score,
+                champion_score=float(champion_record["score"]) if champion_record else None,
+                seed=seeds,
+                config_hash=config_hash,
+                description=f"Matrix config error: {config_error.splitlines()[0]}",
+            )
+            sys.exit(1)
+
+        # Compare scores
+        # We need to decide if we beat the champion on a majority of seeds.
+        # Let's see if the champion has multi-seed results recorded.
+        champ_per_seed = champion_record.get("per_seed", {})
+
+        wins = 0
+        losses = 0
+        ties = 0
+        compared_seeds = []
+
+        for seed in seeds:
+            seed_str = str(seed)
+            if seed_str in champ_per_seed:
+                cand_s = per_seed[seed_str]["score"]
+                champ_s = champ_per_seed[seed_str]["score"]
+                compared_seeds.append(seed)
+                diff = cand_s - champ_s
+                if diff > args.tolerance:
+                    wins += 1
+                elif diff < -args.tolerance:
+                    losses += 1
+                else:
+                    ties += 1
+
+        if compared_seeds:
+            print(f"\nSeed-by-seed comparison (n={len(compared_seeds)} overlapping seeds):")
+            for seed in compared_seeds:
+                seed_str = str(seed)
+                cand_s = per_seed[seed_str]["score"]
+                champ_s = champ_per_seed[seed_str]["score"]
+                print(
+                    f"  Seed {seed}: Candidate={cand_s:.6f} vs Champion={champ_s:.6f} (diff={cand_s-champ_s:+.6f})"
+                )
+
+            n_compared = len(compared_seeds)
+            print(f"Comparison summary: {wins} wins, {losses} losses, {ties} ties")
+
+            # Majority win is defined as wins > n_compared / 2
+            is_better = wins > (n_compared / 2)
+            verdict = "accepted" if is_better else "rejected"
+            desc = f"Matrix: {wins}/{n_compared} wins, {losses} losses, {ties} ties"
+        else:
+            # Fallback if no overlapping seeds:
+            # Check if champion is single-seed on primary seed or seed 42
+            champ_seed = champion_record.get("seed")
+            if champ_seed is not None and str(champ_seed) in per_seed:
+                cand_s = per_seed[str(champ_seed)]["score"]
+                champ_s = float(champion_record["score"])
+                diff = cand_s - champ_s
+                is_better = diff > args.tolerance
+                verdict = "accepted" if is_better else "rejected"
+                desc = f"Matrix fallback (seed {champ_seed}): Candidate={cand_s:.6f} vs Champion={champ_s:.6f} (diff={diff:+.6f})"
+                print(f"\nComparing on matching seed {champ_seed}:")
+                print(f"  {desc}")
+            else:
+                # Compare overall mean/score against champion score
+                cand_s = mean_score
+                champ_s = float(champion_record["score"])
+                diff = cand_s - champ_s
+                is_better = diff > args.tolerance
+                verdict = "accepted" if is_better else "rejected"
+                desc = f"Matrix fallback (mean): Candidate mean={cand_s:.6f} vs Champion score={champ_s:.6f} (diff={diff:+.6f})"
+                print("\nComparing mean vs single champion score:")
+                print(f"  {desc}")
+
+        log_attempt(
+            benchmark_id=benchmark_id,
+            verdict=verdict,
+            candidate_score=mean_score,
+            champion_score=float(champion_record["score"]),
+            seed=seeds,
+            config_hash=config_hash,
+            description=desc,
+        )
+
+        if not is_better:
+            print("\nFAILURE: Candidate failed to improve on the champion.")
+            sys.exit(1)
+        else:
+            print("\nSUCCESS: Candidate improved on the champion!")
+            sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_improvement.py
+++ b/tools/validate_improvement.py
@@ -63,14 +63,62 @@ def is_improvement(
         # If no champion exists, any valid result is an "improvement" (or rather, the new champion)
         return True
 
-    try:
-        new_score = float(new_result["score"])
-        old_score = float(get_champion_record(champion_data)["score"])
-    except (KeyError, TypeError, ValueError):
-        return False
+    champion_record = get_champion_record(champion_data)
 
-    # Check for strictly better score
-    return new_score - old_score > tolerance
+    # Check if either or both are matrix results (indicated by "per_seed" presence)
+    new_per_seed = new_result.get("per_seed")
+    old_per_seed = champion_record.get("per_seed")
+
+    if new_per_seed and old_per_seed:
+        # Compare overlapping seeds
+        overlapping = [s for s in new_per_seed if s in old_per_seed]
+        if overlapping:
+            wins = 0
+            for seed in overlapping:
+                if (
+                    float(new_per_seed[seed]["score"]) - float(old_per_seed[seed]["score"])
+                    > tolerance
+                ):
+                    wins += 1
+            # Majority of compared seeds must improve
+            return wins > len(overlapping) / 2
+        # Fallback if no overlap: compare primary seeds if matching, or fall back to score
+        champ_seed = champion_record.get("seed")
+        if champ_seed is not None and str(champ_seed) in new_per_seed:
+            return (
+                float(new_per_seed[str(champ_seed)]["score"]) - float(champion_record["score"])
+                > tolerance
+            )
+        return float(new_result["score"]) - float(champion_record["score"]) > tolerance
+
+    elif new_per_seed:
+        # Candidate is matrix, champion is single-seed
+        champ_seed = champion_record.get("seed")
+        if champ_seed is not None and str(champ_seed) in new_per_seed:
+            return (
+                float(new_per_seed[str(champ_seed)]["score"]) - float(champion_record["score"])
+                > tolerance
+            )
+        return float(new_result["score"]) - float(champion_record["score"]) > tolerance
+
+    elif old_per_seed:
+        # Candidate is single-seed, champion is matrix
+        cand_seed = new_result.get("seed")
+        if cand_seed is not None and str(cand_seed) in old_per_seed:
+            return (
+                float(new_result["score"]) - float(old_per_seed[str(cand_seed)]["score"])
+                > tolerance
+            )
+        return float(new_result["score"]) - float(champion_record["score"]) > tolerance
+
+    else:
+        # Standard flat format comparison
+        try:
+            new_score = float(new_result["score"])
+            old_score = float(champion_record["score"])
+        except (KeyError, TypeError, ValueError):
+            return False
+        return new_score - old_score > tolerance
 
 
 def update_champion_data(
@@ -109,6 +157,11 @@ def update_champion_data(
         new_champion["score_breakdown"] = new_result["score_breakdown"]
     if "config_hash" in new_result:
         new_champion["config_hash"] = new_result["config_hash"]
+
+    # Copy matrix fields if present
+    for field in ["seeds", "scores", "mean", "min", "max", "stdev", "n", "per_seed"]:
+        if field in new_result:
+            new_champion[field] = new_result[field]
 
     return {
         "benchmark_id": new_result.get("benchmark_id", "unknown"),
@@ -218,9 +271,51 @@ def main():
             old_score = old_record["score"]
             diff = new_score - float(old_score)
 
-            print(f"New Score: {new_score:.6f}")
-            print(f"Old Score: {old_score:.6f}")
+            # Print matrix/seed details if present
+            new_per_seed = result.get("per_seed")
+            old_per_seed = old_record.get("per_seed")
+
+            if new_per_seed:
+                print(f"New Score (Mean): {new_score:.6f}")
+                print(f"  Scores: {[round(s, 6) for s in result.get('scores', [])]}")
+                print(f"  Seeds:  {result.get('seeds', [])}")
+            else:
+                print(f"New Score: {new_score:.6f}")
+
+            if old_per_seed:
+                print(f"Old Score (Mean): {float(old_score):.6f}")
+                print(f"  Scores: {[round(s, 6) for s in old_record.get('scores', [])]}")
+                print(f"  Seeds:  {old_record.get('seeds', [])}")
+            else:
+                print(f"Old Score: {float(old_score):.6f}")
+
             print(f"Diff:      {diff:+.6f}")
+
+            # Print seed-by-seed table if there are overlapping seeds
+            wins = 0
+            losses = 0
+            ties = 0
+            if new_per_seed and old_per_seed:
+                overlapping = [s for s in new_per_seed if s in old_per_seed]
+                if overlapping:
+                    print("\nSeed-by-seed comparison:")
+                    for seed in overlapping:
+                        cand_s = float(new_per_seed[seed]["score"])
+                        champ_s = float(old_per_seed[seed]["score"])
+                        s_diff = cand_s - champ_s
+                        if s_diff > args.tolerance:
+                            status = "win"
+                            wins += 1
+                        elif s_diff < -args.tolerance:
+                            status = "loss"
+                            losses += 1
+                        else:
+                            status = "tie"
+                            ties += 1
+                        print(
+                            f"  Seed {seed}: Candidate={cand_s:.6f} vs Champion={champ_s:.6f} ({status}, diff={s_diff:+.6f})"
+                        )
+                    print(f"Comparison: {wins} wins, {losses} losses, {ties} ties")
 
             # Extract old breakdown
             old_breakdown = old_record.get("score_breakdown")
@@ -281,7 +376,20 @@ def main():
                     )
                 print("")
 
-            if diff < -args.tolerance:
+            # Evaluate success using the is_improvement function
+            is_better = is_improvement(result, champion, args.tolerance)
+
+            # Determine if this is a regression.
+            if new_per_seed and old_per_seed:
+                overlapping = [s for s in new_per_seed if s in old_per_seed]
+                if overlapping:
+                    is_regression = losses > wins
+                else:
+                    is_regression = diff < -args.tolerance
+            else:
+                is_regression = diff < -args.tolerance
+
+            if is_regression:
                 print("FAILURE: Regression detected.")
                 verdict = "rejected"
                 description = "Regression detected"
@@ -300,10 +408,10 @@ def main():
                 except Exception as le:
                     print(f"Warning: Failed to log attempt: {le}")
                 sys.exit(1)
-            elif abs(diff) <= args.tolerance:
-                print("Result matches champion (within tolerance).")
+            elif not is_better:
+                print("Result did not improve on champion (matches or below tolerance).")
                 verdict = "rejected"
-                description = "Result matches champion within tolerance"
+                description = "Result matches champion or did not improve"
             else:
                 print("SUCCESS: Improvement detected!")
                 verdict = "accepted"


### PR DESCRIPTION
- Create tools/run_bench_matrix.py to run a benchmark across a seed list, calculate stats (mean, min, max, stdev, n), and compare against the champion on a majority of seeds.
- Update tools/validate_improvement.py to support matrix-seed results and champion updates.
- Support ATTEMPT_LEDGER_PATH environment variable in core/research/attempt_ledger.py to allow sandboxing ledger outputs.
- Add tests/test_run_bench_matrix.py to verify functionality.
- Update docs/IMPROVEMENT_PROPOSALS.md.