### PR TITLE
Add first-class skill ladder standings

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -55,5 +55,5 @@ jobs:
         run: python benchmarks/soccer/training_5k.py --verify-determinism
       - name: Run Poker Ladder Benchmark (determinism check)
         timeout-minutes: 5
-        run: python benchmarks/poker/ladder_20k.py --verify-determinism
+        run: python tools/run_bench.py benchmarks/poker/ladder_20k.py --seed 42 --verify-determinism
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         python-version: '3.10'
     - name: Check locked paths
       run: |
-        python tools/check_locked_paths.py --locked benchmarks/heldout tools/check_locked_paths.py --base origin/${{ github.base_ref }}
+        python tools/check_locked_paths.py --locked benchmarks/heldout tools/check_locked_paths.py core/poker/strategy/implementations/baseline.py core/poker/strategy/implementations/standard.py core/poker/strategy/implementations/expert.py --base origin/${{ github.base_ref }}
 
   frontend-ci:
     runs-on: ubuntu-latest

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -307,6 +307,7 @@ def _setup_routers(app: FastAPI, ctx: AppContext) -> None:
         discovery,
         metrics,
         servers,
+        skill,
         transfers,
         websocket,
     )
@@ -357,5 +358,9 @@ def _setup_routers(app: FastAPI, ctx: AppContext) -> None:
     # Setup agent commentary router (the "Insights" feed)
     commentary_router = commentary.setup_router(ctx.world_manager)
     app.include_router(commentary_router)
+
+    # Setup skill-ladder standings router (reads the champion registry)
+    skill_router = skill.setup_router()
+    app.include_router(skill_router)
 
     ctx.logger.info("All API routers configured successfully")

--- a/backend/routers/skill.py
+++ b/backend/routers/skill.py
@@ -1,0 +1,47 @@
+"""Skill-ladder standings REST API router.
+
+Exposes the frozen-ruler skill summaries embedded in the champion registry so
+the frontend can show, per domain, how good the evolved agents are in absolute
+terms and how close they are to each ladder's ceiling. Stateless and
+world-independent: it reads ``champions/**/*.json`` on request.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from core.skill import load_ladder_summaries
+
+logger = logging.getLogger(__name__)
+
+# Repo-root-relative champions directory (backend/ -> repo root -> champions).
+_CHAMPIONS_DIR = Path(__file__).resolve().parents[2] / "champions"
+
+SCHEMA_VERSION = 1
+
+
+def setup_router(champions_dir: Path | None = None) -> APIRouter:
+    """Create the skill-ladder standings router."""
+    router = APIRouter(prefix="/api/skill", tags=["skill"])
+    resolved_dir = champions_dir or _CHAMPIONS_DIR
+
+    @router.get("/ladders")
+    async def get_skill_ladders() -> JSONResponse:
+        """Return skill-ladder summaries for every domain that emits one."""
+        try:
+            summaries = load_ladder_summaries(resolved_dir)
+        except OSError as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to read champion registry: %s", exc)
+            summaries = []
+        return JSONResponse(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "ladders": [s.to_dict() for s in summaries],
+            }
+        )
+
+    return router

--- a/benchmarks/poker/ladder_20k.py
+++ b/benchmarks/poker/ladder_20k.py
@@ -12,7 +12,10 @@ Ladder rungs (weak to strong):
     L0 random         - random legal actions (skill floor)
     L1 loose_passive  - calling station
     L2 tight_aggressive - solid rule-based TAG
-    L3 gto_expert     - strongest scripted opponent (state-of-the-art proxy)
+    L3 gto_expert     - strongest scripted opponent. Despite the strategy id,
+                        this is a GTO-inspired heuristic, not a solver-verified
+                        GTO agent; it is the best scripted ruler available, not
+                        an unexploitable ceiling.
 
 Each rung is evaluated with duplicate deals (same cards, both seats) via
 core/poker/evaluation/benchmark_eval.py, which cancels card luck and seat
@@ -156,7 +159,12 @@ def run(
             "big_blind": BIG_BLIND,
             "starting_stack": STARTING_STACK,
             "score_mode": "mean bb/100 across ladder rungs (duplicate-deal HU)",
-            "vs_sota_bb_per_100": rung_scores.get(LADDER_RUNGS[-1], 0.0),
+            "top_rung_note": (
+                "gto_expert is a GTO-inspired scripted heuristic, not a "
+                "solver-verified GTO agent; treat it as the strongest scripted "
+                "ruler, not an unexploitable ceiling."
+            ),
+            "vs_top_rung_bb_per_100": rung_scores.get(LADDER_RUNGS[-1], 0.0),
             "per_rung_results": per_rung,
         },
     }

--- a/benchmarks/poker/ladder_20k.py
+++ b/benchmarks/poker/ladder_20k.py
@@ -33,6 +33,10 @@ from core.poker.evaluation.benchmark_eval import (
     evaluate_vs_single_benchmark_duplicate,
 )
 from core.poker.strategy.composable.strategy import ComposablePokerStrategy
+from core.skill import RungResult, SkillLadderSummary, ladder_position_index
+
+SKILL_DOMAIN = "poker"
+SKILL_METRIC_NAME = "bb_per_100"
 
 BENCHMARK_ID = "poker/ladder_20k"
 
@@ -96,6 +100,7 @@ def run(
     start_time = time.time()
 
     per_rung: list[dict[str, Any]] = []
+    rung_results: list[RungResult] = []
     rung_scores: dict[str, float] = {}
     rungs_beaten = 0
     total_hands = 0
@@ -137,9 +142,32 @@ def run(
                 "beaten": beaten,
             }
         )
+        rung_results.append(
+            RungResult(
+                rung=f"L{rung_index}",
+                rung_id=rung_id,
+                metric=result.bb_per_100,
+                ci_95=result.bb_per_100_ci_95,
+                beaten=beaten,
+                detail={"hands_played": result.hands_played},
+            )
+        )
 
     score = sum(rung_scores.values()) / max(len(rung_scores), 1)
     runtime = time.time() - start_time
+
+    skill = SkillLadderSummary(
+        domain=SKILL_DOMAIN,
+        benchmark_id=BENCHMARK_ID,
+        metric_name=SKILL_METRIC_NAME,
+        skill_index=ladder_position_index(tuple(rung_results)),
+        rungs=tuple(rung_results),
+        notes=(
+            "Ladder-position index: 100 = beats every current rung (ceiling "
+            "saturated, add a taller rung). gto_expert is a GTO-inspired "
+            "scripted heuristic, not solver-verified GTO."
+        ),
+    )
 
     return {
         "benchmark_id": BENCHMARK_ID,
@@ -166,6 +194,7 @@ def run(
             ),
             "vs_top_rung_bb_per_100": rung_scores.get(LADDER_RUNGS[-1], 0.0),
             "per_rung_results": per_rung,
+            "skill": skill.to_dict(),
         },
     }
 

--- a/champions/poker/ladder_20k.json
+++ b/champions/poker/ladder_20k.json
@@ -4,7 +4,7 @@
   "champion": {
     "score": 676.1522815496628,
     "seed": 42,
-    "timestamp": 1783540002.1273735,
+    "timestamp": 1783542987.4836917,
     "metadata": {
       "hero": "composable_default",
       "ladder_rungs": [
@@ -22,7 +22,8 @@
       "big_blind": 100,
       "starting_stack": 10000,
       "score_mode": "mean bb/100 across ladder rungs (duplicate-deal HU)",
-      "vs_sota_bb_per_100": 588.7031373582917,
+      "top_rung_note": "gto_expert is a GTO-inspired scripted heuristic, not a solver-verified GTO agent; treat it as the strongest scripted ruler, not an unexploitable ceiling.",
+      "vs_top_rung_bb_per_100": 588.7031373582917,
       "per_rung_results": [
         {
           "rung": "L0",

--- a/champions/poker/ladder_20k.json
+++ b/champions/poker/ladder_20k.json
@@ -4,7 +4,7 @@
   "champion": {
     "score": 676.1522815496628,
     "seed": 42,
-    "timestamp": 1783542987.4836917,
+    "timestamp": 1783543837.2208123,
     "metadata": {
       "hero": "composable_default",
       "ladder_rungs": [
@@ -77,7 +77,70 @@
           "statistically_significant": true,
           "beaten": true
         }
-      ]
+      ],
+      "skill": {
+        "domain": "poker",
+        "benchmark_id": "poker/ladder_20k",
+        "metric_name": "bb_per_100",
+        "skill_index": 100.0,
+        "rungs_beaten": 4,
+        "total_rungs": 4,
+        "rungs": [
+          {
+            "rung": "L0",
+            "rung_id": "random",
+            "metric": 1063.2414975845409,
+            "beaten": true,
+            "ci_95": [
+              945.2107299412481,
+              1291.7658783404113
+            ],
+            "detail": {
+              "hands_played": 2070
+            }
+          },
+          {
+            "rung": "L1",
+            "rung_id": "loose_passive",
+            "metric": 667.4797334986057,
+            "beaten": true,
+            "ci_95": [
+              641.6584189178593,
+              754.4506294520384
+            ],
+            "detail": {
+              "hands_played": 3227
+            }
+          },
+          {
+            "rung": "L2",
+            "rung_id": "tight_aggressive",
+            "metric": 385.1847577572128,
+            "beaten": true,
+            "ci_95": [
+              322.5392995576424,
+              565.5104556825169
+            ],
+            "detail": {
+              "hands_played": 3674
+            }
+          },
+          {
+            "rung": "L3",
+            "rung_id": "gto_expert",
+            "metric": 588.7031373582917,
+            "beaten": true,
+            "ci_95": [
+              526.9655034013663,
+              747.9906168731418
+            ],
+            "detail": {
+              "hands_played": 3793
+            }
+          }
+        ],
+        "notes": "Ladder-position index: 100 = beats every current rung (ceiling saturated, add a taller rung). gto_expert is a GTO-inspired scripted heuristic, not solver-verified GTO."
+      }
     },
     "score_breakdown": {
       "random": 1063.2414975845409,

--- a/core/skill/__init__.py
+++ b/core/skill/__init__.py
@@ -1,0 +1,19 @@
+"""Skill ladder schema: frozen-ruler skill measurement shared by benchmarks."""
+
+from core.skill.ladder import (
+    RungResult,
+    SkillLadderSummary,
+    interpolated_index,
+    ladder_position_index,
+    load_ladder_summaries,
+    summary_from_champion_data,
+)
+
+__all__ = [
+    "RungResult",
+    "SkillLadderSummary",
+    "interpolated_index",
+    "ladder_position_index",
+    "load_ladder_summaries",
+    "summary_from_champion_data",
+]

--- a/core/skill/ladder.py
+++ b/core/skill/ladder.py
@@ -1,0 +1,211 @@
+"""Skill ladder schema: a shared shape for frozen-ruler skill measurement.
+
+A skill ladder benchmark evaluates the evolvable substrate of one domain
+(poker, foraging, soccer, ...) against a set of *frozen rulers* - reference
+opponents or oracles that never change once committed. Because the rulers are
+immutable, ladder metrics stay comparable across champion re-baselines and
+config changes, unlike raw benchmark scores.
+
+Benchmarks embed the summary under ``result["metadata"]["skill"]`` via
+:meth:`SkillLadderSummary.to_dict`, which makes it land in the champion
+registry automatically. Consumers (``tools/skill_status.py``, dashboards)
+read it back with :func:`summary_from_champion_data` without caring which
+domain produced it.
+
+Conventions:
+- ``skill_index`` is calibrated so 0 = floor and 100 = the benchmark's
+  ceiling rung. It may exceed 100 when the substrate beats a heuristic
+  ceiling (e.g. a greedy oracle is an estimate, not a bound) - report it
+  unclamped and let readers see that the ruler needs a taller rung.
+- Rungs are ordered weakest to strongest. Changing an existing rung's
+  behavior invalidates longitudinal comparisons; add a new rung instead.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RungResult:
+    """The substrate's measured performance against one frozen ruler."""
+
+    rung: str
+    """Ladder position label, e.g. ``"L0"``."""
+
+    rung_id: str
+    """Stable identifier of the ruler, e.g. ``"loose_passive"`` or ``"oracle_greedy"``."""
+
+    metric: float
+    """Domain metric against this rung (bb/100, energy ratio, goal diff, ...)."""
+
+    ci_95: tuple[float, float] | None = None
+    """Optional 95% confidence interval on ``metric``."""
+
+    beaten: bool = False
+    """Whether the substrate beats this rung (domain-defined, ideally CI-backed)."""
+
+    detail: dict[str, Any] = field(default_factory=dict)
+    """Free-form domain extras (hands played, sample variance, ...)."""
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "rung": self.rung,
+            "rung_id": self.rung_id,
+            "metric": self.metric,
+            "beaten": self.beaten,
+        }
+        if self.ci_95 is not None:
+            data["ci_95"] = [self.ci_95[0], self.ci_95[1]]
+        if self.detail:
+            data["detail"] = dict(self.detail)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RungResult:
+        ci_raw = data.get("ci_95")
+        ci: tuple[float, float] | None = None
+        if isinstance(ci_raw, (list, tuple)) and len(ci_raw) == 2:
+            ci = (float(ci_raw[0]), float(ci_raw[1]))
+        return cls(
+            rung=str(data["rung"]),
+            rung_id=str(data["rung_id"]),
+            metric=float(data["metric"]),
+            ci_95=ci,
+            beaten=bool(data.get("beaten", False)),
+            detail=dict(data.get("detail", {})),
+        )
+
+
+@dataclass(frozen=True)
+class SkillLadderSummary:
+    """A domain's skill measurement against its frozen ruler ladder."""
+
+    domain: str
+    """Domain name: ``"poker"``, ``"foraging"``, ``"soccer"``, ..."""
+
+    benchmark_id: str
+    """The benchmark that produced this summary, e.g. ``"poker/ladder_20k"``."""
+
+    metric_name: str
+    """Name of the per-rung metric, e.g. ``"bb_per_100"``."""
+
+    skill_index: float
+    """Normalized skill: 0 = floor, 100 = ceiling rung (unclamped, see module doc)."""
+
+    rungs: tuple[RungResult, ...]
+    """Per-rung results, ordered weakest to strongest."""
+
+    notes: str = ""
+    """Honest caveats about the rulers (heuristic ceiling, sample size, ...)."""
+
+    @property
+    def rungs_beaten(self) -> int:
+        return sum(1 for r in self.rungs if r.beaten)
+
+    @property
+    def total_rungs(self) -> int:
+        return len(self.rungs)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "domain": self.domain,
+            "benchmark_id": self.benchmark_id,
+            "metric_name": self.metric_name,
+            "skill_index": self.skill_index,
+            "rungs_beaten": self.rungs_beaten,
+            "total_rungs": self.total_rungs,
+            "rungs": [r.to_dict() for r in self.rungs],
+        }
+        if self.notes:
+            data["notes"] = self.notes
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SkillLadderSummary:
+        return cls(
+            domain=str(data["domain"]),
+            benchmark_id=str(data["benchmark_id"]),
+            metric_name=str(data["metric_name"]),
+            skill_index=float(data["skill_index"]),
+            rungs=tuple(RungResult.from_dict(r) for r in data.get("rungs", [])),
+            notes=str(data.get("notes", "")),
+        )
+
+
+def ladder_position_index(rungs: tuple[RungResult, ...]) -> float:
+    """Skill index for a *play-against-the-ladder* domain (poker, soccer).
+
+    The substrate plays each frozen ruler; ``skill_index`` is the fraction of
+    rungs beaten, scaled to 0-100. 100 means the substrate beats every rung on
+    the current ladder - a saturation signal that the ceiling is no longer
+    challenging and a taller rung should be added, not proof of perfect play.
+    Per-rung margins in the summary preserve the finer picture (including any
+    non-monotonicity, e.g. beating a nominal "expert" by more than a weaker
+    rung).
+    """
+    if not rungs:
+        return 0.0
+    beaten = sum(1 for r in rungs if r.beaten)
+    return 100.0 * beaten / len(rungs)
+
+
+def interpolated_index(metric: float, floor_metric: float, ceiling_metric: float) -> float:
+    """Skill index for a *same-task* domain with floor and ceiling references.
+
+    Used when a floor (random) and ceiling (oracle) perform the identical task
+    the substrate does, so ``metric`` is directly comparable to both:
+    ``100 * (metric - floor) / (ceiling - floor)``. 0 = floor, 100 = ceiling.
+    Reported unclamped: >100 means the substrate beat a heuristic ceiling (the
+    oracle is an estimate, not a hard bound); <0 means it underperformed the
+    floor.
+    """
+    span = ceiling_metric - floor_metric
+    if abs(span) < 1e-12:
+        return 0.0
+    return 100.0 * (metric - floor_metric) / span
+
+
+def summary_from_champion_data(champion_data: dict[str, Any]) -> SkillLadderSummary | None:
+    """Extract the skill summary from a champion registry JSON structure.
+
+    Accepts both the standard nested format (``{"champion": {...}}``) and a
+    bare champion record. Returns None for champions whose benchmark does not
+    emit skill metadata (e.g. ecosystem-level benchmarks).
+    """
+    record = champion_data.get("champion", champion_data)
+    metadata = record.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    skill = metadata.get("skill")
+    if not isinstance(skill, dict):
+        return None
+    try:
+        return SkillLadderSummary.from_dict(skill)
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def load_ladder_summaries(champions_dir: str | os.PathLike[str]) -> list[SkillLadderSummary]:
+    """Load every skill summary embedded in a champion registry directory.
+
+    Scans ``champions_dir`` recursively for ``*.json`` and returns the skill
+    summaries of the benchmarks that emit one, sorted by domain then
+    benchmark id. Malformed or skill-less champion files are skipped.
+    """
+    summaries: list[SkillLadderSummary] = []
+    pattern = os.path.join(str(champions_dir), "**", "*.json")
+    for champ_path in sorted(glob.glob(pattern, recursive=True)):
+        try:
+            with open(champ_path, encoding="utf-8") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+        summary = summary_from_champion_data(data)
+        if summary is not None:
+            summaries.append(summary)
+    return sorted(summaries, key=lambda s: (s.domain, s.benchmark_id))

--- a/frontend/src/components/PokerDashboard.tsx
+++ b/frontend/src/components/PokerDashboard.tsx
@@ -4,6 +4,7 @@ import { PokerLeaderboard } from './PokerLeaderboard';
 import PokerEvents from './PokerEvents';
 import { AutoEvaluateDisplay } from './AutoEvaluateDisplay';
 import { EvolutionBenchmarkDisplay } from './EvolutionBenchmarkDisplay';
+import { SkillLadderPanel } from './SkillLadderPanel';
 import './PokerDashboard.css';
 
 interface PokerDashboardProps {
@@ -93,6 +94,14 @@ export const PokerDashboard: React.FC<PokerDashboardProps> = ({ state }) => {
                     <span>🎯</span> Poker Skill Benchmark (bb/100)
                 </div>
                 <EvolutionBenchmarkDisplay worldId={state.world_id} />
+            </div>
+
+            {/* Cross-domain skill ladders vs frozen rulers (poker / foraging / soccer) */}
+            <div className="section-container">
+                <div className="section-title">
+                    <span>🪜</span> Skill Ladders (absolute, vs frozen rulers)
+                </div>
+                <SkillLadderPanel />
             </div>
 
             {/* Detailed Split View */}

--- a/frontend/src/components/SkillLadderPanel.test.tsx
+++ b/frontend/src/components/SkillLadderPanel.test.tsx
@@ -1,0 +1,58 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { SkillLadderList } from './SkillLadderPanel';
+import type { SkillLadder } from '../types/skill';
+
+function pokerLadder(overrides: Partial<SkillLadder> = {}): SkillLadder {
+    return {
+        domain: 'poker',
+        benchmark_id: 'poker/ladder_20k',
+        metric_name: 'bb_per_100',
+        skill_index: 100,
+        rungs_beaten: 4,
+        total_rungs: 4,
+        rungs: [
+            { rung: 'L0', rung_id: 'random', metric: 1063.2, beaten: true },
+            { rung: 'L3', rung_id: 'gto_expert', metric: 588.7, beaten: true },
+        ],
+        notes: 'ceiling saturated',
+        ...overrides,
+    };
+}
+
+describe('SkillLadderList', () => {
+    it('renders each domain and its rungs', () => {
+        const html = renderToString(<SkillLadderList ladders={[pokerLadder()]} />);
+        expect(html).toContain('poker');
+        expect(html).toContain('poker/ladder_20k');
+        expect(html).toContain('gto_expert');
+        expect(html).toContain('4/4 rungs');
+        expect(html).toContain('100');
+    });
+
+    it('marks unbeaten rungs distinctly', () => {
+        const html = renderToString(
+            <SkillLadderList
+                ladders={[
+                    pokerLadder({
+                        skill_index: 50,
+                        rungs_beaten: 1,
+                        total_rungs: 2,
+                        rungs: [
+                            { rung: 'L0', rung_id: 'random', metric: 500, beaten: true },
+                            { rung: 'L1', rung_id: 'tag', metric: -20, beaten: false },
+                        ],
+                    }),
+                ]}
+            />,
+        );
+        expect(html).toContain('beaten');
+        expect(html).toContain('not yet');
+    });
+
+    it('shows an empty-state message when there are no ladders', () => {
+        const html = renderToString(<SkillLadderList ladders={[]} />);
+        expect(html).toContain('No skill ladders recorded yet');
+    });
+});

--- a/frontend/src/components/SkillLadderPanel.tsx
+++ b/frontend/src/components/SkillLadderPanel.tsx
@@ -1,0 +1,266 @@
+/**
+ * Skill Ladder Panel
+ *
+ * Shows, per domain (poker / foraging / soccer / ...), how the evolved agents
+ * measure against that domain's frozen ruler ladder: a normalized skill index
+ * and the per-rung standings. Data comes from GET /api/skill/ladders, which
+ * reads the champion registry. This is the "absolute skill + distance to
+ * ceiling" view the raw self-play numbers can't give.
+ */
+
+import { useEffect, useState } from 'react';
+import { colors } from '../styles/theme';
+import type { SkillLadder, SkillLaddersResponse } from '../types/skill';
+import { CollapsibleSection } from './ui';
+
+function skillColor(index: number): string {
+    if (index >= 90) return colors.success;
+    if (index >= 60) return '#84cc16';
+    if (index >= 30) return colors.warning;
+    return colors.danger;
+}
+
+function formatMetric(value: number): string {
+    return `${value >= 0 ? '+' : ''}${value.toFixed(1)}`;
+}
+
+export function LadderCard({ ladder }: { ladder: SkillLadder }) {
+    const index = ladder.skill_index;
+    const color = skillColor(index);
+    const rungProgress = `${ladder.rungs_beaten}/${ladder.total_rungs} rungs`;
+
+    return (
+        <div style={styles.card}>
+            <div style={styles.cardHeader}>
+                <span style={styles.domain}>{ladder.domain}</span>
+                <span style={styles.benchmarkId}>{ladder.benchmark_id}</span>
+                <span style={{ ...styles.rungsBeaten, color }}>{rungProgress}</span>
+            </div>
+
+            <div style={styles.indexRow}>
+                <div style={styles.indexBarTrack}>
+                    <div
+                        style={{
+                            ...styles.indexBarFill,
+                            width: `${Math.max(0, Math.min(100, index))}%`,
+                            backgroundColor: color,
+                        }}
+                    />
+                </div>
+                <span style={{ ...styles.indexValue, color }}>{index.toFixed(0)}</span>
+                <span style={styles.indexUnit}>/ 100 skill</span>
+            </div>
+
+            <div style={styles.rungList}>
+                {ladder.rungs.map(rung => (
+                    <div key={rung.rung_id} style={styles.rungRow}>
+                        <span style={styles.rungLabel}>
+                            {rung.rung} {rung.rung_id}
+                        </span>
+                        <span
+                            style={{
+                                ...styles.rungMetric,
+                                color: rung.beaten ? colors.success : colors.textSecondary,
+                            }}
+                        >
+                            {formatMetric(rung.metric)}
+                            <span style={styles.metricName}> {ladder.metric_name}</span>
+                        </span>
+                        <span
+                            style={{
+                                ...styles.rungBadge,
+                                color: rung.beaten ? colors.success : colors.danger,
+                            }}
+                        >
+                            {rung.beaten ? 'beaten' : 'not yet'}
+                        </span>
+                    </div>
+                ))}
+            </div>
+
+            {ladder.notes && <div style={styles.notes}>{ladder.notes}</div>}
+        </div>
+    );
+}
+
+export function SkillLadderList({ ladders }: { ladders: SkillLadder[] }) {
+    if (ladders.length === 0) {
+        return (
+            <div style={styles.noData}>
+                No skill ladders recorded yet. Run a ladder benchmark (e.g. poker/ladder_20k)
+                and register its champion.
+            </div>
+        );
+    }
+    return (
+        <div style={styles.list}>
+            {ladders.map(ladder => (
+                <LadderCard key={ladder.benchmark_id} ladder={ladder} />
+            ))}
+        </div>
+    );
+}
+
+export function SkillLadderPanel() {
+    const [ladders, setLadders] = useState<SkillLadder[] | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const fetchData = async () => {
+            try {
+                const response = await fetch('/api/skill/ladders');
+                const contentType = response.headers.get('content-type');
+                if (!contentType?.includes('application/json') || !response.ok) {
+                    if (!cancelled) setLoading(false);
+                    return;
+                }
+                const json: SkillLaddersResponse = await response.json();
+                if (!cancelled) setLadders(json.ladders ?? []);
+            } catch (e) {
+                console.debug('Skill ladder API not available:', e);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+
+        setLoading(true);
+        fetchData();
+        const interval = setInterval(fetchData, 60000);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, []);
+
+    return (
+        <div className="glass-panel" style={{ padding: '16px' }}>
+            <CollapsibleSection
+                title={
+                    <span style={{ fontSize: '16px', fontWeight: 600, color: colors.primary }}>
+                        Skill Ladders (vs frozen rulers)
+                    </span>
+                }
+                defaultExpanded={true}
+            >
+                {loading ? (
+                    <div style={styles.noData}>Loading skill ladders...</div>
+                ) : (
+                    <SkillLadderList ladders={ladders ?? []} />
+                )}
+            </CollapsibleSection>
+        </div>
+    );
+}
+
+const styles = {
+    list: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        gap: '12px',
+    },
+    card: {
+        backgroundColor: colors.bgLight,
+        borderRadius: '10px',
+        padding: '12px',
+        border: `1px solid ${colors.border}`,
+        display: 'flex',
+        flexDirection: 'column' as const,
+        gap: '8px',
+    },
+    cardHeader: {
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: '10px',
+        flexWrap: 'wrap' as const,
+    },
+    domain: {
+        color: colors.text,
+        fontSize: '15px',
+        fontWeight: 700,
+        textTransform: 'capitalize' as const,
+    },
+    benchmarkId: {
+        color: colors.textSecondary,
+        fontSize: '11px',
+        fontFamily: 'var(--font-mono)',
+    },
+    rungsBeaten: {
+        marginLeft: 'auto',
+        fontSize: '12px',
+        fontWeight: 700,
+    },
+    indexRow: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '10px',
+    },
+    indexBarTrack: {
+        flex: 1,
+        height: '10px',
+        borderRadius: '5px',
+        backgroundColor: 'rgba(15,23,42,0.6)',
+        overflow: 'hidden',
+    },
+    indexBarFill: {
+        height: '100%',
+        borderRadius: '5px',
+    },
+    indexValue: {
+        fontSize: '20px',
+        fontWeight: 700,
+        fontFamily: 'var(--font-mono)',
+    },
+    indexUnit: {
+        color: colors.textSecondary,
+        fontSize: '10px',
+    },
+    rungList: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        gap: '4px',
+    },
+    rungRow: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '10px',
+        fontSize: '12px',
+    },
+    rungLabel: {
+        color: colors.text,
+        width: '180px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap' as const,
+    },
+    rungMetric: {
+        marginLeft: 'auto',
+        fontFamily: 'var(--font-mono)',
+        fontWeight: 600,
+    },
+    metricName: {
+        color: colors.textSecondary,
+        fontWeight: 400,
+        fontSize: '10px',
+    },
+    rungBadge: {
+        width: '64px',
+        textAlign: 'right' as const,
+        fontSize: '11px',
+        fontWeight: 600,
+    },
+    notes: {
+        color: colors.textSecondary,
+        fontSize: '11px',
+        lineHeight: 1.4,
+        borderTop: `1px solid ${colors.border}`,
+        paddingTop: '6px',
+    },
+    noData: {
+        padding: '20px',
+        textAlign: 'center' as const,
+        color: colors.textSecondary,
+        fontSize: '13px',
+    },
+} as const;

--- a/frontend/src/types/skill.ts
+++ b/frontend/src/types/skill.ts
@@ -1,0 +1,27 @@
+// Skill-ladder standings (frozen-ruler measurement). Mirrors
+// core/skill/ladder.py::SkillLadderSummary / RungResult.
+
+export interface SkillRung {
+    rung: string;
+    rung_id: string;
+    metric: number;
+    beaten: boolean;
+    ci_95?: [number, number];
+    detail?: Record<string, number>;
+}
+
+export interface SkillLadder {
+    domain: string;
+    benchmark_id: string;
+    metric_name: string;
+    skill_index: number;
+    rungs_beaten: number;
+    total_rungs: number;
+    rungs: SkillRung[];
+    notes?: string;
+}
+
+export interface SkillLaddersResponse {
+    schema_version: number;
+    ladders: SkillLadder[];
+}

--- a/tests/core/test_skill_ladder.py
+++ b/tests/core/test_skill_ladder.py
@@ -1,0 +1,107 @@
+"""Tests for the skill-ladder schema and status tooling."""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from core.skill import (
+    RungResult,
+    SkillLadderSummary,
+    interpolated_index,
+    ladder_position_index,
+    summary_from_champion_data,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _make_summary() -> SkillLadderSummary:
+    return SkillLadderSummary(
+        domain="poker",
+        benchmark_id="poker/ladder_20k",
+        metric_name="bb_per_100",
+        skill_index=75.0,
+        rungs=(
+            RungResult("L0", "random", 1000.0, ci_95=(900.0, 1100.0), beaten=True),
+            RungResult("L1", "loose_passive", 500.0, beaten=True),
+            RungResult("L2", "tight_aggressive", -20.0, ci_95=(-60.0, 20.0), beaten=False),
+        ),
+        notes="test",
+    )
+
+
+class TestSkillLadderSchema(unittest.TestCase):
+    def test_roundtrip_preserves_fields(self):
+        summary = _make_summary()
+        restored = SkillLadderSummary.from_dict(summary.to_dict())
+        self.assertEqual(restored, summary)
+
+    def test_rung_counts(self):
+        summary = _make_summary()
+        self.assertEqual(summary.total_rungs, 3)
+        self.assertEqual(summary.rungs_beaten, 2)
+
+    def test_ci_roundtrip_and_none(self):
+        with_ci = RungResult("L0", "random", 1.0, ci_95=(0.5, 1.5))
+        self.assertEqual(RungResult.from_dict(with_ci.to_dict()).ci_95, (0.5, 1.5))
+        without = RungResult("L1", "x", 1.0)
+        self.assertIsNone(RungResult.from_dict(without.to_dict()).ci_95)
+
+
+class TestSkillIndices(unittest.TestCase):
+    def test_ladder_position_index_fraction_beaten(self):
+        rungs = (
+            RungResult("L0", "a", 1.0, beaten=True),
+            RungResult("L1", "b", 1.0, beaten=True),
+            RungResult("L2", "c", 1.0, beaten=False),
+            RungResult("L3", "d", 1.0, beaten=False),
+        )
+        self.assertEqual(ladder_position_index(rungs), 50.0)
+
+    def test_ladder_position_index_empty(self):
+        self.assertEqual(ladder_position_index(()), 0.0)
+
+    def test_interpolated_index_endpoints_and_midpoint(self):
+        self.assertAlmostEqual(interpolated_index(0.0, 0.0, 100.0), 0.0)
+        self.assertAlmostEqual(interpolated_index(100.0, 0.0, 100.0), 100.0)
+        self.assertAlmostEqual(interpolated_index(42.0, 0.0, 100.0), 42.0)
+
+    def test_interpolated_index_unclamped_above_ceiling(self):
+        self.assertGreater(interpolated_index(120.0, 0.0, 100.0), 100.0)
+
+    def test_interpolated_index_degenerate_span(self):
+        self.assertEqual(interpolated_index(5.0, 3.0, 3.0), 0.0)
+
+
+class TestSummaryFromChampion(unittest.TestCase):
+    def test_extracts_nested_champion(self):
+        champ = {"champion": {"metadata": {"skill": _make_summary().to_dict()}}}
+        summary = summary_from_champion_data(champ)
+        self.assertIsNotNone(summary)
+        assert summary is not None
+        self.assertEqual(summary.domain, "poker")
+
+    def test_returns_none_without_skill_metadata(self):
+        self.assertIsNone(summary_from_champion_data({"champion": {"metadata": {}}}))
+        self.assertIsNone(summary_from_champion_data({"champion": {}}))
+        self.assertIsNone(summary_from_champion_data({}))
+
+
+class TestSkillStatusCli(unittest.TestCase):
+    def test_json_output_includes_poker(self):
+        proc = subprocess.run(
+            [sys.executable, str(ROOT / "tools" / "skill_status.py"), "--json"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        payload = json.loads(proc.stdout)
+        domains = {entry["domain"] for entry in payload}
+        self.assertIn("poker", domains)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_api.py
+++ b/tests/test_skill_api.py
@@ -1,0 +1,60 @@
+"""Tests for the skill-ladder standings REST endpoint."""
+
+import json
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routers import skill
+from core.skill import RungResult, SkillLadderSummary
+
+
+def _client_for(champions_dir: Path) -> TestClient:
+    app = FastAPI()
+    app.include_router(skill.setup_router(champions_dir=champions_dir))
+    return TestClient(app)
+
+
+def _write_champion(path: Path, summary: SkillLadderSummary) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"champion": {"metadata": {"skill": summary.to_dict()}}}),
+        encoding="utf-8",
+    )
+
+
+def test_ladders_endpoint_returns_summaries(tmp_path):
+    summary = SkillLadderSummary(
+        domain="poker",
+        benchmark_id="poker/ladder_20k",
+        metric_name="bb_per_100",
+        skill_index=100.0,
+        rungs=(RungResult("L0", "random", 1000.0, beaten=True),),
+    )
+    _write_champion(tmp_path / "poker" / "ladder_20k.json", summary)
+
+    resp = _client_for(tmp_path).get("/api/skill/ladders")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == skill.SCHEMA_VERSION
+    assert len(body["ladders"]) == 1
+    assert body["ladders"][0]["domain"] == "poker"
+    assert body["ladders"][0]["skill_index"] == 100.0
+
+
+def test_ladders_endpoint_skips_skilless_champions(tmp_path):
+    (tmp_path / "tank").mkdir(parents=True)
+    (tmp_path / "tank" / "survival_5k.json").write_text(
+        json.dumps({"champion": {"metadata": {"avg_pop": 50}}}), encoding="utf-8"
+    )
+
+    resp = _client_for(tmp_path).get("/api/skill/ladders")
+    assert resp.status_code == 200
+    assert resp.json()["ladders"] == []
+
+
+def test_ladders_endpoint_handles_empty_dir(tmp_path):
+    resp = _client_for(tmp_path).get("/api/skill/ladders")
+    assert resp.status_code == 200
+    assert resp.json()["ladders"] == []

--- a/tools/skill_status.py
+++ b/tools/skill_status.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Summarize skill-ladder standings across all domains.
+
+Reads the champion registry (``champions/**/*.json``) and prints, for every
+benchmark that emits a skill-ladder summary (see ``core/skill/ladder.py``), the
+normalized skill index, how many frozen rungs the substrate beats, and the
+per-rung margins. This is the "how good are the agents, absolutely and vs the
+ceiling" view in one place.
+
+Usage:
+    python tools/skill_status.py                # human-readable table
+    python tools/skill_status.py --json         # machine-readable
+    python tools/skill_status.py --domain poker # filter to one domain
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from core.skill import SkillLadderSummary, load_ladder_summaries
+
+
+def _format_rung(rung: Any) -> str:
+    mark = "beat" if rung.beaten else "----"
+    ci = ""
+    if rung.ci_95 is not None:
+        ci = f"  [{rung.ci_95[0]:.1f}, {rung.ci_95[1]:.1f}]"
+    return f"    {rung.rung} {rung.rung_id:<20} {rung.metric:+10.2f}  {mark}{ci}"
+
+
+def render_text(summaries: list[SkillLadderSummary]) -> str:
+    if not summaries:
+        return "No skill-ladder summaries found in the champion registry."
+
+    lines: list[str] = []
+    lines.append("=" * 70)
+    lines.append("SKILL LADDER STATUS (frozen-ruler standings)")
+    lines.append("=" * 70)
+    for summary in sorted(summaries, key=lambda s: s.domain):
+        lines.append("")
+        lines.append(
+            f"{summary.domain.upper()}  ({summary.benchmark_id})  "
+            f"skill_index={summary.skill_index:.1f}  "
+            f"rungs_beaten={summary.rungs_beaten}/{summary.total_rungs}"
+        )
+        lines.append(f"  metric: {summary.metric_name}")
+        for rung in summary.rungs:
+            lines.append(_format_rung(rung))
+        if summary.notes:
+            lines.append(f"  note: {summary.notes}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Summarize skill-ladder standings")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of a table")
+    parser.add_argument("--domain", help="Filter to a single domain (e.g. poker)")
+    parser.add_argument(
+        "--champions-dir",
+        default=str(ROOT / "champions"),
+        help="Champion registry directory (default: ./champions)",
+    )
+    args = parser.parse_args()
+
+    summaries = load_ladder_summaries(args.champions_dir)
+    if args.domain:
+        summaries = [s for s in summaries if s.domain == args.domain]
+
+    if args.json:
+        print(json.dumps([s.to_dict() for s in summaries], indent=2))
+    else:
+        print(render_text(summaries))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed
This draft PR finishes the skill-ladders-first-class work in two Layer 2 steps:

- carries the poker ladder review follow-up: honest `gto_expert` naming, `vs_top_rung_*` metadata, subprocess-vs-subprocess determinism in CI, and locked reference-ruler files
- adds first-class skill ladder standings: shared `core.skill` schema/helpers, poker `metadata.skill`, `tools/skill_status.py`, stateless `GET /api/skill/ladders`, and a dashboard panel with focused tests

## Layer
- [ ] Layer 1 (algorithm / config - affects simulation results)
- [x] Layer 2 (benchmarks / CI / telemetry / UI / tests - does not change simulation behavior)

## Why
Raw self-play or benchmark scores do not clearly show absolute skill or distance to a frozen ruler. This creates one common schema/API/UI surface for poker now and for future foraging/soccer ladders, while keeping rulers explicit and comparable.

## Proof
Initial required command with the local `python` shim failed because Windows resolves `python` to the Microsoft Store alias:

```bash
python tools/smoke_gate.py
# Python was not found; run without arguments to install from the Microsoft Store...
```

Using the available launcher passed, and all checks below were rerun after rebasing onto current `origin/master`:

```bash
py -3 tools/smoke_gate.py
# 43 passed; SMOKE gate passed

py -3 -m pytest tests/core/test_skill_ladder.py tests/test_skill_api.py -v
# 14 passed

py -3 tools/skill_status.py --json
# emitted poker skill ladder summary, skill_index=100.0, rungs_beaten=4/4

py -3 tools/run_bench.py benchmarks/poker/ladder_20k.py --seed 42 --verify-determinism
# Determinism check PASSED; score=676.1522815496628; skill_index=100.0

py -3 tools/validate_champion_provenance.py
# Champion provenance validation passed for 5 files

npm run lint
# passed

npm run build
# passed

npm run test -- --run SkillLadderPanel
# 3 passed

py -3 tools/agent_gate.py
# AGENT gate passed; 595 selected tests passed after smoke + mypy

py -3 tools/pre_pr_gate.py
# PRE-PR gate passed; worlds/evolution/backend_tools/core shards passed
```

## Notes
A pre-PR attempt caught growth in `frontend/src/types/simulation.ts`; the final patch moves new skill types into `frontend/src/types/skill.ts` instead of re-pinning the legacy file.