### PR TITLE
Add poker ladder benchmark: absolute HU skill vs frozen reference opponents

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -53,4 +53,7 @@ jobs:
       - name: Run Soccer Benchmark (determinism check)
         timeout-minutes: 5
         run: python benchmarks/soccer/training_5k.py --verify-determinism
+      - name: Run Poker Ladder Benchmark (determinism check)
+        timeout-minutes: 5
+        run: python benchmarks/poker/ladder_20k.py --verify-determinism
 

--- a/benchmarks/poker/ladder_20k.py
+++ b/benchmarks/poker/ladder_20k.py
@@ -1,0 +1,184 @@
+"""Poker Ladder Benchmark (20k nominal hands).
+
+Measures the absolute heads-up skill of the evolvable poker substrate
+(ComposablePokerStrategy with neutral defaults - what founder fish play) against
+a frozen ladder of reference opponents, from a random-legal floor to the GTO
+expert ceiling. Because the rungs never change, bb/100 against each rung is an
+absolute, longitudinally comparable skill measure: improvements to the
+composable strategy's logic or defaults move the score; re-tuning ecosystem
+config does not.
+
+Ladder rungs (weak to strong):
+    L0 random         - random legal actions (skill floor)
+    L1 loose_passive  - calling station
+    L2 tight_aggressive - solid rule-based TAG
+    L3 gto_expert     - strongest scripted opponent (state-of-the-art proxy)
+
+Each rung is evaluated with duplicate deals (same cards, both seats) via
+core/poker/evaluation/benchmark_eval.py, which cancels card luck and seat
+position. Score is the mean bb/100 across rungs (higher is better; 0 vs a rung
+means break-even with it).
+"""
+
+import random
+import sys
+import time
+from typing import Any
+
+from core.poker.evaluation.benchmark_eval import (
+    BenchmarkEvalConfig,
+    evaluate_vs_single_benchmark_duplicate,
+)
+from core.poker.strategy.composable.strategy import ComposablePokerStrategy
+
+BENCHMARK_ID = "poker/ladder_20k"
+
+# Frozen ruler ladder, weak to strong. Changing a rung's strategy code changes
+# what the benchmark measures; treat these as immutable references and add new
+# rungs instead of editing existing ones.
+LADDER_RUNGS: tuple[str, ...] = (
+    "random",
+    "loose_passive",
+    "tight_aggressive",
+    "gto_expert",
+)
+
+SMALL_BLIND = 50
+BIG_BLIND = 100
+STARTING_STACK = 10_000
+HANDS_PER_MATCH = 100
+NUM_DUPLICATE_SETS = 25  # per rung; x2 seats = 5,000 nominal hands per rung
+EXPECTED_RUNTIME_SECONDS = 60
+
+# Effective configuration captured by the champion config hash
+# (core/solutions/config_hash.py). Anything that changes the score belongs here.
+CONFIG: dict[str, Any] = {
+    "ladder_rungs": list(LADDER_RUNGS),
+    "small_blind": SMALL_BLIND,
+    "big_blind": BIG_BLIND,
+    "starting_stack": STARTING_STACK,
+    "hands_per_match": HANDS_PER_MATCH,
+    "num_duplicate_sets": NUM_DUPLICATE_SETS,
+    "hero": "composable_default",
+}
+
+
+def _make_hero(seed: int, rung_index: int) -> ComposablePokerStrategy:
+    """Fresh neutral-default hero per rung.
+
+    A fresh instance per rung keeps rung results independent (no opponent-model
+    or RNG-state leakage between rungs) and pins the hero to the evolvable
+    substrate's defaults - the exact strategy founder fish receive.
+    """
+    hero_rng = random.Random(seed * 1_000_003 + rung_index)
+    return ComposablePokerStrategy(rng=hero_rng)
+
+
+def run(
+    seed: int,
+    *,
+    num_duplicate_sets: int = NUM_DUPLICATE_SETS,
+    hands_per_match: int = HANDS_PER_MATCH,
+) -> dict[str, Any]:
+    """Run the benchmark deterministically.
+
+    Args:
+        seed: Base seed for card dealing and all strategy RNGs
+        num_duplicate_sets: Duplicate-deal sets per rung (default: full config)
+        hands_per_match: Hands per duplicate set per seat (default: full config)
+
+    Returns:
+        Result dictionary with score, per-rung metrics, and metadata
+    """
+    start_time = time.time()
+
+    per_rung: list[dict[str, Any]] = []
+    rung_scores: dict[str, float] = {}
+    rungs_beaten = 0
+    total_hands = 0
+
+    for rung_index, rung_id in enumerate(LADDER_RUNGS):
+        cfg = BenchmarkEvalConfig(
+            small_blind=SMALL_BLIND,
+            big_blind=BIG_BLIND,
+            starting_stack=STARTING_STACK,
+            hands_per_match=hands_per_match,
+            num_duplicate_sets=num_duplicate_sets,
+            base_seed=seed,
+        )
+        hero = _make_hero(seed, rung_index)
+
+        print(
+            f"  Rung L{rung_index} ({rung_id}): "
+            f"{num_duplicate_sets} duplicate sets x {hands_per_match} hands x 2 seats...",
+            file=sys.stderr,
+        )
+        result = evaluate_vs_single_benchmark_duplicate(hero, rung_id, cfg)
+
+        # "Beaten" = the 95% CI on bb/100 sits entirely above zero.
+        beaten = result.is_statistically_significant and result.bb_per_100 > 0.0
+        if beaten:
+            rungs_beaten += 1
+
+        total_hands += result.hands_played
+        rung_scores[rung_id] = result.bb_per_100
+        per_rung.append(
+            {
+                "rung": f"L{rung_index}",
+                "rung_id": rung_id,
+                "bb_per_100": result.bb_per_100,
+                "bb_per_100_ci_95": list(result.bb_per_100_ci_95),
+                "hands_played": result.hands_played,
+                "sample_variance": result.sample_variance,
+                "statistically_significant": result.is_statistically_significant,
+                "beaten": beaten,
+            }
+        )
+
+    score = sum(rung_scores.values()) / max(len(rung_scores), 1)
+    runtime = time.time() - start_time
+
+    return {
+        "benchmark_id": BENCHMARK_ID,
+        "seed": seed,
+        "score": score,
+        "score_breakdown": dict(rung_scores),
+        "runtime_seconds": runtime,
+        "metadata": {
+            "hero": "composable_default",
+            "ladder_rungs": list(LADDER_RUNGS),
+            "rungs_beaten": rungs_beaten,
+            "total_rungs": len(LADDER_RUNGS),
+            "total_hands": total_hands,
+            "num_duplicate_sets": num_duplicate_sets,
+            "hands_per_match": hands_per_match,
+            "small_blind": SMALL_BLIND,
+            "big_blind": BIG_BLIND,
+            "starting_stack": STARTING_STACK,
+            "score_mode": "mean bb/100 across ladder rungs (duplicate-deal HU)",
+            "vs_sota_bb_per_100": rung_scores.get(LADDER_RUNGS[-1], 0.0),
+            "per_rung_results": per_rung,
+        },
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--verify-determinism", action="store_true")
+    args = parser.parse_args()
+
+    if args.verify_determinism:
+        res1 = run(args.seed)
+        res2 = run(args.seed)
+        score_diff = abs(res1["score"] - res2["score"])
+        if score_diff > 1e-9:
+            print(f"DETERMINISM FAILED: {res1['score']} != {res2['score']}", file=sys.stderr)
+            sys.exit(1)
+        print(f"DETERMINISM PASSED: {res1['score']}")
+    else:
+        result = run(args.seed)
+        print(json.dumps(result, indent=2))

--- a/champions/poker/ladder_20k.json
+++ b/champions/poker/ladder_20k.json
@@ -1,0 +1,90 @@
+{
+  "benchmark_id": "poker/ladder_20k",
+  "version": 1,
+  "champion": {
+    "score": 676.1522815496628,
+    "seed": 42,
+    "timestamp": 1783540002.1273735,
+    "metadata": {
+      "hero": "composable_default",
+      "ladder_rungs": [
+        "random",
+        "loose_passive",
+        "tight_aggressive",
+        "gto_expert"
+      ],
+      "rungs_beaten": 4,
+      "total_rungs": 4,
+      "total_hands": 12764,
+      "num_duplicate_sets": 25,
+      "hands_per_match": 100,
+      "small_blind": 50,
+      "big_blind": 100,
+      "starting_stack": 10000,
+      "score_mode": "mean bb/100 across ladder rungs (duplicate-deal HU)",
+      "vs_sota_bb_per_100": 588.7031373582917,
+      "per_rung_results": [
+        {
+          "rung": "L0",
+          "rung_id": "random",
+          "bb_per_100": 1063.2414975845409,
+          "bb_per_100_ci_95": [
+            945.2107299412481,
+            1291.7658783404113
+          ],
+          "hands_played": 2070,
+          "sample_variance": 187578.82790811025,
+          "statistically_significant": true,
+          "beaten": true
+        },
+        {
+          "rung": "L1",
+          "rung_id": "loose_passive",
+          "bb_per_100": 667.4797334986057,
+          "bb_per_100_ci_95": [
+            641.6584189178593,
+            754.4506294520384
+          ],
+          "hands_played": 3227,
+          "sample_variance": 19869.975151790743,
+          "statistically_significant": true,
+          "beaten": true
+        },
+        {
+          "rung": "L2",
+          "rung_id": "tight_aggressive",
+          "bb_per_100": 385.1847577572128,
+          "bb_per_100_ci_95": [
+            322.5392995576424,
+            565.5104556825169
+          ],
+          "hands_played": 3674,
+          "sample_variance": 92203.74225633814,
+          "statistically_significant": true,
+          "beaten": true
+        },
+        {
+          "rung": "L3",
+          "rung_id": "gto_expert",
+          "bb_per_100": 588.7031373582917,
+          "bb_per_100_ci_95": [
+            526.9655034013663,
+            747.9906168731418
+          ],
+          "hands_played": 3793,
+          "sample_variance": 76299.61597023836,
+          "statistically_significant": true,
+          "beaten": true
+        }
+      ]
+    },
+    "score_breakdown": {
+      "random": 1063.2414975845409,
+      "loose_passive": 667.4797334986057,
+      "tight_aggressive": 385.1847577572128,
+      "gto_expert": 588.7031373582917
+    },
+    "config_hash": "b80b0eb402b070fe"
+  },
+  "history": []
+}

--- a/tests/test_benchmark_determinism.py
+++ b/tests/test_benchmark_determinism.py
@@ -210,6 +210,27 @@ class TestBenchmarkEvaluation(unittest.TestCase):
             self.assertEqual(res.benchmark_id, pid)
 
 
+class TestPokerLadderBenchmarkDeterminism(unittest.TestCase):
+    """Smoke tests for poker ladder benchmark determinism (fast config)."""
+
+    def test_ladder_20k_is_deterministic_smoke(self):
+        import benchmarks.poker.ladder_20k as bench
+
+        res1 = bench.run(42, num_duplicate_sets=1, hands_per_match=10)
+        res2 = bench.run(42, num_duplicate_sets=1, hands_per_match=10)
+
+        self.assertAlmostEqual(res1["score"], res2["score"], places=9)
+
+    def test_ladder_20k_reports_all_rungs(self):
+        import benchmarks.poker.ladder_20k as bench
+
+        res = bench.run(42, num_duplicate_sets=1, hands_per_match=10)
+
+        rung_ids = [r["rung_id"] for r in res["metadata"]["per_rung_results"]]
+        self.assertEqual(rung_ids, list(bench.LADDER_RUNGS))
+        self.assertEqual(set(res["score_breakdown"]), set(bench.LADDER_RUNGS))
+
+
 class TestSoccerBenchmarkDeterminism(unittest.TestCase):
     """Smoke tests for soccer benchmark determinism (fast config)."""
 


### PR DESCRIPTION
## Summary

**Layer 2 (benchmark-only).** Poker previously had no benchmark at all — in-sim `PokerStats` are self-play (fish vs fish, zero-sum), so aggregate win rate is ~50% by definition and there was no absolute skill measure and no ruler for "how close to state of the art".

`benchmarks/poker/ladder_20k.py` measures the evolvable poker substrate (`ComposablePokerStrategy` with neutral defaults — exactly what founder fish play) against a **frozen ladder of reference opponents** from `BASELINE_STRATEGIES`, using the existing duplicate-deal evaluation engine (`core/poker/evaluation/benchmark_eval.py`, previously unwired into any benchmark). Duplicate dealing (same cards, both seats) cancels card luck and position.

## Ladder results (seed 42 champion baseline)

| Rung | Opponent | bb/100 | 95% CI | Beaten |
|------|----------|-------:|--------|--------|
| L0 | `random` | +1063.24 | [945, 1292] | yes |
| L1 | `loose_passive` (calling station) | +667.48 | [642, 754] | yes |
| L2 | `tight_aggressive` (TAG) | +385.18 | [322, 566] | yes |
| L3 | `gto_expert` (SOTA proxy) | +588.70 | [527, 748] | yes |

**Score = mean bb/100 across rungs = 676.152.** Because the rungs are frozen references, this is an absolute, longitudinally comparable skill measure — it moves only when composable strategy logic/defaults change, unlike ecosystem scores that re-baseline whenever config shifts.

Notable: the ladder is **non-monotonic** for the default hero — it wins more from `gto_expert` than from `tight_aggressive`. That's exactly the kind of fact this benchmark exists to surface; worth a follow-up look at whether `GTOExpertStrategy` over-folds against aggression.

## Contents

- `benchmarks/poker/ladder_20k.py` — benchmark (4 rungs × 25 duplicate sets × 100 hands × 2 seats = 20k nominal hands; ~20s runtime, 60s budget)
- `champions/poker/ladder_20k.json` — initial champion, registered via `validate_improvement.py --update-champion`; provenance validation passes
- `tests/test_benchmark_determinism.py` — fast smoke determinism + rung-shape tests (mirrors the soccer smoke tests)
- `.github/workflows/bench.yml` — poker ladder added to the nightly `benchmark-gate` determinism checks (`verify-champions` picks the new champion up automatically via glob)

## Validation

- `python tools/run_bench.py benchmarks/poker/ladder_20k.py --seed 42 --verify-determinism` — **PASSED** (subprocess-vs-subprocess)
- `tools/agent_gate.py` — PASSED
- `tools/pre_pr_gate.py` — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)