### PR TITLE
[codex] Retire Any in small core modules

### DIFF
--- a/core/actions/__init__.py
+++ b/core/actions/__init__.py
@@ -7,6 +7,7 @@ from external brains to domain-specific actions for each world type.
 from core.actions.action_registry import (
     ActionSpace,
     ActionTranslator,
+    RawAction,
     get_action_space,
     list_registered_translators,
     register_action_translator,
@@ -16,6 +17,7 @@ from core.actions.action_registry import (
 __all__ = [
     "ActionSpace",
     "ActionTranslator",
+    "RawAction",
     "get_action_space",
     "list_registered_translators",
     "register_action_translator",

--- a/core/actions/action_registry.py
+++ b/core/actions/action_registry.py
@@ -12,7 +12,7 @@ Usage:
         def get_action_space(self) -> ActionSpace:
             return {"movement": {"type": "continuous", "shape": (2,)}}
 
-        def translate_action(self, agent_id: str, raw_action: Any) -> Action:
+        def translate_action(self, agent_id: str, raw_action: RawAction) -> Action:
             return Action(entity_id=agent_id, target_velocity=raw_action["velocity"])
 
     register_action_translator("tank", TankActionTranslator())
@@ -27,7 +27,8 @@ Usage:
 from __future__ import annotations
 
 import logging
-from typing import Any, Protocol
+from collections.abc import Mapping, Sequence
+from typing import Protocol
 
 from core.brains.contracts import BrainAction
 
@@ -36,8 +37,10 @@ Action = BrainAction
 
 logger = logging.getLogger(__name__)
 
-# Type alias for action space descriptors
-ActionSpace = dict[str, Any]
+RawAction = Action | Mapping[str, object] | Sequence[object]
+"""Raw action payload accepted from external brain/policy code."""
+
+ActionSpace = dict[str, object]
 """Describes valid actions for a world type.
 
 Example:
@@ -72,7 +75,7 @@ class ActionTranslator(Protocol):
         """
         ...
 
-    def translate_action(self, agent_id: str, raw_action: Any) -> Action:
+    def translate_action(self, agent_id: str, raw_action: RawAction) -> Action:
         """Translate a raw action to a domain Action.
 
         Args:
@@ -138,7 +141,7 @@ def get_action_space(world_type: str) -> ActionSpace | None:
 def translate_action(
     world_type: str,
     agent_id: str,
-    raw_action: Any,
+    raw_action: RawAction,
 ) -> Action:
     """Translate a raw action using the registered translator.
 

--- a/core/energy/energy_utils.py
+++ b/core/energy/energy_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Protocol, cast, runtime_checkable
 
 
 @runtime_checkable
@@ -13,8 +13,20 @@ class EnergyModifier(Protocol):
         """Apply an energy delta and return the actual change."""
 
 
+class EnergyAttributeHolder(Protocol):
+    """Object with mutable direct energy storage."""
+
+    energy: float
+
+
+class BoundedEnergyAttributeHolder(EnergyAttributeHolder, Protocol):
+    """Object with direct energy storage and a maximum energy cap."""
+
+    max_energy: float
+
+
 def apply_energy_delta(
-    entity: Any,
+    entity: object,
     delta: float,
     *,
     source: str = "unknown",
@@ -46,13 +58,18 @@ def apply_energy_delta(
     if not hasattr(entity, "energy"):
         raise AttributeError("Cannot apply energy delta without energy attribute.")
 
-    old_energy = float(entity.energy)
-    max_energy = getattr(entity, "max_energy", None)
+    energy_holder = cast(EnergyAttributeHolder, entity)
+    old_energy = float(energy_holder.energy)
+    max_energy = (
+        cast(BoundedEnergyAttributeHolder, entity).max_energy
+        if hasattr(entity, "max_energy")
+        else None
+    )
     new_energy = old_energy + delta
     if max_energy is not None:
         new_energy = max(0.0, min(new_energy, float(max_energy)))
     else:
         new_energy = max(0.0, new_energy)
 
-    entity.energy = new_energy
+    energy_holder.energy = new_energy
     return float(new_energy - old_energy)

--- a/core/entities/base.py
+++ b/core/entities/base.py
@@ -25,7 +25,7 @@ non-steering movers don't inherit AI behaviors.
 """
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Protocol
 
 from core.config.display import DEFAULT_AGENT_SIZE
 from core.config.fish import ALIGNMENT_SPEED_CHANGE, AVOIDANCE_SPEED_CHANGE
@@ -47,7 +47,15 @@ class EntityUpdateResult:
     """
 
     spawned_entities: list[Entity] = field(default_factory=list)
-    events: list[Any] = field(default_factory=list)
+    events: list[object] = field(default_factory=list)
+
+
+class SpriteGroup(Protocol):
+    """Minimal group protocol needed for entity removal."""
+
+    def remove(self, entity: Entity) -> object:
+        """Remove an entity from the group."""
+        ...
 
 
 class Rect:
@@ -122,7 +130,7 @@ class Entity:
         self.blocks_root_spots: bool = False
 
         self.rect: Rect = Rect(x, y, self.width, self.height)
-        self._groups: list = []  # Track sprite groups for kill() method
+        self._groups: list[SpriteGroup] = []  # Track sprite groups for kill() method
 
         # Lifecycle state machine (Active -> Dead/Removed)
         self.state = create_entity_state_machine(track_history=True)
@@ -150,7 +158,7 @@ class Entity:
         """
         return EntityUpdateResult()
 
-    def add_internal(self, group: Any) -> None:
+    def add_internal(self, group: SpriteGroup) -> None:
         """Track group for kill() method."""
         if group not in self._groups:
             self._groups.append(group)

--- a/core/genetics/behavioral_inheritance.py
+++ b/core/genetics/behavioral_inheritance.py
@@ -13,7 +13,7 @@ split): RNG call order is determinism-critical and must not change.
 """
 
 import random as pyrandom
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from core.genetics.mate_preferences import (
     DEFAULT_MATE_PREFERENCES,
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 def inherit_trait_meta(
     parent1_trait: GeneticTrait | None,
     parent2_trait: GeneticTrait | None,
-    value: Any,
+    value: object,
     rng: pyrandom.Random,
 ) -> GeneticTrait:
     """Create a GeneticTrait with inherited meta-values from parents.

--- a/core/genetics/mate_preferences.py
+++ b/core/genetics/mate_preferences.py
@@ -10,7 +10,7 @@ compatibility.
 """
 
 import random as pyrandom
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional, SupportsFloat, SupportsIndex, cast
 
 from core.evolution.inheritance import inherit_discrete_trait as _inherit_discrete_trait
 from core.evolution.inheritance import inherit_trait as _inherit_trait
@@ -62,9 +62,9 @@ def default_preference_value(spec: TraitSpec) -> float:
     return float(midpoint)
 
 
-def coerce_preference_value(value: Any, spec: TraitSpec) -> float:
+def coerce_preference_value(value: object, spec: TraitSpec) -> float:
     try:
-        numeric = float(value)
+        numeric = float(cast(str | SupportsFloat | SupportsIndex, value))
     except (TypeError, ValueError):
         numeric = default_preference_value(spec)
     if spec.discrete:

--- a/core/minigames/soccer/seeds.py
+++ b/core/minigames/soccer/seeds.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Any
 
 
-def stable_seed_from_parts(*parts: Any) -> int:
+def stable_seed_from_parts(*parts: object) -> int:
     """Build a stable 32-bit seed from arbitrary parts."""
     seed_material = "|".join(str(part) for part in parts).encode("utf-8")
     return int.from_bytes(hashlib.sha256(seed_material).digest()[:4], "little") & 0xFFFFFFFF

--- a/core/modes/petri.py
+++ b/core/modes/petri.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Callable
 
 from core.modes.interfaces import ModePackDefinition
 from core.modes.tank import normalize_tank_config
@@ -10,7 +10,7 @@ from core.modes.tank import normalize_tank_config
 
 def create_petri_mode_pack(
     *,
-    snapshot_builder_factory: Any | None = None,
+    snapshot_builder_factory: Callable[[], object] | None = None,
 ) -> ModePackDefinition:
     """Create the Petri Dish mode pack.
 

--- a/core/modes/tank.py
+++ b/core/modes/tank.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Callable
 
 from core.config.display import FRAME_RATE, SCREEN_HEIGHT, SCREEN_WIDTH
 from core.config.ecosystem import CRITICAL_POPULATION_THRESHOLD, MAX_POPULATION
@@ -21,7 +21,7 @@ TANK_MODE_DEFAULTS = {
 
 
 def normalize_tank_config(config: ModeConfig) -> ModeConfig:
-    normalized: dict[str, Any] = dict(config)
+    normalized: ModeConfig = dict(config)
 
     for key, default in TANK_MODE_DEFAULTS.items():
         normalized.setdefault(key, default)
@@ -31,7 +31,7 @@ def normalize_tank_config(config: ModeConfig) -> ModeConfig:
 
 def create_tank_mode_pack(
     *,
-    snapshot_builder_factory: Any | None = None,
+    snapshot_builder_factory: Callable[[], object] | None = None,
 ) -> ModePackDefinition:
     """Create the Tank mode pack with optional snapshot builder hook."""
     return ModePackDefinition(

--- a/core/policies/movement_policy_runner.py
+++ b/core/policies/movement_policy_runner.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import logging
 import math
 import random as pyrandom
-from typing import TYPE_CHECKING, Any
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, SupportsFloat, SupportsIndex, cast
 
 from core.math_utils import Vector2
 from core.policies.interfaces import MovementAction
@@ -129,11 +130,11 @@ def _extract_frame(observation: dict[str, Any]) -> int | None:
         return None
 
 
-def _parse_and_validate_output(output: Any) -> VelocityComponents | None:
+def _parse_and_validate_output(output: object) -> VelocityComponents | None:
     """Parse policy output into (vx, vy) and validate.
 
     Contract:
-    - Input: Any object returned by policy
+    - Input: arbitrary object returned by policy
     - Output: (vx, vy) tuple of floats, clamped to [-1.0, 1.0], or None if invalid
 
     Supported formats:
@@ -142,24 +143,25 @@ def _parse_and_validate_output(output: Any) -> VelocityComponents | None:
     - tuple/list [vx, vy]
     - dict {"vx": vx, "vy": vy} or {"x": vx, "y": vy} or {"target_velocity": [vx, vy]}
     """
-    vx, vy = 0.0, 0.0
+    vx_raw: object
+    vy_raw: object
 
     # Extract raw values
     if isinstance(output, MovementAction):
-        vx, vy = output.vx, output.vy
+        vx_raw, vy_raw = output.vx, output.vy
     elif isinstance(output, Vector2):
-        vx, vy = output.x, output.y
+        vx_raw, vy_raw = output.x, output.y
     elif isinstance(output, (tuple, list)) and len(output) == 2:
-        vx, vy = output[0], output[1]
-    elif isinstance(output, dict):
+        vx_raw, vy_raw = output[0], output[1]
+    elif isinstance(output, Mapping):
         if "vx" in output and "vy" in output:
-            vx, vy = output["vx"], output["vy"]
+            vx_raw, vy_raw = output["vx"], output["vy"]
         elif "x" in output and "y" in output:
-            vx, vy = output["x"], output["y"]
+            vx_raw, vy_raw = output["x"], output["y"]
         elif "target_velocity" in output:
             val = output["target_velocity"]
             if isinstance(val, (list, tuple)) and len(val) == 2:
-                vx, vy = val[0], val[1]
+                vx_raw, vy_raw = val[0], val[1]
             else:
                 return None
         else:
@@ -169,8 +171,8 @@ def _parse_and_validate_output(output: Any) -> VelocityComponents | None:
 
     # Convert to float and check for finiteness
     try:
-        vx = float(vx)
-        vy = float(vy)
+        vx = float(cast(str | SupportsFloat | SupportsIndex, vx_raw))
+        vy = float(cast(str | SupportsFloat | SupportsIndex, vy_raw))
     except (TypeError, ValueError):
         return None
 

--- a/core/spatial/bounds.py
+++ b/core/spatial/bounds.py
@@ -1,8 +1,23 @@
 """World boundary management and collision resolution."""
 
-from typing import Any
+from typing import Protocol
 
 from core.entities import Agent
+
+
+class BoundaryHandler(Protocol):
+    """Boundary object capable of clamping and reflecting moving agents."""
+
+    def clamp_and_reflect(
+        self,
+        x: float,
+        y: float,
+        vx: float,
+        vy: float,
+        radius: float,
+    ) -> tuple[float, float, float, float, bool]:
+        """Return adjusted center, velocity, and collision status."""
+        ...
 
 
 class WorldBounds:
@@ -24,9 +39,9 @@ class WorldBounds:
         self.width = width
         self.height = height
         # Optional custom boundary handler (e.g., PetriDish)
-        self._custom_boundary: Any = None
+        self._custom_boundary: BoundaryHandler | None = None
 
-    def set_custom_boundary(self, boundary_handler: Any) -> None:
+    def set_custom_boundary(self, boundary_handler: BoundaryHandler | None) -> None:
         """Set a custom boundary handler (e.g. for Petri Dish mode)."""
         self._custom_boundary = boundary_handler
 

--- a/core/worlds/shared/action_translator.py
+++ b/core/worlds/shared/action_translator.py
@@ -7,9 +7,10 @@ any world with tank-like agents (Tank, Petri, etc.).
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import SupportsFloat, SupportsIndex, cast
 
-from core.actions.action_registry import ActionSpace
+from core.actions.action_registry import ActionSpace, RawAction
 from core.brains.contracts import BrainAction
 
 # Backward-compatibility alias
@@ -51,7 +52,7 @@ class TankLikeActionTranslator:
             },
         }
 
-    def translate_action(self, agent_id: str, raw_action: Any) -> Action:
+    def translate_action(self, agent_id: str, raw_action: RawAction) -> Action:
         """Translate raw action to Action.
 
         Handles multiple input formats:
@@ -71,18 +72,22 @@ class TankLikeActionTranslator:
             return raw_action
 
         # Extract velocity from dict
-        if isinstance(raw_action, dict):
+        if isinstance(raw_action, Mapping):
             # Support both "target_velocity" and "velocity" keys
             velocity = raw_action.get(
                 "target_velocity",
                 raw_action.get("velocity", (0.0, 0.0)),
             )
-            extra = raw_action.get("extra", {})
+            extra = cast(dict[str, object], raw_action.get("extra", {}))
 
             # Ensure velocity is a tuple of floats
-            if isinstance(velocity, (list, tuple)) and len(velocity) >= 2:
-                vx = self._clamp(float(velocity[0]))
-                vy = self._clamp(float(velocity[1]))
+            if (
+                isinstance(velocity, Sequence)
+                and not isinstance(velocity, str)
+                and len(velocity) >= 2
+            ):
+                vx = self._clamp_numeric(velocity[0])
+                vy = self._clamp_numeric(velocity[1])
             else:
                 vx, vy = 0.0, 0.0
 
@@ -94,8 +99,8 @@ class TankLikeActionTranslator:
 
         # Handle tuple/list directly as velocity
         if isinstance(raw_action, (list, tuple)) and len(raw_action) >= 2:
-            vx = self._clamp(float(raw_action[0]))
-            vy = self._clamp(float(raw_action[1]))
+            vx = self._clamp_numeric(raw_action[0])
+            vy = self._clamp_numeric(raw_action[1])
             return Action(
                 entity_id=agent_id,
                 target_velocity=(vx, vy),
@@ -107,3 +112,8 @@ class TankLikeActionTranslator:
     def _clamp(self, value: float) -> float:
         """Clamp velocity component to valid range."""
         return max(-self.max_velocity, min(self.max_velocity, value))
+
+    def _clamp_numeric(self, value: object) -> float:
+        """Convert a raw velocity component to float and clamp it."""
+        numeric = cast(str | SupportsFloat | SupportsIndex, value)
+        return self._clamp(float(numeric))

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -266,8 +266,8 @@ algorithm-count bug is exactly the failure this prevents.
 The reviewer's point is that in a system built for AI agents to *modify* code,
 typing is not cosmetic — it is the guardrail that catches a bad edit before CI
 does. Current state (measured 2026-07): ~64% of Python functions fully typed;
-after several cleanup passes, a quick re-count shows **247 simple `Any`
-annotation hits** (`: Any`, `-> Any`, `[Any]`) and **778 plain `Any`
+after several cleanup passes, a quick re-count shows **209 simple `Any`
+annotation hits** (`: Any`, `-> Any`, `[Any]`) and **688 plain `Any`
 occurrences** across `core/`. Mypy config is deliberately relaxed
 (`disallow_untyped_defs = false`, `check_untyped_defs = true`). These tasks
 tighten the *core path* first, where a mistake is most expensive.
@@ -284,9 +284,9 @@ Layer 2, `pre_pr_gate` green. The `# No overrides` line in `pyproject.toml`'s
 mypy section is where the per-module override block goes.
 
 ### 6.2 Retire `Any` in the hottest core modules — `S` · ★★
-Grep `core/` for `: Any`, `-> Any`, and `[Any]` (225 hits re-measured
+Grep `core/` for `: Any`, `-> Any`, and `[Any]` (209 hits re-measured
 2026-07-07; note this pattern misses generic-parameterized forms like
-`dict[str, Any]`; a plain `\bAny\b` count is 716) and replace the easy ones
+`dict[str, Any]`; a plain `\bAny\b` count is 688) and replace the easy ones
 with real types. Each PR: pick one module, remove its `Any`s, keep `mypy core/`
 green. Small, safe, and it compounds. **Layer 2.**
 
@@ -294,7 +294,12 @@ green. Small, safe, and it compounds. **Layer 2.**
 `core/services/stats/genetic_stats.py`, `core/worlds/petri/backend.py`,
 `core/worlds/tank/backend.py`, `core/agents_wrapper.py`, `core/entity_ids.py`,
 `core/entities/fish.py`, `core/transfer/entity_transfer.py`,
-`core/genetics/sanitization.py`, `core/util/rng.py`, and `core/util/mutations.py`.
+`core/genetics/sanitization.py`, `core/util/rng.py`, `core/util/mutations.py`,
+`core/spatial/bounds.py`, `core/actions/action_registry.py`,
+`core/energy/energy_utils.py`, `core/entities/base.py`, `core/modes/tank.py`,
+`core/modes/petri.py`, `core/worlds/shared/action_translator.py`,
+`core/genetics/mate_preferences.py`, `core/genetics/behavioral_inheritance.py`,
+`core/minigames/soccer/seeds.py`, and `core/policies/movement_policy_runner.py`.
 
 **Avoid as a small 6.2 pick:** `backend/state_payloads.py`. Checked 2026-07;
 nearly every remaining `Any` is either `to_dict() -> dict[str, Any]` or a


### PR DESCRIPTION
## What changed
Retired easy `Any` annotations across a set of small core modules by replacing them with `object`, narrow structural protocols, or existing shared aliases such as `RawAction`.

Updated `docs/IMPROVEMENT_PROPOSALS.md` to record the new Theme 6.2 counts: 209 simple `Any` annotation hits and 688 plain `Any` occurrences across `core/`.

## Layer
- [ ] Layer 1 (algorithm / config - affects simulation results)
- [x] Layer 2 (docs / tests / tooling - does not affect simulation results)

## Why
This implements the documented Theme 6.2 typing cleanup: reduce loose `Any` usage in core modules so future agent edits get better type-checker feedback without changing simulation behavior.

## Proof
Validation:

```text
py tools/agent_gate.py
py tools/pre_pr_gate.py
```

`agent_gate` passed with mypy over 438 source files and 595 curated tests.
`pre_pr_gate` passed all shards: smoke, worlds, evolution, backend_tools, and core.

## No regressions
This is a Layer 2 typing/docs cleanup only. No behavior algorithms, configs, benchmark scoring, or champion metadata were changed.