### PR TITLE
Interface honesty: type Positionable.pos, fix stale BehaviorStrategy docs

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -181,7 +181,7 @@ class Positionable(Protocol):
     """Any entity with a position in 2D space."""
 
     @property
-    def pos(self) -> Any:
+    def pos(self) -> "Vector2":
         """Position vector with x and y attributes."""
         ...
 
@@ -322,9 +322,9 @@ class BehaviorStrategy(Protocol):
     """Contract for behavior algorithm implementation.
 
     This is the **Strategy Pattern** applied to fish behavior. Each fish
-    has a behavior algorithm (strategy) that determines how it moves and
-    makes decisions. There are 48+ different behavior algorithms in the
-    simulation, each with unique characteristics.
+    has a behavior strategy that determines how it moves and makes
+    decisions. In production this is the genome's ``ComposableBehavior``
+    (``core/algorithms/composable/``); this protocol is its contract.
 
     Design Philosophy:
         - Behaviors are **stateless**: they make decisions based only on


### PR DESCRIPTION
## Summary
- `Positionable.pos` is now typed `Vector2` instead of `Any` — `Entity.pos` is already declared `Vector2`, so the protocol was the only untyped link in the chain.
- `BehaviorStrategy`'s docstring claimed "48+ different behavior algorithms"; post-ADR-006, production fish execute the genome's `ComposableBehavior`, so the docstring now states the actual contract.
- Removed `post_deliberate_observation.sh` from the repo root (untracked one-shot script that already served its purpose).

## Validation
- Layer 2 only — no simulation behavior change, no RNG or trajectory impact.
- `mypy core/`: green (325 files, no issues).
- `python tools/pre_pr_gate.py`: **PASS** (including the god-class ratchet — the docstring rewrite stays within `core/interfaces.py`'s 664-line pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)