### PR TITLE
Rename core/registry.py to core/algorithms/introspection.py

### DIFF
--- a/core/algorithm_validator.py
+++ b/core/algorithm_validator.py
@@ -209,7 +209,7 @@ class AlgorithmValidator:
         Returns:
             Performance metrics for the algorithm
         """
-        from core.registry import get_algorithm_metadata
+        from core.algorithms.introspection import get_algorithm_metadata
 
         # Get the source file path
         metadata = get_algorithm_metadata()

--- a/core/algorithms/introspection.py
+++ b/core/algorithms/introspection.py
@@ -3,6 +3,13 @@
 This module provides metadata and source file location utilities for algorithms.
 Used by AI tooling and stats exporters to introspect algorithm definitions.
 
+Discovery here walks the ``core.algorithms`` package and collects every
+``BehaviorStrategyBase`` subclass it finds. That is a *different* (broader) set
+than the canonical, hand-curated ``ALL_ALGORITHMS`` list in
+``core.algorithms.registry``, which defines the stable algorithm-id space used
+by genomes and stats. Introspection results are for tooling and reporting only
+and must never be used for algorithm-id assignment (see ADR-014).
+
 For runtime algorithm operations (crossover, mutation, instantiation), see:
     core.algorithms.registry
 """
@@ -10,24 +17,47 @@ For runtime algorithm operations (crossover, mutation, instantiation), see:
 import inspect
 import os
 import pkgutil
-from collections.abc import Iterable
+import random
+from collections.abc import Callable, Iterable
 from importlib import import_module
+from typing import cast
 
 import core.algorithms as algorithms
 from core.algorithms.base import BehaviorAlgorithm, BehaviorStrategyBase
+from core.util.rng import MissingRNGError
+
+
+def _instantiate_for_metadata(algorithm_class: type[BehaviorStrategyBase]) -> BehaviorStrategyBase:
+    """Instantiate an algorithm class just to read its metadata.
+
+    Classes that randomize initial parameters refuse a bare constructor call
+    (``MissingRNGError``); a throwaway seeded RNG is fine here because the
+    instance is only inspected for its ``algorithm_id``, never simulated.
+    """
+    try:
+        return algorithm_class()
+    except MissingRNGError:
+        # Subclasses accept rng=...; the base class signature does not declare it.
+        ctor = cast(Callable[..., BehaviorStrategyBase], algorithm_class)
+        return ctor(rng=random.Random(0))
 
 
 def _iter_algorithm_modules() -> Iterable[str]:
     """Yield fully qualified algorithm module paths within core.algorithms."""
     for module_info in pkgutil.walk_packages(algorithms.__path__, prefix="core.algorithms."):
         stem = module_info.name.rsplit(".", 1)[-1]
-        if stem.startswith("__") or stem in {"base", "BEHAVIOR_TEMPLATE"}:
+        if stem.startswith("__") or stem in {"base", "BEHAVIOR_TEMPLATE", "introspection"}:
             continue
         yield module_info.name
 
 
-def _discover_algorithms() -> list[type[BehaviorStrategyBase]]:
-    """Dynamically import and collect behavior strategy classes."""
+def discover_algorithm_classes() -> list[type[BehaviorStrategyBase]]:
+    """Dynamically import and collect behavior strategy classes.
+
+    Returns every ``BehaviorStrategyBase`` subclass defined under
+    ``core.algorithms``, in module-walk order. This is a tooling view of the
+    package contents, not the canonical registry ordering.
+    """
 
     discovered: list[type[BehaviorStrategyBase]] = []
     seen: set[type[BehaviorStrategyBase]] = set()
@@ -48,9 +78,6 @@ def _discover_algorithms() -> list[type[BehaviorStrategyBase]]:
     return discovered
 
 
-ALL_ALGORITHMS: list[type[BehaviorStrategyBase]] = _discover_algorithms()
-
-
 def get_algorithm_metadata() -> dict[str, dict[str, str]]:
     """Get comprehensive metadata about all algorithms.
 
@@ -64,12 +91,12 @@ def get_algorithm_metadata() -> dict[str, dict[str, str]]:
     """
     metadata = {}
 
-    for algorithm_class in ALL_ALGORITHMS:
+    for algorithm_class in discover_algorithm_classes():
         class_name = algorithm_class.__name__
 
         try:
             # Get instance for algorithm_id
-            instance = algorithm_class()
+            instance = _instantiate_for_metadata(algorithm_class)
             algo_id = instance.algorithm_id
 
             # Get source file info

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,7 +137,7 @@ loop were removed as inert duplicates (see ADR-009).
 - Deterministic list (`ALL_ALGORITHMS`) for serialization and indexing
 - Adaptive mutation utilities (`inherit_algorithm_with_mutation`, `calculate_adaptive_mutation_factor`)
 - Sub-behavior controls in `core/algorithms/composable/` for hybrid behaviors (threat response, food approach, energy style, social mode, poker engagement)
-`core/registry.py` is a separate introspection helper used by AI tooling to map algorithms to source files.
+`core/algorithms/introspection.py` is a separate discovery/metadata helper used by AI tooling to map algorithms to source files; it is a tooling view only and does not define the algorithm-id space.
 
 ### Poker Systems
 


### PR DESCRIPTION
## Summary
`core/registry.py` exported a module-level `ALL_ALGORITHMS` that shadowed the canonical `core/algorithms/registry.py::ALL_ALGORITHMS` with **different contents and a different id space** — the same-name split that previously caused the stats-keying bug behind ADR-014/015. The module is introspection tooling, so it is now named that.

- Moved to `core/algorithms/introspection.py`; the docstring now states the tooling-view vs canonical-id-space distinction explicitly (with an ADR-014 pointer).
- The duplicate `ALL_ALGORITHMS` constant is replaced by an explicit `discover_algorithm_classes()` function — no more two symbols with one name, and discovery is now lazy instead of an import-time package walk.
- **Fixes a pre-existing crash**: `get_algorithm_metadata()` died with `MissingRNGError` on the first algorithm whose constructor requires an RNG (e.g. `AdaptivePacer`), because that exception wasn't in the caught tuple. Reproduced on master with `python -c "from core.registry import get_algorithm_metadata; get_algorithm_metadata()"`. Metadata instantiation now retries with a throwaway seeded RNG; the function returns all 47 registered algorithms.
- Updated the single production consumer (`core/algorithm_validator.py`) and `docs/ARCHITECTURE.md`.

## Validation
- Layer 2 only — tooling module, no simulation behavior change, no RNG or trajectory impact.
- `mypy core/`: green (325 files).
- `python tools/pre_pr_gate.py`: **PASS**.
- Smoke check: `get_algorithm_metadata()` returns 47 entries across all 6 categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)