### PR TITLE
Fix tank benchmark determinism verification exit behavior

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -38,7 +38,7 @@ jobs:
 
   benchmark-gate:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -48,6 +48,9 @@ jobs:
       - name: Install dependencies
         run: pip install -e .
       - name: Run Tank Benchmark (determinism check)
-        run: python benchmarks/tank/survival_5k.py --verify-determinism
+        timeout-minutes: 10
+        run: python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42 --verify-determinism
       - name: Run Soccer Benchmark (determinism check)
+        timeout-minutes: 5
         run: python benchmarks/soccer/training_5k.py --verify-determinism
+

--- a/benchmarks/tank/survival_5k.py
+++ b/benchmarks/tank/survival_5k.py
@@ -177,11 +177,36 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.verify_determinism:
+        # Run both checks as fresh subprocesses so in-process global state
+        # (threads, WorldRegistry, asyncio loops) cannot prevent clean exit.
+        # Timeout is generous (3× expected runtime) but finite so CI cannot hang.
+        timeout_s = int(EXPECTED_RUNTIME_SECONDS * 3)
         cmd = [sys.executable, __file__, "--seed", str(args.seed)]
-        res1 = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        res2 = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        data1 = json.loads(res1.stdout)
-        data2 = json.loads(res2.stdout)
+        for run_num in (1, 2):
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_s,
+                )
+            except subprocess.TimeoutExpired:
+                print(
+                    f"DETERMINISM FAILED: Run {run_num} timed out after {timeout_s}s",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            if proc.returncode != 0:
+                print(
+                    f"DETERMINISM FAILED: Run {run_num} exited {proc.returncode}\n"
+                    f"STDERR: {proc.stderr}",
+                    file=sys.stderr,
+                )
+                sys.exit(proc.returncode)
+            if run_num == 1:
+                data1 = json.loads(proc.stdout)
+            else:
+                data2 = json.loads(proc.stdout)
         if data1["score"] == data2["score"]:
             print(f"DETERMINISM PASSED: {data1['score']}")
             sys.exit(0)

--- a/tests/test_watchdog_survival.py
+++ b/tests/test_watchdog_survival.py
@@ -23,7 +23,7 @@ def test_watchdog_real_survival_5k_3200_frames():
         # Read original content and update CONFIG["frames"] to 3200
         content = benchmark_file.read_text(encoding="utf-8")
         # Replace the frames config
-        content = content.replace('"frames": 5000', '"frames": 3200')
+        content = content.replace("FRAMES = 5000", "FRAMES = 3200")
 
         tmp_bench.write_text(content, encoding="utf-8")
 
@@ -60,3 +60,94 @@ def test_watchdog_real_survival_5k_3200_frames():
 
         assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
         assert "config_hash" in result.stdout or "config_hash" in result.stderr
+
+
+@pytest.mark.slow
+def test_verify_determinism_exits_cleanly():
+    """Verify that --verify-determinism exits cleanly (does not hang).
+
+    Runs both the benchmark's own --verify-determinism entry-point and the
+    run_bench.py --verify-determinism wrapper on a short 1000-frame copy so the
+    test completes quickly but still exercises the full subprocess round-trip.
+    """
+    benchmark_file = REPO_ROOT / "benchmarks" / "tank" / "survival_5k.py"
+    assert benchmark_file.exists()
+
+    content = benchmark_file.read_text(encoding="utf-8")
+    # Truncate to 1000 frames so both subprocess runs finish in well under 30 s
+    short_content = content.replace("FRAMES = 5000", "FRAMES = 1000")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_bench = Path(tmpdir) / "survival_1000.py"
+        tmp_bench.write_text(short_content, encoding="utf-8")
+
+        # --- 1. benchmark __main__ --verify-determinism ---
+        try:
+            proc = subprocess.run(
+                [sys.executable, str(tmp_bench), "--seed", "42", "--verify-determinism"],
+                cwd=str(REPO_ROOT),
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired as e:
+            stdout_str = (
+                e.stdout.decode("utf-8", errors="replace")
+                if isinstance(e.stdout, bytes)
+                else (e.stdout or "")
+            )
+            stderr_str = (
+                e.stderr.decode("utf-8", errors="replace")
+                if isinstance(e.stderr, bytes)
+                else (e.stderr or "")
+            )
+            print("\n=== benchmark --verify-determinism Timeout ===")
+            print(f"stdout:\n{stdout_str}")
+            print(f"stderr:\n{stderr_str}")
+            raise
+
+        assert (
+            proc.returncode == 0
+        ), f"benchmark --verify-determinism failed\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+        assert (
+            "DETERMINISM PASSED" in proc.stdout
+        ), f"Expected 'DETERMINISM PASSED' in stdout\n{proc.stdout}"
+
+        # --- 2. run_bench.py --verify-determinism ---
+        try:
+            proc2 = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUN_BENCH),
+                    str(tmp_bench),
+                    "--seed",
+                    "42",
+                    "--verify-determinism",
+                ],
+                cwd=str(REPO_ROOT),
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired as e:
+            stdout_str = (
+                e.stdout.decode("utf-8", errors="replace")
+                if isinstance(e.stdout, bytes)
+                else (e.stdout or "")
+            )
+            stderr_str = (
+                e.stderr.decode("utf-8", errors="replace")
+                if isinstance(e.stderr, bytes)
+                else (e.stderr or "")
+            )
+            print("\n=== run_bench.py --verify-determinism Timeout ===")
+            print(f"stdout:\n{stdout_str}")
+            print(f"stderr:\n{stderr_str}")
+            raise
+
+        assert (
+            proc2.returncode == 0
+        ), f"run_bench.py --verify-determinism failed\nstdout: {proc2.stdout}\nstderr: {proc2.stderr}"
+        assert (
+            "Determinism check PASSED" in proc2.stdout
+        ), f"Expected 'Determinism check PASSED' in stdout\n{proc2.stdout}"

--- a/tools/run_bench.py
+++ b/tools/run_bench.py
@@ -108,26 +108,31 @@ def main():
 
         print(f"Running benchmark: {bench_module.BENCHMARK_ID} (Seed: {args.seed})...")
         budget_seconds = expected_runtime_seconds(bench_module)
+        # Timeout for each subprocess: 3× budget if available, else 10 minutes.
+        subprocess_timeout = int(budget_seconds * 3) if budget_seconds else 600
 
-        # Run 1
-        recorder = None
-        if args.fingerprint_out:
-            recorder = create_fingerprint_recorder(
-                args.fingerprint_out,
-                bench_module,
-                args.seed,
-                args.fingerprint_every,
-            )
-        try:
-            result1 = run_benchmark(bench_module, args.seed, recorder)
-            if recorder is not None:
-                recorder.finish(result1)
-        except Exception:
-            if recorder is not None:
-                recorder.close()
-            raise
-
-        if args.verify_determinism:
+        if not args.verify_determinism:
+            # Normal single run (in-process).
+            recorder = None
+            if args.fingerprint_out:
+                recorder = create_fingerprint_recorder(
+                    args.fingerprint_out,
+                    bench_module,
+                    args.seed,
+                    args.fingerprint_every,
+                )
+            try:
+                result1 = run_benchmark(bench_module, args.seed, recorder)
+                if recorder is not None:
+                    recorder.finish(result1)
+            except Exception:
+                if recorder is not None:
+                    recorder.close()
+                raise
+        else:
+            # Determinism verification: run both checks as fresh subprocesses
+            # so in-process global state (threads, WorldRegistry, asyncio loops)
+            # cannot prevent clean exit. Explicit timeouts prevent CI from hanging.
             print("Verifying determinism (subprocess-vs-subprocess)...", flush=True)
             temp_out1 = tempfile.NamedTemporaryFile(suffix=".json", delete=False)  # noqa: SIM115
             temp_out2 = tempfile.NamedTemporaryFile(suffix=".json", delete=False)  # noqa: SIM115
@@ -146,7 +151,16 @@ def main():
                     str(args.fingerprint_every),
                 ]
             print("Running determinism check: Run 1...", flush=True)
-            res1 = subprocess.run(cmd1, capture_output=True, text=True)
+            try:
+                res1 = subprocess.run(
+                    cmd1, capture_output=True, text=True, timeout=subprocess_timeout
+                )
+            except subprocess.TimeoutExpired:
+                print(
+                    f"Error: Run 1 timed out after {subprocess_timeout}s",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             if res1.returncode != 0:
                 print(
                     f"Error: Run 1 failed with exit code {res1.returncode}\nSTDOUT:\n{res1.stdout}\nSTDERR:\n{res1.stderr}",
@@ -164,7 +178,16 @@ def main():
                     str(args.fingerprint_every),
                 ]
             print("Running determinism check: Run 2...", flush=True)
-            res2 = subprocess.run(cmd2, capture_output=True, text=True)
+            try:
+                res2 = subprocess.run(
+                    cmd2, capture_output=True, text=True, timeout=subprocess_timeout
+                )
+            except subprocess.TimeoutExpired:
+                print(
+                    f"Error: Run 2 timed out after {subprocess_timeout}s",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             if res2.returncode != 0:
                 print(
                     f"Error: Run 2 failed with exit code {res2.returncode}\nSTDOUT:\n{res2.stdout}\nSTDERR:\n{res2.stderr}",
@@ -172,7 +195,7 @@ def main():
                 )
                 sys.exit(res2.returncode)
 
-            # Parse output JSONs
+            # Parse output JSONs (result1 comes from the subprocess, not in-process)
             with open(temp_out1.name) as f:
                 result1 = json.load(f)
             with open(temp_out2.name) as f:


### PR DESCRIPTION
Reproduction: python tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42 --verify-determinism

- Run both verification runs as subprocesses in run_bench.py to avoid state pollution
- Add explicit subprocess timeouts based on EXPECTED_RUNTIME_SECONDS
- Fix test_watchdog_survival.py to correctly replace frame count constant
- Add watchdog test checking that determinism verification exits cleanly
- Update CI workflow to use run_bench.py with timeouts