### PR TITLE
[codex] Retire Any from small core helpers

### DIFF
--- a/core/agents_wrapper.py
+++ b/core/agents_wrapper.py
@@ -5,8 +5,32 @@ supporting both raw lists (for testing) and engine-aware management
 that keeps spatial grids and caches in sync.
 """
 
-from collections.abc import Iterator
-from typing import Any
+from __future__ import annotations
+
+from collections.abc import Iterator, MutableSequence
+from typing import TYPE_CHECKING, Protocol, TypeGuard
+
+if TYPE_CHECKING:
+    from core.entities.base import Entity
+
+
+class _EntityBackedEngine(Protocol):
+    """Minimal engine surface needed for entity collection management."""
+
+    @property
+    def entities_list(self) -> list[Entity]: ...
+
+    def add_entity(self, entity: Entity) -> None: ...
+
+    def remove_entity(self, entity: Entity) -> None: ...
+
+
+def _is_entity_backed_engine(value: object) -> TypeGuard[_EntityBackedEngine]:
+    return hasattr(value, "_entity_manager") and hasattr(value, "entities_list")
+
+
+def _is_entity_sequence(value: object) -> TypeGuard[MutableSequence[Entity]]:
+    return isinstance(value, MutableSequence)
 
 
 class AgentsWrapper:
@@ -22,7 +46,7 @@ class AgentsWrapper:
         spatial indexing consistency.
     """
 
-    def __init__(self, entities_or_engine: Any) -> None:
+    def __init__(self, entities_or_engine: object) -> None:
         """Initialize the wrapper.
 
         Args:
@@ -31,16 +55,17 @@ class AgentsWrapper:
         """
         # Support both list usage (for tests) and engine-aware management
         # Check for _entity_manager to detect SimulationEngine
-        if hasattr(entities_or_engine, "_entity_manager") and hasattr(
-            entities_or_engine, "entities_list"
-        ):
+        self._engine: _EntityBackedEngine | None
+        if _is_entity_backed_engine(entities_or_engine):
             self._engine = entities_or_engine
-            self._entities: list[Any] = entities_or_engine.entities_list
-        else:
+            self._entities: MutableSequence[Entity] = entities_or_engine.entities_list
+        elif _is_entity_sequence(entities_or_engine):
             self._engine = None
             self._entities = entities_or_engine
+        else:
+            raise TypeError("AgentsWrapper requires an entity list or SimulationEngine")
 
-    def add(self, *entities: Any) -> None:
+    def add(self, *entities: Entity) -> None:
         """Add entities to the list or engine-aware collection.
 
         When backed by an engine, uses the public add_entity() API which
@@ -48,18 +73,16 @@ class AgentsWrapper:
         """
         for entity in entities:
             if entity in self._entities:
-                if hasattr(entity, "add_internal"):
-                    entity.add_internal(self)
+                entity.add_internal(self)
                 continue
 
             if self._engine is not None:
                 self._engine.add_entity(entity)
             else:
                 self._entities.append(entity)
-            if hasattr(entity, "add_internal"):
-                entity.add_internal(self)
+            entity.add_internal(self)
 
-    def remove(self, *entities: Any) -> None:
+    def remove(self, *entities: Entity) -> None:
         """Remove entities from the list or engine-aware collection.
 
         When backed by an engine, uses the public remove_entity() API which
@@ -78,11 +101,11 @@ class AgentsWrapper:
         for entity in list(self._entities):
             self.remove(entity)
 
-    def __contains__(self, entity: Any) -> bool:
+    def __contains__(self, entity: object) -> bool:
         """Check if entity is in the collection."""
         return entity in self._entities
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[Entity]:
         """Iterate over entities."""
         return iter(self._entities)
 

--- a/core/entity_ids.py
+++ b/core/entity_ids.py
@@ -51,7 +51,6 @@ Design Notes:
 """
 
 from dataclasses import dataclass
-from typing import Any
 
 # ============================================================================
 # Base ID Type
@@ -87,7 +86,7 @@ class EntityId:
         """Debug representation."""
         return f"{self.__class__.__name__}({self.value})"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Compare to same type or raw int."""
         if isinstance(other, self.__class__):
             return self.value == other.value
@@ -99,7 +98,7 @@ class EntityId:
         """Hash based on value (same as raw int)."""
         return hash(self.value)
 
-    def __lt__(self, other: Any) -> bool:
+    def __lt__(self, other: object) -> bool:
         """Less than comparison."""
         if isinstance(other, self.__class__):
             return self.value < other.value
@@ -107,7 +106,7 @@ class EntityId:
             return self.value < other
         return NotImplemented
 
-    def __le__(self, other: Any) -> bool:
+    def __le__(self, other: object) -> bool:
         """Less than or equal comparison."""
         if isinstance(other, self.__class__):
             return self.value <= other.value
@@ -115,7 +114,7 @@ class EntityId:
             return self.value <= other
         return NotImplemented
 
-    def __gt__(self, other: Any) -> bool:
+    def __gt__(self, other: object) -> bool:
         """Greater than comparison."""
         if isinstance(other, self.__class__):
             return self.value > other.value
@@ -123,7 +122,7 @@ class EntityId:
             return self.value > other
         return NotImplemented
 
-    def __ge__(self, other: Any) -> bool:
+    def __ge__(self, other: object) -> bool:
         """Greater than or equal comparison."""
         if isinstance(other, self.__class__):
             return self.value >= other.value

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -311,6 +311,12 @@ safe, and it compounds. **Layer 2.**
 - `core/worlds/tank/backend.py` (Completed) — removed module-level `Any`
   annotations by typing engine/environment/entity accessors and using
   `dict[str, object]` for config, actions, snapshots, and recent events.
+- `core/agents_wrapper.py` (Completed) — replaced loose collection `Any`
+  annotations with an entity-backed engine protocol and typed mutable entity
+  sequence.
+- `core/entity_ids.py` (Completed) — changed rich-comparison parameters from
+  `Any` to `object`, matching Python's comparison protocol while preserving raw
+  integer compatibility.
 - Next good candidate by hit count: re-run `rg -n "\bAny\b" core/` and pick one
   small core module with mechanical annotations. (Note:
   `core/transfer/entity_transfer.py` and


### PR DESCRIPTION
## What changed
Removed module-level `Any` usage from two small core helper modules.

## Layer
- [x] Layer 2 (docs / tests / tooling — does not affect simulation results)

## Why
This continues the Theme 6.2 type-safety cleanup from `docs/IMPROVEMENT_PROPOSALS.md`. These modules are small but central enough that tighter annotations give future edits better guardrails without changing simulation behavior.

## Details
- Typed `AgentsWrapper` with a minimal entity-backed engine protocol and mutable entity sequence guard.
- Changed `EntityId` rich-comparison parameters from `Any` to `object`, matching Python's comparison protocol while preserving raw integer compatibility.
- Updated the 6.2 progress notes in `docs/IMPROVEMENT_PROPOSALS.md`.

## Validation
- `./.venv/Scripts/python.exe tools/smoke_gate.py`
- `./.venv/Scripts/python.exe -m mypy core/agents_wrapper.py core/entity_ids.py`
- `./.venv/Scripts/python.exe -m ruff check core/agents_wrapper.py core/entity_ids.py`
- `./.venv/Scripts/python.exe -c "from core.entity_ids import FishId, PlantId; assert FishId(2) == 2; assert FishId(2) > FishId(1); assert FishId(2) != PlantId(2); print('entity id comparison smoke passed')"`
- `./.venv/Scripts/python.exe -m pytest tests/test_agents.py tests/test_collision.py -q`
- `./.venv/Scripts/python.exe tools/agent_gate.py`
- `./.venv/Scripts/python.exe tools/pre_pr_gate.py`

## Notes
No benchmark claim is made; this is a Layer 2 type-safety cleanup.