### PR TITLE
hasattr burn-down: movement_strategy.py to zero + core-wide ratchet test

### DIFF
--- a/core/movement_strategy.py
+++ b/core/movement_strategy.py
@@ -54,40 +54,30 @@ VelocityComponents = tuple[float, float]
 class MovementStrategy:
     """Base class for movement strategies."""
 
-    def move(self, sprite: Fish) -> None:
-        """Move a sprite according to the strategy."""
-        self.check_collision_with_food(sprite)
+    def move(self, fish: Fish) -> None:
+        """Move a fish according to the strategy."""
+        self.check_collision_with_food(fish)
 
-    def check_collision_with_food(self, sprite: Fish) -> None:
-        """Check if sprite collides with food and stop it if so.
+    def check_collision_with_food(self, fish: Fish) -> None:
+        """Check if the fish collides with food and stop it if so.
 
         Args:
-            sprite: The fish sprite to check for collisions
+            fish: The fish entity to check for collisions
         """
-        # Get the sprite entity (unwrap if it's a sprite wrapper)
-        sprite_entity: Fish = sprite._entity if hasattr(sprite, "_entity") else sprite
-
         # Optimize: Use spatial query to only check nearby food
         # Radius of 50 is sufficient for collision detection (fish size + food size)
-        # Use optimized nearby_resources query if available
-        if hasattr(sprite.environment, "nearby_resources"):
-            nearby_food = sprite.environment.nearby_resources(sprite_entity, 50)
-        else:
-            nearby_food = sprite.environment.nearby_agents_by_type(sprite_entity, 50, Food)
+        nearby_food = fish.environment.nearby_resources(fish, 50)
 
         for candidate in nearby_food:
-            # Get the food entity (unwrap if it's a sprite wrapper)
-            candidate_entity = candidate._entity if hasattr(candidate, "_entity") else candidate
-            if not isinstance(candidate_entity, Food):
+            if not isinstance(candidate, Food):
                 continue
-            food_entity = candidate_entity
 
             # Use the collision detector for consistent collision detection
-            if default_collision_detector.collides(sprite_entity, food_entity):
+            if default_collision_detector.collides(fish, candidate):
                 # Only stop if the fish can actually consume food
-                if hasattr(sprite_entity, "can_eat") and not sprite_entity.can_eat():
+                if not fish.can_eat():
                     continue
-                sprite.vel = Vector2(0, 0)  # Set velocity to 0
+                fish.vel = Vector2(0, 0)  # Set velocity to 0
 
 
 class AlgorithmicMovement(MovementStrategy):
@@ -118,7 +108,7 @@ class AlgorithmicMovement(MovementStrategy):
         # See ADR-010 and core.movement.considerations.
         self._arbiter = MovementArbiter(default_considerations())
 
-    def move(self, sprite: Fish) -> None:
+    def move(self, fish: Fish) -> None:
         """Move the fish by resolving its competing drives.
 
         Drives (explicit policy override, ball pursuit, genome code policy, and
@@ -127,17 +117,13 @@ class AlgorithmicMovement(MovementStrategy):
         fires (the genome has no composable behavior), fall back to random
         movement.
         """
-        sprite_entity: Fish = sprite._entity if hasattr(sprite, "_entity") else sprite
-
-        desired_velocity = self._arbiter.decide(self, sprite_entity)
+        desired_velocity = self._arbiter.decide(self, fish)
 
         if desired_velocity is None:
             # No drive produced a velocity (genome has no composable behavior):
             # fall back to simple random movement.
-            sprite_entity.add_random_velocity_change(
-                RANDOM_MOVE_PROBABILITIES, RANDOM_VELOCITY_DIVISOR
-            )
-            super().move(sprite_entity)
+            fish.add_random_velocity_change(RANDOM_MOVE_PROBABILITIES, RANDOM_VELOCITY_DIVISOR)
+            super().move(fish)
             return
 
         # Clamp the desired velocity to the kinematic action bound, then scale by
@@ -149,12 +135,12 @@ class AlgorithmicMovement(MovementStrategy):
         desired_vy = _clamp_action_velocity(float(desired_velocity[1]))
 
         # Apply algorithm decision - scale by speed to get actual velocity
-        speed = sprite_entity.speed
+        speed = fish.speed
         target_vx = desired_vx * speed
         target_vy = desired_vy * speed
 
         # Smoothly interpolate toward desired velocity - inline for performance
-        vel = sprite_entity.vel
+        vel = fish.vel
         vel.x += (target_vx - vel.x) * ALGORITHMIC_MOVEMENT_SMOOTHING
         vel.y += (target_vy - vel.y) * ALGORITHMIC_MOVEMENT_SMOOTHING
 
@@ -167,7 +153,7 @@ class AlgorithmicMovement(MovementStrategy):
         # Anti-stuck mechanism: if velocity is very low, add small random nudge
         # This prevents fish from getting permanently stuck at (0,0)
         if vel_length_sq < 0.01:
-            rng = sprite_entity.environment.rng
+            rng = fish.environment.rng
             angle = rng.random() * 6.283185307
             nudge_speed = speed * 0.3  # Small nudge to get unstuck
             vel.x = nudge_speed * math.cos(angle)
@@ -184,7 +170,7 @@ class AlgorithmicMovement(MovementStrategy):
                 vel.x = vel_x * scale
                 vel.y = vel_y * scale
 
-        super().move(sprite_entity)
+        super().move(fish)
 
     def _get_policy_override_velocity(self, fish: Fish) -> VelocityComponents | None:
         """Explicit movement-policy override, if one is set on the fish.
@@ -205,7 +191,7 @@ class AlgorithmicMovement(MovementStrategy):
         except Exception:
             logger.debug(
                 "Movement policy failed for fish %s, falling back to genome behavior",
-                getattr(fish, "fish_id", "?"),
+                fish.fish_id,
                 exc_info=True,
             )
             return None
@@ -236,31 +222,21 @@ class AlgorithmicMovement(MovementStrategy):
 
         # OPTIMIZATION: Check if policy is configured before doing expensive setup
         # This avoids building observations (which runs spatial queries) for fish without policies
-        behavioral = fish.genome.behavioral
-
-        # Quick check: extract value and see if it's set
-        trait = getattr(behavioral, "movement_policy_id", None)
-        if trait is not None and hasattr(trait, "value"):
-            trait = trait.value
-
-        if not trait:
+        trait = fish.genome.behavioral.movement_policy_id
+        policy_id = trait.value if trait is not None else None
+        if not policy_id:
             return None
 
         # We need a reference to a code pool
-        genome_code_pool = getattr(fish.environment, "genome_code_pool", None)
-
+        genome_code_pool = fish.environment.genome_code_pool
         if genome_code_pool is None:
-            # Fallback to legacy behavior or just return None
-            # If we really want to support raw CodePool without GenomeCodePool wrapper,
-            # we'd need to adapt the runner or keep legacy logic.
-            # Given the goal is "Use GenomeCodePool", we focus on that path.
             return None
 
         # Build observation
         observation = build_movement_observation(fish)
 
-        # Extract explicit dt and frame for deterministic execution
-        env_dt = getattr(fish.environment, "dt", 1.0)
+        # Environments have no dt attribute: the simulation is fixed-timestep.
+        env_dt = 1.0
         fish_frame = fish.age
 
         # Execute via runner
@@ -270,7 +246,7 @@ class AlgorithmicMovement(MovementStrategy):
             code_pool=genome_code_pool,
             observation=observation,
             rng=fish.environment.rng,
-            fish_id=getattr(fish, "fish_id", None),
+            fish_id=fish.fish_id,
             dt=env_dt,
             frame=fish_frame,
         )

--- a/core/world.py
+++ b/core/world.py
@@ -29,6 +29,7 @@ import random
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from core.code_pool.genome_code_pool import GenomeCodePool
     from core.entities.base import Entity
 
 
@@ -113,6 +114,11 @@ class World(Protocol):
         Returns:
             List of resource agents within radius
         """
+        ...
+
+    @property
+    def genome_code_pool(self) -> "GenomeCodePool | None":
+        """Pool of evolvable code components, or None when code policies are disabled."""
         ...
 
     def update_agent_position(self, agent: "Entity") -> None:

--- a/tests/core/test_movement_actions.py
+++ b/tests/core/test_movement_actions.py
@@ -16,10 +16,6 @@ class TestMovementActions(unittest.TestCase):
         self.fish.environment.world_type = "tank"
         self.fish.environment.rng = MagicMock()
 
-        # IMPORTANT: MagicMock will auto-create _entity attribute, confusing the safe-unwrap logic
-        # in MovementStrategy. We must explicitly delete it to simulate a raw Fish object.
-        del self.fish._entity
-
         # AlgorithmicMovement instance
         from core.movement_strategy import AlgorithmicMovement
 

--- a/tests/test_dynamic_attr_ratchet.py
+++ b/tests/test_dynamic_attr_ratchet.py
@@ -1,0 +1,181 @@
+"""Ratchet on hasattr()/getattr() usage in core/.
+
+The protocol layer (core/interfaces.py, core/world.py, ADR-002) is the
+project's contract mechanism. Every ``hasattr``/``getattr`` call in core is a
+contract the code declares but does not trust: the fallback branch silently
+hides wiring bugs instead of failing loudly (the same silent-fallback problem
+ADR-007 removed). This ratchet keeps the count from growing and harvests every
+cleanup, one module at a time — the same discipline as
+``test_god_class_limits.py``.
+
+When a check is genuinely needed, prefer:
+- adding the missing member to the protocol (``World``, ``core/interfaces.py``)
+  and accessing it directly;
+- an explicit ``isinstance`` check against a ``@runtime_checkable`` protocol;
+- an ``X | None`` attribute that always exists and is checked for ``None``.
+
+Counts are raw occurrences of ``hasattr(`` / ``getattr(`` per file (comments
+included — cheap, deterministic, and good enough for a ratchet).
+"""
+
+import re
+from pathlib import Path
+
+# Allowance for files not pinned below. A couple of dynamic checks can be
+# legitimate (e.g. duck-typing at a true serialization boundary); a file that
+# needs more than this is leaning on hasattr instead of its protocols.
+MAX_DYNAMIC_ATTR_CHECKS_FOR_NEW_FILES = 2
+
+# Grandfathered files, pinned at their measured counts (2026-07). Pins are
+# ceilings: a pinned file may shrink freely but may not regrow. When a file
+# drops to the allowance or below, test_pinned_list_is_current fails until its
+# entry is removed — the ratchet only tightens.
+LEGACY_DYNAMIC_ATTR_COUNTS = {
+    "core/algorithms/base.py": 4,
+    "core/algorithms/composable/actions.py": 4,
+    "core/algorithms/composable/food_selection.py": 8,
+    "core/algorithms/food_seeking/cooperative.py": 5,
+    "core/algorithms/food_seeking/quality.py": 3,
+    "core/code_pool/genome_code_pool.py": 4,
+    "core/ecosystem_reporting.py": 3,
+    "core/entities/base.py": 6,
+    "core/entities/fish.py": 13,
+    "core/entities/goal_zone.py": 3,
+    "core/entities/plant.py": 8,
+    "core/entities/predators.py": 8,
+    "core/environment.py": 8,
+    "core/fish/visual_geometry.py": 5,
+    "core/genetics/behavioral_inheritance.py": 16,
+    "core/genetics/code_policy_traits.py": 9,
+    "core/genetics/genome.py": 4,
+    "core/genetics/genome_codec.py": 9,
+    "core/genetics/trait.py": 8,
+    "core/genetics/trait_utils.py": 3,
+    "core/minigames/soccer/evaluator.py": 5,
+    "core/minigames/soccer/fish_stats.py": 3,
+    "core/minigames/soccer/league/provider.py": 23,
+    "core/minigames/soccer/league_runtime.py": 14,
+    "core/minigames/soccer/participant.py": 7,
+    "core/minigames/soccer/policy_adapter.py": 7,
+    "core/minigames/soccer/rewards.py": 5,
+    "core/minigames/soccer/scheduler.py": 16,
+    "core/minigames/soccer/selection.py": 3,
+    "core/mixed_poker/interaction.py": 15,
+    "core/movement/considerations.py": 4,
+    "core/plant/energy_component.py": 5,
+    "core/plant/migration_component.py": 6,
+    "core/plant_manager.py": 8,
+    "core/poker/evaluation/periodic_benchmark.py": 3,
+    "core/poker/integration/poker_interaction.py": 9,
+    "core/poker/integration/poker_rewards.py": 5,
+    "core/poker/integration/poker_system.py": 13,
+    "core/poker/integration/poker_table_planner.py": 9,
+    "core/poker/integration/post_poker_reproduction.py": 6,
+    "core/poker/stats/poker_stats_manager.py": 3,
+    "core/policies/movement_policy_runner.py": 4,
+    "core/reproduction/asexual_factory.py": 4,
+    "core/reproduction/mutation_controller.py": 3,
+    "core/reproduction/niche_cost.py": 18,
+    "core/reproduction/reproduction_service.py": 15,
+    "core/reproduction/sexual_factory.py": 4,
+    "core/serializers.py": 3,
+    "core/services/stats/genetic_stats.py": 20,
+    "core/services/stats/trait_trends.py": 6,
+    "core/simulation/engine.py": 5,
+    "core/simulation/entity_manager.py": 6,
+    "core/solutions/tracker.py": 12,
+    "core/spatial/bounds.py": 4,
+    "core/statistics_utils.py": 3,
+    "core/systems/entity_lifecycle.py": 6,
+    "core/systems/soccer_system.py": 15,
+    "core/transfer/entity_transfer.py": 19,
+    "core/util/mutations.py": 8,
+    "core/util/rng.py": 3,
+    "core/worlds/petri/environment.py": 5,
+    "core/worlds/shared/movement_observations.py": 5,
+    "core/worlds/shared/tank_like_phase_hooks.py": 8,
+    "core/worlds/tank/backend.py": 7,
+    "core/worlds/tank/observation_builder.py": 7,
+    "core/worlds/tank/pack.py": 5,
+}
+
+_DYNAMIC_ATTR_PATTERN = re.compile(r"\b(?:hasattr|getattr)\s*\(")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _iter_core_files() -> list[Path]:
+    root = _repo_root() / "core"
+    return [
+        p
+        for p in sorted(root.rglob("*.py"))
+        if "__pycache__" not in p.parts and "tests" not in p.parts
+    ]
+
+
+def _dynamic_attr_count(path: Path) -> int:
+    return len(_DYNAMIC_ATTR_PATTERN.findall(path.read_text(encoding="utf-8")))
+
+
+def test_no_new_dynamic_attr_checks() -> None:
+    """New core files stay within the allowance; pinned files may not regrow."""
+    repo_root = _repo_root()
+    violations: list[str] = []
+
+    for path in _iter_core_files():
+        rel = path.relative_to(repo_root).as_posix()
+        count = _dynamic_attr_count(path)
+        ceiling = LEGACY_DYNAMIC_ATTR_COUNTS.get(rel, MAX_DYNAMIC_ATTR_CHECKS_FOR_NEW_FILES)
+        if count > ceiling:
+            if rel in LEGACY_DYNAMIC_ATTR_COUNTS:
+                violations.append(
+                    f"  {rel}: {count} hasattr/getattr calls — grew past its pin of {ceiling}"
+                )
+            else:
+                violations.append(
+                    f"  {rel}: {count} hasattr/getattr calls "
+                    f"(allowance {MAX_DYNAMIC_ATTR_CHECKS_FOR_NEW_FILES})"
+                )
+
+    if violations:
+        raise AssertionError(
+            "hasattr/getattr ratchet exceeded:\n" + "\n".join(sorted(violations)) + "\n\nOptions:\n"
+            "  1. Add the missing member to the relevant protocol (core/world.py,\n"
+            "     core/interfaces.py) and access it directly (preferred)\n"
+            "  2. Use isinstance() against a @runtime_checkable protocol\n"
+            "  3. If the dynamic check is genuinely required (true serialization\n"
+            "     boundary), re-pin the file in LEGACY_DYNAMIC_ATTR_COUNTS with a\n"
+            "     justification in the PR."
+        )
+
+
+def test_pinned_list_is_current() -> None:
+    """Every pinned file must still exist and still exceed the allowance.
+
+    This harvests wins so the ratchet can only tighten: when a file is cleaned
+    to the allowance or below (or deleted), this fails until its entry is
+    removed from ``LEGACY_DYNAMIC_ATTR_COUNTS``.
+    """
+    repo_root = _repo_root()
+    stale: list[str] = []
+
+    for rel, pinned in sorted(LEGACY_DYNAMIC_ATTR_COUNTS.items()):
+        path = repo_root / rel
+        if not path.exists():
+            stale.append(f"  {rel}: no longer exists — remove it from LEGACY_DYNAMIC_ATTR_COUNTS")
+            continue
+        count = _dynamic_attr_count(path)
+        if count <= MAX_DYNAMIC_ATTR_CHECKS_FOR_NEW_FILES:
+            stale.append(
+                f"  {rel}: now {count} hasattr/getattr calls "
+                f"(<= {MAX_DYNAMIC_ATTR_CHECKS_FOR_NEW_FILES}) — remove it from "
+                "LEGACY_DYNAMIC_ATTR_COUNTS; it is clean"
+            )
+
+    if stale:
+        raise AssertionError(
+            "LEGACY_DYNAMIC_ATTR_COUNTS is out of date (the ratchet must only tighten):\n"
+            + "\n".join(stale)
+        )


### PR DESCRIPTION
## Summary

`core/` has 547 `hasattr`/`getattr` calls across 108 files — each one a protocol the code declares but doesn't trust, with a fallback branch that hides wiring bugs instead of failing loudly (the silent-fallback problem ADR-007 removed). This PR starts the burn-down at the movement hot path and adds a ratchet so the count can only go down.

### `core/movement_strategy.py`: 10 → 0, each removal proven

- **The `sprite._entity` unwrap idiom**: nothing in the codebase defines an `_entity` attribute. The only reference anywhere was a test doing `del mock._entity` to defeat the check on a MagicMock. Pygame-era vestige — removed, parameters renamed `sprite` → `fish`.
- **`hasattr(environment, "nearby_resources")` fallback**: both environment classes implement it and the `World` protocol declares it. Dead branch removed.
- **`hasattr(fish, "can_eat")`**: Fish always has it via `EnergyMixin` (fish.py already calls it unguarded). Guard removed.
- **`getattr(environment, "genome_code_pool", None)`**: set unconditionally in `Environment.__init__`. The `World` protocol now declares it — the honest fix, since the getattr existed because the *protocol* was incomplete, not the implementations. (`mypy` proved this: direct access errored until the protocol was completed.)
- **`getattr(environment, "dt", 1.0)`**: no environment defines `dt` — the default always won. Replaced with the literal it always was, with a comment stating the fixed-timestep fact.
- **`getattr(behavioral, "movement_policy_id", None)`**, **`getattr(fish, "fish_id", …)`×2**: declared fields. Direct access.

### New `tests/test_dynamic_attr_ratchet.py`

Same discipline as `test_god_class_limits.py`: 66 files pinned at their measured counts, unpinned core files get an allowance of 2, pins are ceilings only, and a stale-pin test harvests every cleanup so the ratchet only tightens. `movement_strategy.py` is not in the table — it's clean.

## Acceptance

All four champions reproduce **bit-exactly** at their recorded seeds after the change (survival_5k 388.2226951952828, ecosystem_health_10k 9.081249753268745, training_3k 26.309999999999995, training_5k 34.67166666666667) — every removed branch was provably dead, so trajectories are untouched.

`mypy core/` green · agent gate green · `python tools/pre_pr_gate.py` **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)