### PR TITLE
Retire Any from composable food selection

### DIFF
--- a/core/algorithms/composable/food_selection.py
+++ b/core/algorithms/composable/food_selection.py
@@ -9,7 +9,7 @@ and where to intercept it (:func:`predict_food_target`).
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, cast
 
 from core.config.fish import CRITICAL_ENERGY_THRESHOLD_RATIO, SAFE_ENERGY_THRESHOLD_RATIO
 from core.config.food import (
@@ -19,7 +19,7 @@ from core.config.food import (
     FOOD_QUALITY_DISTANCE_WEIGHT,
     FOOD_SINK_ACCELERATION,
 )
-from core.entities import Food as FoodClass
+from core.entities import Food
 from core.math_utils import Vector2
 from core.predictive_movement import predict_falling_intercept
 
@@ -61,7 +61,9 @@ def _food_chase_distance_for_energy(fish: Fish) -> float:
     return float(CHASE_DISTANCE_SAFE_BASE)
 
 
-def predict_food_target(fish: Fish, food: Any, distance: float, prediction_skill: float) -> Vector2:
+def predict_food_target(
+    fish: Fish, food: Food, distance: float, prediction_skill: float
+) -> Vector2:
     """Return the predicted intercept position for a food item.
 
     Falls back to the food's current position when it isn't moving.
@@ -78,7 +80,7 @@ def predict_food_target(fish: Fish, food: Any, distance: float, prediction_skill
         return target_pos
 
     if hasattr(food, "food_properties"):
-        sink_multiplier = food.food_properties.get("sink_multiplier", 1.0)
+        sink_multiplier = cast(float, food.food_properties.get("sink_multiplier", 1.0))
         acceleration = FOOD_SINK_ACCELERATION * sink_multiplier
         if acceleration > 0 and food_vel.y >= 0:
             predicted_pos, _ = predict_falling_intercept(
@@ -104,7 +106,7 @@ def predict_food_target(fish: Fish, food: Any, distance: float, prediction_skill
     )
 
 
-def select_food_target(fish: Fish) -> Any | None:
+def select_food_target(fish: Fish) -> Food | None:
     """Pick the best food to pursue within detection range.
 
     Unlike the proximity-only ``_find_nearest_food`` helper (kept for the cheap
@@ -132,9 +134,9 @@ def select_food_target(fish: Fish) -> Any | None:
     max_distance_sq = max_distance * max_distance
 
     if hasattr(env, "nearby_resources"):
-        nearby = env.nearby_resources(fish, int(max_distance) + 1)
+        nearby = cast(list[Food], env.nearby_resources(fish, int(max_distance) + 1))
     else:
-        nearby = env.nearby_agents_by_type(fish, int(max_distance) + 1, FoodClass)
+        nearby = cast(list[Food], env.nearby_agents_by_type(fish, int(max_distance) + 1, Food))
     if not nearby:
         return None
 

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -625,6 +625,11 @@ shared module on multiple ladders (foraging gym / soccer / poker) to produce a
 
 ## Shipped
 
+- **6.2 Retired `Any` in composable food selection.** Replaced the broad food
+  target and selection annotations in
+  `core/algorithms/composable/food_selection.py` with the concrete `Food`
+  entity type, preserving the selector's existing runtime behavior while making
+  the composable foraging contract visible to static analysis.
 - **ADR-016: removed the five vestigial monolith algorithm categories.**
   Deleted `predator_avoidance.py`, `schooling.py`, `energy_management.py`,
   `territory.py`, and `poker.py` from `core/algorithms/` (44 algorithms,


### PR DESCRIPTION
## What changed

Replaced the broad `Any` annotations in composable food target prediction and selection with the concrete `Food` entity type. Documented this completed slice of proposal 6.2 in the improvement backlog.

## Layer

- [x] Layer 2 (type safety / tooling; no simulation behavior change)

## Why

Composable foraging is a core behavior path. Concrete return and parameter types make its contract visible to static analysis while preserving the existing runtime behavior.

## Proof

- `py -m pytest tests/core/test_food_target_selection.py -v` — 10 passed
- `py -m mypy core` — success (322 source files)
- `py tools/agent_gate.py` — passed (595 tests)
- `py tools/pre_pr_gate.py` — passed (all shards)
- `py -m pre_commit run --files core/algorithms/composable/food_selection.py docs/IMPROVEMENT_PROPOSALS.md` — passed

No benchmark run is needed: this is a Layer 2 typing-only change and does not alter simulation logic or champion files.
