### PR TITLE
Reject Proposal #55 (Two-Resource Tank food niches): document negative result

### DIFF
--- a/docs/EVOLVABILITY.md
+++ b/docs/EVOLVABILITY.md
@@ -180,6 +180,33 @@ A living log so the board doesn't re‑propose dead ends. **Builders: append out
   signal, first confirm the signal is (a) heritable/correlated with a genome trait and (b) not
   already captured by the existing energy pathway.
 
+- 2026-07-07 | Two-Resource Tank -- trait-differentiated food niches for disruptive selection
+  (decision-board Proposal #55), with assortative-mating and long-horizon iterations | lever
+  §3.8 + §3.4 + §3.6 | hypothesis: two intermixed food types with a body-size trade-off ("tough"
+  food's extracted energy scales UP with the eater's `size_modifier`; "fast" food scales up as
+  the eater is SMALLER) create two niches -> disruptive selection -> sustained bimodal size /
+  sympatric speciation | result (standard `ecosystem_health_10k` config, seeds 42/7/123, ON vs
+  OFF, all behind default-off no-op flags so baseline stays byte-identical -- verified score
+  9.081249753268745 unchanged): **FOOD-ONLY @10k** -- each seed slides to ONE niche and
+  re-converges (Sarle bimodality coeff down on 2/3; size mean 1.61->1.16 on seed 42 but
+  1.67->1.73 on seed 123; no small+large coexistence). **+ forced SIZE-ASSORTATIVE MATING @10k**
+  (bonus 0.5 in `_find_proximity_mate`) made it WORSE -- BC down on 3/3, size std collapsed
+  (0.30->0.17 on seed 42): from a unimodal start, assortative mating is a variance-REDUCER that
+  reinforces the majority cluster, it does not split it. **LONG-HORIZON @30k** (does bimodality
+  build over time?) -- NO: the small (<1.0) subpopulation is EXTINCT on all 3 seeds by 30k, and
+  seed 7 collapsed to a size monoculture (std 0.32->0.06, all 60 fish large). Baseline itself
+  converges toward large over 30k and the mechanism does not counteract it | verdict: rejected
+  (horizon was NOT the limiter) | lessons: (1) a STATIC resource trade-off (a fixed size->energy
+  curve) has no rare-type advantage, so whichever niche gets ahead wins outright. Stable niche
+  coexistence needs **negative frequency-dependent selection** -- e.g. consumable/depletable food
+  where a crowded niche's resource is drawn down and the rarer niche's accumulates. Retest #55
+  only with frequency-dependent food dynamics, not a fixed curve. (2) Assortative mating on a
+  trait only sustains niches if the population is ALREADY bimodal on that trait; it locks in
+  clusters, it does not create them. (3) Measurement caveat: Sarle's bimodality coefficient reads
+  HIGH for tight/skewed unimodal distributions (seed 7 @30k: BC 0.80 with std 0.06 = a
+  monoculture), so gate any bimodality claim on BOTH sub-population counts (small AND large
+  populated) and trait std, never BC alone.
+
 ---
 
 ## 6. Open problem — a frozen evolvability benchmark


### PR DESCRIPTION
## Builder outcome: BUILD ABORTED — decision-board Proposal #55

**Proposal #55** (*Two-Resource Tank*): give the world two intermixed food types with a body-size trade-off so no single body plan wins both → disruptive selection → sustained bimodal size / sympatric speciation. Targets the board's recurring single-niche convergence (#46/#47/#48).

Prototyped and measured in three stages, all behind default-off no-op flags (baseline `ecosystem_health_10k` verified byte-identical at **9.081249753268745**).

### Stage 1 — food-only @10k (seeds 42/7/123)
Each seed slides to **one** niche and re-converges; Sarle bimodality coefficient down on 2/3. Size mean 1.61→1.16 (seed 42) vs 1.67→1.73 (seed 123) — opposite directions, no small+large coexistence.

### Stage 2 — + forced size-assortative mating @10k
**Worse**: BC down on 3/3 seeds, size std collapses (0.30→0.17 on seed 42). From a unimodal start, assortative mating is a *variance-reducer* that reinforces the majority cluster — it locks in clusters, it doesn't create them.

### Stage 3 — long-horizon @30k (does bimodality build over time?)
**No — the horizon was not the limiter.** The small-bodied (`size < 1.0`) subpopulation is **extinct on all 3 seeds** by 30k; seed 7 collapses to a size *monoculture* (std 0.32→0.06, all 60 fish large). Baseline itself converges toward large over 30k and the mechanism doesn't counter it.

### Root cause / lessons (in the graveyard entry)
1. A **static** resource trade-off (fixed size→energy curve) has no rare-type advantage, so whichever niche pulls ahead wins outright. Stable coexistence needs **negative frequency-dependent selection** — e.g. depletable food where a crowded niche's resource is drawn down. Retest only with frequency-dependent food dynamics.
2. Assortative mating sustains niches only if the population is *already* bimodal on that trait.
3. Measurement caveat: Sarle's BC reads high for tight/skewed unimodal distributions — gate bimodality claims on sub-population counts **and** std, not BC alone.

### This PR
- **Only** a graveyard entry in `docs/EVOLVABILITY.md §5`. All prototype code reverted; nothing in `core/` changes.
- **Champion files:** untouched. Smoke gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)