### PR TITLE
[codex] Retire Any from world backend adapters

### DIFF
--- a/core/worlds/petri/backend.py
+++ b/core/worlds/petri/backend.py
@@ -6,8 +6,13 @@ Petri mode without duplicating simulation logic.
 
 from __future__ import annotations
 
-from typing import Any
+import random
 
+from core.config.simulation_config import SimulationConfig
+from core.ecosystem import EcosystemManager
+from core.entities import Entity
+from core.environment import Environment
+from core.simulation import SimulationEngine
 from core.worlds.interfaces import FAST_STEP_ACTION, MultiAgentWorldBackend, StepResult
 from core.worlds.tank.backend import TankWorldBackendAdapter
 
@@ -18,9 +23,9 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
     def __init__(
         self,
         seed: int | None = None,
-        config: Any | None = None,
+        config: SimulationConfig | dict[str, object] | None = None,
         tank_backend: TankWorldBackendAdapter | None = None,
-        **config_overrides: Any,
+        **config_overrides: object,
     ) -> None:
         if tank_backend is not None:
             self._tank_backend = tank_backend
@@ -31,14 +36,14 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
         self.supports_fast_step = True
         self._last_step_result: StepResult | None = None
 
-    def _build_render_hint(self) -> dict[str, Any]:
+    def _build_render_hint(self) -> dict[str, object]:
         return {
             "style": "topdown",
             "entity_style": "microbe",
             "dish": self._get_dish_dict(),
         }
 
-    def _get_dish_dict(self) -> dict[str, Any]:
+    def _get_dish_dict(self) -> dict[str, object]:
         """Get dish geometry from environment as a dict for render_hint."""
         env = self._tank_backend.engine.environment
         dish = env.dish if env else None
@@ -61,7 +66,7 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
             "r": PETRI_RADIUS,
         }
 
-    def reset(self, seed: int | None = None, config: dict[str, Any] | None = None) -> StepResult:
+    def reset(self, seed: int | None = None, config: dict[str, object] | None = None) -> StepResult:
         from core.worlds.petri.pack import PetriPack
 
         # Create a PetriPack from current config or provided overrides
@@ -72,7 +77,7 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
         self._last_step_result = self._patch_step_result(result)
         return self._last_step_result
 
-    def step(self, actions_by_agent: dict[str, Any] | None = None) -> StepResult:
+    def step(self, actions_by_agent: dict[str, object] | None = None) -> StepResult:
         result = self._tank_backend.step(actions_by_agent=actions_by_agent)
         self._last_step_result = self._patch_step_result(result)
         return self._last_step_result
@@ -80,7 +85,7 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
     def update(self) -> None:
         self.step({FAST_STEP_ACTION: True})
 
-    def get_current_snapshot(self) -> dict[str, Any]:
+    def get_current_snapshot(self) -> dict[str, object]:
         snapshot = self._tank_backend.get_current_snapshot()
         if snapshot:
             snapshot = dict(snapshot)
@@ -88,10 +93,10 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
             snapshot["render_hint"] = self._build_render_hint()
         return snapshot
 
-    def get_current_metrics(self, include_distributions: bool = True) -> dict[str, Any]:
+    def get_current_metrics(self, include_distributions: bool = True) -> dict[str, object]:
         return self._tank_backend.get_current_metrics(include_distributions=include_distributions)
 
-    def get_debug_snapshot(self) -> dict[str, Any]:
+    def get_debug_snapshot(self) -> dict[str, object]:
         snapshot = self._tank_backend.get_debug_snapshot()
         if snapshot:
             snapshot = dict(snapshot)
@@ -105,7 +110,7 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
         return "petri"
 
     @property
-    def entities_list(self) -> list[Any]:
+    def entities_list(self) -> list[Entity]:
         return self._tank_backend.entities_list
 
     @property
@@ -125,26 +130,26 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
         self._tank_backend.paused = value
 
     @property
-    def world(self) -> Any:
+    def world(self) -> Environment | None:
         return self._tank_backend.world
 
     @property
-    def engine(self) -> Any:
+    def engine(self) -> SimulationEngine:
         return self._tank_backend.engine
 
     @property
-    def ecosystem(self) -> Any:
+    def ecosystem(self) -> EcosystemManager | None:
         return self._tank_backend.ecosystem
 
     @property
-    def config(self) -> Any:
+    def config(self) -> SimulationConfig:
         return self._tank_backend.config
 
     @property
-    def rng(self) -> Any:
+    def rng(self) -> random.Random:
         return self._tank_backend.rng
 
-    def get_stats(self, include_distributions: bool = True) -> dict[str, Any]:
+    def get_stats(self, include_distributions: bool = True) -> dict[str, object]:
         return self._tank_backend.get_stats(include_distributions=include_distributions)
 
     def get_last_step_result(self) -> StepResult | None:
@@ -182,14 +187,14 @@ class PetriWorldBackendAdapter(MultiAgentWorldBackend):
         """Set the simulation paused state (protocol method)."""
         self._tank_backend.set_paused(value)
 
-    def get_entities_for_snapshot(self) -> list[Any]:
+    def get_entities_for_snapshot(self) -> list[Entity]:
         """Get entities for snapshot building (protocol method)."""
         return self._tank_backend.get_entities_for_snapshot()
 
-    def capture_state_for_save(self) -> dict[str, Any]:
+    def capture_state_for_save(self) -> dict[str, object]:
         """Capture complete world state for persistence (protocol method)."""
         return self._tank_backend.capture_state_for_save()
 
-    def restore_state_from_save(self, state: dict[str, Any]) -> None:
+    def restore_state_from_save(self, state: dict[str, object]) -> None:
         """Restore world state from a saved snapshot (protocol method)."""
         self._tank_backend.restore_state_from_save(state)

--- a/core/worlds/tank/backend.py
+++ b/core/worlds/tank/backend.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import logging
 import random
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, cast
 
 from core.config.simulation_config import SimulationConfig
+from core.ecosystem import EcosystemManager
+from core.entities import Entity
+from core.environment import Environment
 from core.exceptions import SimulationError
 from core.simulation import SimulationEngine
 from core.worlds.interfaces import FAST_STEP_ACTION, MultiAgentWorldBackend, StepResult
@@ -20,7 +23,6 @@ from core.worlds.tank.observation_builder import build_tank_observations
 from core.worlds.tank.pack import TankPack
 
 if TYPE_CHECKING:
-    from core import entities, environment
     from core.worlds.system_pack import SystemPack
 
 logger = logging.getLogger(__name__)
@@ -49,8 +51,8 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
     def __init__(
         self,
         seed: int | None = None,
-        config: SimulationConfig | dict[str, Any] | None = None,
-        **config_overrides: Any,
+        config: SimulationConfig | dict[str, object] | None = None,
+        **config_overrides: object,
     ) -> None:
         """Initialize the Tank world backend adapter.
 
@@ -64,7 +66,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         # Start with production defaults
         base_config = SimulationConfig.production(headless=True)
 
-        merged_config: dict[str, Any] = {}
+        merged_config: dict[str, object] = {}
         if isinstance(config, dict):
             merged_config.update(config)
         elif isinstance(config, SimulationConfig):
@@ -83,16 +85,16 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         self.supports_fast_step = True
 
     @property
-    def environment(self) -> environment.Environment | None:
+    def environment(self) -> Environment | None:
         """Expose the underlying simulation environment."""
         return self._engine.environment if self._engine else None
 
     @property
-    def world(self) -> Any:
+    def world(self) -> Environment | None:
         """Expose the underlying world (alias for environment)."""
         return self.environment
 
-    def add_entity(self, entity: entities.Entity) -> None:
+    def add_entity(self, entity: Entity) -> None:
         """Add an entity to the world (shim for tests)."""
         if self._engine is None:
             raise SimulationError("World not initialized. Call reset() before add_entity().")
@@ -101,7 +103,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
     def reset(
         self,
         seed: int | None = None,
-        config: dict[str, Any] | None = None,
+        config: dict[str, object] | None = None,
         pack: SystemPack | None = None,
     ) -> StepResult:
         """Reset the tank world to initial state.
@@ -111,12 +113,10 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             config: Tank-specific configuration overrides
             pack: Optional SystemPack to use
         """
-        # Use provided seed or fall back to constructor seed
         reset_seed = seed if seed is not None else self._seed
         if config:
             self._simulation_config = self._simulation_config.apply_flat_config(config)
 
-        # Create RNG from seed
         if reset_seed is None:
             # Fallback to a default seed if none provided to satisfy determinism policy
             reset_seed = 42
@@ -130,7 +130,6 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             seed=reset_seed,
         )
 
-        # Setup with pack (either provided or default TankPack)
         self._pack = pack or TankPack(self._simulation_config)
         self._engine.setup(self._pack)
         self._current_frame = 0
@@ -142,7 +141,6 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             f"Tank world reset with seed={reset_seed}, " f"config={self._simulation_config}"
         )
 
-        # Return initial state
         snapshot = self._build_snapshot()
         self._last_step_result = StepResult(
             obs_by_agent={},  # No agent observations yet
@@ -154,7 +152,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             spawns=[],
             removals=[],
             energy_deltas=[],
-            render_hint=snapshot.get("render_hint"),
+            render_hint=cast(dict[str, object] | None, snapshot.get("render_hint")),
         )
         return self._last_step_result
 
@@ -202,7 +200,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         self._engine.paused = value
 
     @property
-    def entities_list(self) -> list[Any]:
+    def entities_list(self) -> list[Entity]:
         """Expose entities list for snapshot builders."""
         if self._engine is None:
             raise SimulationError(
@@ -210,7 +208,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             )
         return self._engine.entities_list
 
-    def get_entities_for_snapshot(self) -> list[Any]:
+    def get_entities_for_snapshot(self) -> list[Entity]:
         """Get entities for snapshot building (protocol method)."""
         if self._engine is None:
             return []
@@ -237,7 +235,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         self._cached_brain_mode = brain_mode
         return brain_mode
 
-    def step(self, actions_by_agent: dict[str, Any] | None = None) -> StepResult:
+    def step(self, actions_by_agent: dict[str, object] | None = None) -> StepResult:
         """Advance the tank world by one time step.
 
         The step now follows an action pipeline internally:
@@ -262,7 +260,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         brain_mode = self._get_brain_mode()
 
         # External brain mode: build observations and apply actions
-        obs_by_agent: dict[str, Any] = {}
+        obs_by_agent: dict[str, object] = {}
         if brain_mode == "external" and not fast_step:
             observations = build_tank_observations(self)
             obs_by_agent = {str(k): v.__dict__ for k, v in observations.items()}
@@ -310,7 +308,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             spawns=frame_outputs.spawns,
             removals=frame_outputs.removals,
             energy_deltas=frame_outputs.energy_deltas,
-            render_hint=snapshot.get("render_hint"),
+            render_hint=cast(dict[str, object] | None, snapshot.get("render_hint")),
         )
         return self._last_step_result
 
@@ -326,13 +324,13 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         self._engine.update()
         self._current_frame = self._engine.frame_count
 
-    def get_stats(self, include_distributions: bool = True) -> dict[str, Any]:
+    def get_stats(self, include_distributions: bool = True) -> dict[str, object]:
         """Return current metrics."""
         if self._engine is None:
             raise SimulationError("World not initialized. Call reset() before get_stats().")
         return self.get_current_metrics(include_distributions=include_distributions)
 
-    def get_current_snapshot(self) -> dict[str, Any]:
+    def get_current_snapshot(self) -> dict[str, object]:
         """Get current world state snapshot.
 
         Returns:
@@ -343,7 +341,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
 
         return self._build_snapshot()
 
-    def get_current_metrics(self, include_distributions: bool = True) -> dict[str, Any]:
+    def get_current_metrics(self, include_distributions: bool = True) -> dict[str, object]:
         """Get current simulation metrics/statistics.
 
         Returns:
@@ -358,7 +356,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             metrics["frame"] = self._engine.frame_count
         return metrics
 
-    def _build_snapshot(self) -> dict[str, Any]:
+    def _build_snapshot(self) -> dict[str, object]:
         """Build a minimal snapshot of current world state.
 
         Returns only cheap metadata. Entity data is built separately by the
@@ -382,7 +380,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             },
         }
 
-    def get_debug_snapshot(self) -> dict[str, Any]:
+    def get_debug_snapshot(self) -> dict[str, object]:
         """Build a full snapshot including all entities (for debugging/testing).
 
         This method builds a complete snapshot with entity data. It should NOT
@@ -400,7 +398,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         snapshot["entities"] = self._build_entities_list()
         return snapshot
 
-    def _build_entities_list(self) -> list[dict[str, Any]]:
+    def _build_entities_list(self) -> list[dict[str, object]]:
         """Build list of all entities for persistence/debugging.
 
         Uses the proper entity transfer codecs to ensure full serialization
@@ -419,8 +417,8 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         from core.transfer.entity_transfer import serialize_entity_for_transfer
 
         # Import soccer types
-        BallCls: type[Any] | None
-        GoalZoneCls: type[Any] | None
+        BallCls: type[Entity] | None
+        GoalZoneCls: type[Entity] | None
         try:
             from core.entities.ball import Ball as BallCls
             from core.entities.goal_zone import GoalZone as GoalZoneCls
@@ -499,7 +497,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
 
         return entities_snapshot
 
-    def _collect_recent_events(self) -> list[dict[str, Any]]:
+    def _collect_recent_events(self) -> list[dict[str, object]]:
         """Collect recent events from the simulation.
 
         Returns:
@@ -554,7 +552,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         return self._last_step_result
 
     @property
-    def engine(self) -> Any:
+    def engine(self) -> SimulationEngine:
         """Access underlying simulation engine.
 
         This allows existing backend code to access adapter.engine.
@@ -564,7 +562,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         return self._engine
 
     @property
-    def ecosystem(self) -> Any:
+    def ecosystem(self) -> EcosystemManager | None:
         """Access underlying ecosystem."""
         if self._engine is None:
             raise SimulationError("World not initialized. Call reset() before accessing ecosystem.")
@@ -576,7 +574,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
         return self._simulation_config
 
     @property
-    def rng(self) -> Any:
+    def rng(self) -> random.Random:
         """Access random number generator."""
         if self._rng is None:
             raise SimulationError("World not initialized. Call reset() before accessing rng.")
@@ -586,7 +584,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
     # Protocol methods for state persistence
     # ========================================================================
 
-    def capture_state_for_save(self) -> dict[str, Any]:
+    def capture_state_for_save(self) -> dict[str, object]:
         """Capture complete world state for persistence.
 
         This provides a lightweight snapshot that can be serialized.
@@ -613,7 +611,7 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
             "entities": self._build_entities_list(),
         }
 
-    def restore_state_from_save(self, state: dict[str, Any]) -> None:
+    def restore_state_from_save(self, state: dict[str, object]) -> None:
         """Restore world state from a saved snapshot.
 
         Note: Full restoration including entities is handled by
@@ -628,4 +626,4 @@ class TankWorldBackendAdapter(MultiAgentWorldBackend):
 
         # Restore pause state if present
         if "paused" in state:
-            self._engine.paused = state["paused"]
+            self._engine.paused = cast(bool, state["paused"])

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -305,8 +305,15 @@ safe, and it compounds. **Layer 2.**
 - `core/services/stats/genetic_stats.py` (Completed) — replaced opaque
   `GeneticTrait[Any]` lists with `list[object]` for meta-stat aggregation and
   tightened the `gene_distributions` payload alias to `dict[str, object]`.
-- Next good candidates by hit count: `core/worlds/tank/backend.py` /
-  `core/worlds/petri/backend.py`. (Note: `core/transfer/entity_transfer.py` and
+- `core/worlds/petri/backend.py` (Completed) — removed module-level `Any`
+  annotations by typing delegated config/runtime accessors and using
+  `dict[str, object]` for heterogeneous snapshot/action payloads.
+- `core/worlds/tank/backend.py` (Completed) — removed module-level `Any`
+  annotations by typing engine/environment/entity accessors and using
+  `dict[str, object]` for config, actions, snapshots, and recent events.
+- Next good candidate by hit count: re-run `rg -n "\bAny\b" core/` and pick one
+  small core module with mechanical annotations. (Note:
+  `core/transfer/entity_transfer.py` and
   `core/genetics/sanitization.py` are completed)
 
 ---

--- a/tests/test_god_class_limits.py
+++ b/tests/test_god_class_limits.py
@@ -56,7 +56,7 @@ LEGACY_MAX_LINES: dict[str, int] = {
     "core/solutions/tracker.py": 590,
     "core/spatial/grid.py": 795,
     "core/transfer/entity_transfer.py": 752,
-    "core/worlds/tank/backend.py": 631,
+    "core/worlds/tank/backend.py": 629,
 }
 
 # Maximum allowed lines for files not grandfathered in LEGACY_MAX_LINES.


### PR DESCRIPTION
## What changed
Removed module-level `Any` annotations from the Tank and Petri world backend adapters by replacing them with concrete runtime types and `dict[str, object]` payload annotations.

## Layer
- [x] Layer 2 (docs / tests / tooling — does not affect simulation results)

## Why
This continues the Theme 6.2 type-safety cleanup from `docs/IMPROVEMENT_PROPOSALS.md`. The world backend adapters are hot integration points for agents and frontend/backend contracts, so reducing opaque `Any` usage gives mypy more useful surface area without changing simulation behavior.

## Details
- Typed Tank backend environment, entity, engine, ecosystem, config, and RNG accessors.
- Typed Tank/Petri heterogeneous config, action, snapshot, event, and persistence payloads as `dict[str, object]`.
- Marked both world backend cleanup items complete in the improvement proposals backlog.
- Tightened the god-class ratchet for `core/worlds/tank/backend.py` from 631 to 629 lines after the cleanup shrank the file.

## Validation
- `./.venv/Scripts/python.exe tools/smoke_gate.py`
- `./.venv/Scripts/python.exe -m mypy core/worlds/tank/backend.py core/worlds/petri/backend.py`
- `./.venv/Scripts/python.exe -m pytest tests/test_god_class_limits.py::test_no_new_god_classes -q`
- `./.venv/Scripts/python.exe tools/agent_gate.py`
- `./.venv/Scripts/python.exe tools/pre_pr_gate.py`

## Notes
No benchmark claim is made; this is a Layer 2 type-safety cleanup.