### PR TITLE
Remove duplicate render FPS display

### DIFF
--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -20,19 +20,13 @@ interface CanvasProps {
     style?: CSSProperties;
     viewMode?: ViewMode;
     worldType?: string;  // Optional override for renderer selection (e.g., 'petri' for circular dish)
-    /** Reports the render loop's own draw rate (~2x/sec), independent of simulation FPS. */
-    onRenderFps?: (fps: number) => void;
 }
-
-// How often to report the render-loop FPS sample (ms). Frequent enough to feel
-// live, coarse enough that it never itself becomes the render bottleneck.
-const FPS_REPORT_INTERVAL_MS = 500;
 
 // Tank world dimensions (from core/constants.py)
 const WORLD_WIDTH = 1088;
 const WORLD_HEIGHT = 612;
 
-export function Canvas({ state, width = 800, height = 600, onEntityClick, selectedEntityId, showEffects = true, showSoccer = true, style, viewMode = "side", worldType: worldTypeProp, onRenderFps }: CanvasProps) {
+export function Canvas({ state, width = 800, height = 600, onEntityClick, selectedEntityId, showEffects = true, showSoccer = true, style, viewMode = "side", worldType: worldTypeProp }: CanvasProps) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const rendererRef = useRef<Renderer | null>(null);
     const [imagesLoaded, setImagesLoaded] = useState(false);
@@ -97,7 +91,6 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
     const showSoccerRef = useRef(showSoccer);
     const viewModeRef = useRef(viewMode);
     const worldTypePropRef = useRef(worldTypeProp);
-    const onRenderFpsRef = useRef(onRenderFps);
 
     useEffect(() => {
         stateRef.current = state;
@@ -107,8 +100,7 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
         showSoccerRef.current = showSoccer;
         viewModeRef.current = viewMode;
         worldTypePropRef.current = worldTypeProp;
-        onRenderFpsRef.current = onRenderFps;
-    }, [state, imagesLoaded, selectedEntityId, showEffects, showSoccer, viewMode, worldTypeProp, onRenderFps]);
+    }, [state, imagesLoaded, selectedEntityId, showEffects, showSoccer, viewMode, worldTypeProp]);
 
     useEffect(() => {
         const canvas = canvasRef.current;
@@ -151,26 +143,8 @@ export function Canvas({ state, width = 800, height = 600, onEntityClick, select
 
         let animationFrameId: number;
 
-        // Render-loop FPS tracking: counts actual requestAnimationFrame calls,
-        // independent of whether there's simulation data to draw. This exposes
-        // rendering bottlenecks (e.g. fractal plants) even when the backend
-        // itself is ticking at full speed.
-        let fpsFrameCount = 0;
-        let fpsWindowStart = 0;
-
         const renderLoop = () => {
             const nowMs = performance.now();
-            if (fpsWindowStart === 0) {
-                fpsWindowStart = nowMs;
-            }
-            fpsFrameCount += 1;
-            const fpsWindowElapsed = nowMs - fpsWindowStart;
-            if (fpsWindowElapsed >= FPS_REPORT_INTERVAL_MS) {
-                onRenderFpsRef.current?.((fpsFrameCount * 1000) / fpsWindowElapsed);
-                fpsFrameCount = 0;
-                fpsWindowStart = nowMs;
-            }
-
             const currentState = stateRef.current;
 
             if (currentState && !error) {

--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -60,7 +60,6 @@ const CONNECTION_STATUS_DISPLAY: Record<ConnectionStatus, { label: string; color
 export function TankView({ worldId }: TankViewProps) {
     const { state, isConnected, connectionStatus, sendCommand, sendCommandWithResponse, connectedWorldId, schemaError } =
         useWebSocket(worldId);
-    const [renderFps, setRenderFps] = useState<number | null>(null);
     const [showEffects, setShowEffects] = useState(true);
     const [showSoccer, setShowSoccer] = useState<boolean | null>(null);  // null = not yet synced from server
     const userToggledSoccer = useRef(false);  // Track if user manually toggled
@@ -264,7 +263,7 @@ export function TankView({ worldId }: TankViewProps) {
                                         letterSpacing: '0.05em',
                                     }}
                                 >
-                                    FPS
+                                    SIM FPS
                                 </span>
                                 <span
                                     style={{
@@ -380,7 +379,6 @@ export function TankView({ worldId }: TankViewProps) {
                         showSoccer={effectiveShowSoccer}
                         viewMode={effectiveViewMode as 'side' | 'topdown'}
                         worldType={effectiveWorldType}
-                        onRenderFps={setRenderFps}
                     />
                     <div className="canvas-glow" aria-hidden />
                     <div className="canvas-hud">
@@ -396,12 +394,6 @@ export function TankView({ worldId }: TankViewProps) {
                                     }}
                                 />
                                 {CONNECTION_STATUS_DISPLAY[connectionStatus].label}
-                            </div>
-                        </div>
-                        <div className="hud-group">
-                            <div className="hud-item">
-                                <span className="hud-label">Render</span>
-                                {renderFps !== null ? `${Math.round(renderFps)} fps` : '—'}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## What changed

Removed the canvas-level render-rate HUD badge and its unused sampling callback. The remaining backend-derived counter is now explicitly labeled **SIM FPS**.

## Why

The two counters measured different clocks: the simulation loop runs at about 30 FPS while the browser can repaint at about 60 FPS. Showing both at once looked like conflicting duplicate data.

## User impact

The tank now shows one unambiguous frame-rate metric instead of a misleading 30-vs-60 pair.

## Validation

- `npm run test -- --run` — 57 frontend tests passed
- `npm run lint` — passed
- `npm run build` — passed
- `py tools/agent_gate.py` — passed
- `py tools/pre_pr_gate.py` — passed
