### PR TITLE
Add isolated foraging skill evaluator

### DIFF
--- a/backend/routers/skill.py
+++ b/backend/routers/skill.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
 from core.skill import load_ladder_summaries
@@ -43,5 +43,19 @@ def setup_router(champions_dir: Path | None = None) -> APIRouter:
                 "ladders": [s.to_dict() for s in summaries],
             }
         )
+
+    @router.get("/foraging-gym")
+    async def run_foraging_gym(
+        seed: int = Query(default=42, ge=0, le=2_147_483_647)
+    ) -> JSONResponse:
+        """Run the isolated foraging ruler for one deterministic seed.
+
+        Unlike ``/ladders``, this evaluates the current source tree directly.
+        It lets the UI inspect the foraging substrate before a benchmark result
+        is promoted to the champion registry.
+        """
+        from benchmarks.tank.foraging_gym import run
+
+        return JSONResponse(run(seed))
 
     return router

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,5 +18,6 @@ the environment or investigate a regression.
 | `benchmarks/tank/survival_5k.py` | ~45s | Champion runtime ~35s |
 | `benchmarks/tank/ecosystem_health_10k.py` | ~75s | Champion runtime ~63s |
 | `benchmarks/tank/selection_response_10k.py` | ~90s | 10k-frame selection assay |
+| `benchmarks/tank/foraging_gym.py` | ~2s | Isolated foraging skill, random floor, attainable oracle ceiling |
 | `benchmarks/soccer/training_3k.py` | ~5s | Champion runtime ~3s |
 | `benchmarks/soccer/training_5k.py` | ~5s | Champion runtime ~3s |

--- a/benchmarks/tank/foraging_gym.py
+++ b/benchmarks/tank/foraging_gym.py
@@ -1,0 +1,90 @@
+"""Frozen-ruler foraging benchmark with an attainable oracle ceiling.
+
+This benchmark isolates food seeking from ecosystem confounders.  A single
+neutral-default composable fish pursues a deterministic, seeded food script;
+there is no reproduction, poker, ball, predator, or population feedback.  The
+score is gross food energy collected divided by the full-information oracle's
+attainable energy total, so it is always in the closed interval [0, 1].
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from core.foraging.gym import evaluate_foraging_gym
+from core.skill import RungResult, SkillLadderSummary, interpolated_index
+
+BENCHMARK_ID = "tank/foraging_gym"
+EXPECTED_RUNTIME_SECONDS = 2
+
+CONFIG: dict[str, Any] = {
+    "policy": "composable_neutral_default",
+    "schedule": "frozen_lcg_lane_v1",
+    "floor": "random_walk_v1",
+    "ceiling": "full_information_greedy_v1",
+}
+
+
+def run(seed: int) -> dict[str, Any]:
+    """Measure neutral composable food-seeking skill for one fixed seed."""
+    started = time.perf_counter()
+    evaluation = evaluate_foraging_gym(seed)
+    oracle_energy = evaluation.oracle_energy
+    composable = evaluation.composable
+    random_walk = evaluation.random_walk
+    oracle = evaluation.oracle
+
+    oracle_ratio = oracle.energy_collected / oracle_energy if oracle_energy else 0.0
+    composable_ratio = evaluation.composable_ratio
+    random_ratio = evaluation.random_walk_ratio
+
+    rungs = (
+        RungResult(
+            rung="L0",
+            rung_id="random_walk_v1",
+            metric=random_ratio,
+            beaten=composable_ratio > random_ratio,
+            detail=random_walk.to_dict(),
+        ),
+        RungResult(
+            rung="L1",
+            rung_id="full_information_greedy_v1",
+            metric=oracle_ratio,
+            beaten=composable_ratio >= oracle_ratio,
+            detail=oracle.to_dict(),
+        ),
+    )
+    skill = SkillLadderSummary(
+        domain="foraging",
+        benchmark_id=BENCHMARK_ID,
+        metric_name="energy_collected_over_oracle",
+        skill_index=interpolated_index(composable_ratio, random_ratio, oracle_ratio),
+        rungs=rungs,
+        notes=(
+            "The oracle collects every scripted food item under the same speed, "
+            "bounds, and capture rules, making gross scheduled energy an attainable "
+            "ceiling. The random-walk floor ignores food."
+        ),
+    )
+    runtime = time.perf_counter() - started
+
+    return {
+        "benchmark_id": BENCHMARK_ID,
+        "seed": seed,
+        "score": composable_ratio,
+        "score_breakdown": {
+            "composable_energy_ratio": composable_ratio,
+            "random_walk_energy_ratio": random_ratio,
+            "oracle_energy_ratio": oracle_ratio,
+        },
+        "runtime_seconds": runtime,
+        "metadata": {
+            "score_mode": "gross food energy collected / attainable oracle energy",
+            "oracle_energy": oracle_energy,
+            "composable": composable.to_dict(),
+            "random_walk": random_walk.to_dict(),
+            "oracle": oracle.to_dict(),
+            "skill": skill.to_dict(),
+        },
+    }

--- a/core/foraging/__init__.py
+++ b/core/foraging/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic, isolated evaluators for food-seeking behavior."""
+
+from core.foraging.gym import ForagingGymEvaluation, GymResult, evaluate_foraging_gym
+
+__all__ = ["ForagingGymEvaluation", "GymResult", "evaluate_foraging_gym"]

--- a/core/foraging/gym.py
+++ b/core/foraging/gym.py
@@ -1,0 +1,334 @@
+"""A frozen, single-agent foraging gym with a provable energy ceiling.
+
+The tank benchmarks are deliberately rich ecosystems: reproduction, predators,
+side games, and population dynamics all affect their scores.  This module
+instead measures the food-pursuit substrate alone.  Its scripted food schedule
+has one item per interval and is constructed so a max-speed, full-information
+greedy policy can collect every item.  Consequently the sum of scheduled food
+energy is an attainable upper bound, not a fitted reference score.
+
+The evaluator uses the production ``ComposableBehavior.execute`` food path
+with a minimal world adapter.  It therefore exercises the same target
+selection, prediction, genetic foraging traits, and food-approach modes that a
+fish uses in the tank, while intentionally excluding reproduction, poker,
+predators, and the soccer ball.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol, cast
+
+from core.algorithms.composable.behavior import ComposableBehavior
+from core.energy.energy_utils import apply_energy_delta
+from core.entities import Food
+from core.math_utils import Vector2
+
+if TYPE_CHECKING:
+    from core.entities import Fish
+
+
+WORLD_WIDTH = 600.0
+WORLD_HEIGHT = 400.0
+MAX_SPEED = 2.2
+CAPTURE_RADIUS = 12.0
+ENERGY_COST_PER_DISTANCE = 0.01
+SPAWN_INTERVAL = 160
+FOOD_COUNT = 12
+SETTLE_FRAMES = 160
+RANDOM_WALK_TURN_INTERVAL = 30
+
+
+@dataclass(frozen=True)
+class FoodSpawn:
+    """An immutable, scripted food item in a gym episode."""
+
+    frame: int
+    x: float
+    y: float
+    energy: float
+
+
+@dataclass(frozen=True)
+class GymResult:
+    """One policy's outcome on a fixed foraging episode."""
+
+    energy_collected: float
+    food_collected: int
+    energy_spent: float
+    travel_distance: float
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "energy_collected": self.energy_collected,
+            "food_collected": self.food_collected,
+            "energy_spent": self.energy_spent,
+            "travel_distance": self.travel_distance,
+        }
+
+
+@dataclass(frozen=True)
+class ForagingGymEvaluation:
+    """Comparable floor, substrate, and ceiling outcomes for one seed."""
+
+    oracle_energy: float
+    oracle: GymResult
+    random_walk: GymResult
+    composable: GymResult
+
+    @property
+    def composable_ratio(self) -> float:
+        return self.composable.energy_collected / self.oracle_energy if self.oracle_energy else 0.0
+
+    @property
+    def random_walk_ratio(self) -> float:
+        return self.random_walk.energy_collected / self.oracle_energy if self.oracle_energy else 0.0
+
+
+@dataclass
+class _Trait:
+    value: float
+
+
+@dataclass
+class _BehavioralTraits:
+    aggression: _Trait = field(default_factory=lambda: _Trait(0.5))
+    pursuit_aggression: _Trait = field(default_factory=lambda: _Trait(0.5))
+    prediction_skill: _Trait = field(default_factory=lambda: _Trait(0.5))
+    hunting_stamina: _Trait = field(default_factory=lambda: _Trait(0.5))
+
+
+@dataclass
+class _GymGenome:
+    behavioral: _BehavioralTraits = field(default_factory=_BehavioralTraits)
+
+
+@dataclass
+class _GymFood:
+    pos: Vector2
+    energy: float
+    vel: Vector2 = field(default_factory=lambda: Vector2(0.0, 0.0))
+    food_properties: dict[str, float] = field(default_factory=lambda: {"sink_multiplier": 1.0})
+
+    def get_energy_value(self) -> float:
+        """Expose the production food-selection energy contract."""
+        return self.energy
+
+
+class _GymEnvironment:
+    """Minimal production-behavior adapter over the episode's active food."""
+
+    def __init__(self, rng: random.Random) -> None:
+        self.rng = rng
+        self.active_food: list[_GymFood] = []
+
+    def get_detection_modifier(self) -> float:
+        return 1.0
+
+    def nearby_resources(self, _fish: object, _radius: int) -> list[_GymFood]:
+        return self.active_food
+
+    def nearby_agents_by_type(
+        self, _fish: object, _radius: int, agent_type: type[object]
+    ) -> list[_GymFood]:
+        return self.active_food if agent_type is Food else []
+
+
+@dataclass
+class _GymFish:
+    pos: Vector2
+    environment: _GymEnvironment
+    speed: float = MAX_SPEED
+    energy: float = 200.0
+    max_energy: float = 1_000.0
+    genome: _GymGenome = field(default_factory=_GymGenome)
+
+    def get_energy_ratio(self) -> float:
+        return self.energy / self.max_energy
+
+    def is_critical_energy(self) -> bool:
+        return False
+
+    def is_low_energy(self) -> bool:
+        return False
+
+    def can_eat(self) -> bool:
+        return True
+
+
+class _GymPolicy(Protocol):
+    def velocity(self, fish: _GymFish, active_food: tuple[_GymFood, ...]) -> Vector2:
+        """Choose a desired movement vector for one simulation frame."""
+
+
+def build_food_schedule(seed: int) -> tuple[FoodSpawn, ...]:
+    """Build the immutable scripted schedule for ``seed``.
+
+    Food alternates between distant left/right lanes.  The maximum possible
+    lane-to-lane distance is below ``MAX_SPEED * SPAWN_INTERVAL``; an oracle
+    that knows each exact spawn can therefore collect every item before the
+    next one appears.  A fixed integer recurrence, rather than platform RNG,
+    supplies the per-seed lane heights and energy values.
+    """
+    state = seed & 0xFFFFFFFF
+    spawns: list[FoodSpawn] = []
+    for index in range(FOOD_COUNT):
+        state = (1_664_525 * state + 1_013_904_223) & 0xFFFFFFFF
+        y = 140.0 + float(state % 121)
+        state = (1_664_525 * state + 1_013_904_223) & 0xFFFFFFFF
+        energy = 40.0 + float(state % 61)
+        spawns.append(
+            FoodSpawn(
+                frame=(index + 1) * SPAWN_INTERVAL,
+                x=170.0 if index % 2 == 0 else 430.0,
+                y=y,
+                energy=energy,
+            )
+        )
+    return tuple(spawns)
+
+
+def oracle_energy_ceiling(schedule: tuple[FoodSpawn, ...]) -> float:
+    """Return the attainable gross-energy maximum for this episode."""
+    return sum(spawn.energy for spawn in schedule)
+
+
+class _RandomWalkPolicy:
+    """Frozen floor policy: ignores food and changes heading at fixed intervals."""
+
+    def __init__(self, seed: int) -> None:
+        self._rng = random.Random(seed)
+        self._frames_until_turn = 0
+        self._velocity = Vector2(0.0, 0.0)
+
+    def velocity(self, _fish: _GymFish, _active_food: tuple[_GymFood, ...]) -> Vector2:
+        if self._frames_until_turn <= 0:
+            angle = self._rng.random() * math.tau
+            self._velocity = Vector2(math.cos(angle) * MAX_SPEED, math.sin(angle) * MAX_SPEED)
+            self._frames_until_turn = RANDOM_WALK_TURN_INTERVAL
+        self._frames_until_turn -= 1
+        return self._velocity
+
+
+class _OracleGreedyPolicy:
+    """Frozen ceiling policy: direct max-speed pursuit of the best active food."""
+
+    def velocity(self, fish: _GymFish, active_food: tuple[_GymFood, ...]) -> Vector2:
+        if not active_food:
+            return Vector2(0.0, 0.0)
+        target = max(
+            active_food,
+            key=lambda food: (food.energy / max((food.pos - fish.pos).length(), 1.0), food.energy),
+        )
+        return _seek(fish.pos, target.pos, MAX_SPEED)
+
+
+class _ComposablePolicy:
+    """The neutral-default production foraging substrate under test."""
+
+    def __init__(self, seed: int) -> None:
+        self._behavior = ComposableBehavior()
+        self._wander = _RandomWalkPolicy(seed)
+
+    def velocity(self, fish: _GymFish, active_food: tuple[_GymFood, ...]) -> Vector2:
+        if not active_food:
+            return self._wander.velocity(fish, active_food)
+        vx, vy = self._behavior.execute(cast("Fish", fish))
+        return Vector2(vx, vy)
+
+
+def _seek(origin: Vector2, target: Vector2, speed: float) -> Vector2:
+    delta = target - origin
+    distance = delta.length()
+    if distance <= 1e-12:
+        return Vector2(0.0, 0.0)
+    return Vector2(delta.x * speed / distance, delta.y * speed / distance)
+
+
+def _clamp_velocity(velocity: Vector2) -> Vector2:
+    magnitude = velocity.length()
+    if magnitude <= MAX_SPEED:
+        return velocity
+    return Vector2(velocity.x * MAX_SPEED / magnitude, velocity.y * MAX_SPEED / magnitude)
+
+
+def _step_position(position: Vector2, velocity: Vector2) -> Vector2:
+    return Vector2(
+        min(WORLD_WIDTH, max(0.0, position.x + velocity.x)),
+        min(WORLD_HEIGHT, max(0.0, position.y + velocity.y)),
+    )
+
+
+def run_episode(schedule: tuple[FoodSpawn, ...], policy: _GymPolicy, seed: int) -> GymResult:
+    """Run one deterministic policy episode against a fixed spawn schedule."""
+    environment = _GymEnvironment(random.Random(seed))
+    fish = _GymFish(pos=Vector2(WORLD_WIDTH / 2.0, WORLD_HEIGHT / 2.0), environment=environment)
+    active_food: list[_GymFood] = []
+    energy_collected = 0.0
+    energy_spent = 0.0
+    travel_distance = 0.0
+    food_collected = 0
+    spawns_by_frame = {spawn.frame: spawn for spawn in schedule}
+    final_frame = max(spawns_by_frame, default=0) + SETTLE_FRAMES
+
+    for frame in range(final_frame + 1):
+        spawn = spawns_by_frame.get(frame)
+        if spawn is not None:
+            active_food.append(_GymFood(pos=Vector2(spawn.x, spawn.y), energy=spawn.energy))
+
+        environment.active_food = active_food
+        velocity = _clamp_velocity(policy.velocity(fish, tuple(active_food)))
+        next_pos = _step_position(fish.pos, velocity)
+        distance = (next_pos - fish.pos).length()
+        fish.pos = next_pos
+        travel_distance += distance
+        spent = distance * ENERGY_COST_PER_DISTANCE
+        energy_spent += spent
+        apply_energy_delta(
+            fish,
+            -spent,
+            source="foraging_gym_movement",
+            allow_direct_assignment=True,
+        )
+
+        remaining: list[_GymFood] = []
+        for food in active_food:
+            if (food.pos - fish.pos).length() <= CAPTURE_RADIUS:
+                energy_collected += food.energy
+                apply_energy_delta(
+                    fish,
+                    food.energy,
+                    source="foraging_gym_food",
+                    allow_direct_assignment=True,
+                )
+                food_collected += 1
+            else:
+                remaining.append(food)
+        active_food = remaining
+
+    return GymResult(
+        energy_collected=energy_collected,
+        food_collected=food_collected,
+        energy_spent=energy_spent,
+        travel_distance=travel_distance,
+    )
+
+
+def evaluate_foraging_gym(seed: int) -> ForagingGymEvaluation:
+    """Evaluate the frozen floor, production substrate, and ceiling for ``seed``."""
+    schedule = build_food_schedule(seed)
+    ceiling = oracle_energy_ceiling(schedule)
+    oracle = run_episode(schedule, _OracleGreedyPolicy(), seed)
+    if not math.isclose(oracle.energy_collected, ceiling, abs_tol=1e-9):
+        raise AssertionError("Foraging-gym oracle did not attain its scripted energy ceiling")
+
+    random_floor = run_episode(schedule, _RandomWalkPolicy(seed), seed)
+    composable = run_episode(schedule, _ComposablePolicy(seed), seed)
+    return ForagingGymEvaluation(
+        oracle_energy=ceiling,
+        oracle=oracle,
+        random_walk=random_floor,
+        composable=composable,
+    )

--- a/docs/AGENT_FIELD_GUIDE.md
+++ b/docs/AGENT_FIELD_GUIDE.md
@@ -377,6 +377,7 @@ Only these exist today. Use them; do not reference benchmarks that aren't here
 | `benchmarks/tank/survival_5k.py` | ~45s | Ecosystem stability over 5k frames (fish energy × fish population) |
 | `benchmarks/tank/ecosystem_health_10k.py` | ~75s | Longer-horizon ecosystem health over 10k frames |
 | `benchmarks/tank/selection_response_10k.py` | ~90s | Frozen directional-selection response assay |
+| `benchmarks/tank/foraging_gym.py` | ~2s | Isolated foraging skill against random and oracle frozen rulers |
 | `benchmarks/soccer/training_3k.py` | ~5s | Soccer-mode agent training, short |
 | `benchmarks/soccer/training_5k.py` | ~5s | Soccer-mode agent training, longer |
 

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -437,7 +437,7 @@ non-monotonic finding that the default hero wins more from `gto_expert`
 (+589) than from `tight_aggressive` (+385), which the ladder makes visible
 for the first time.
 
-### 11.3 Foraging gym with an oracle ceiling — `M` · ★★★
+### 11.3 Foraging gym with an oracle ceiling — `M` · ★★★ — SHIPPED
 An isolated foraging benchmark: one fish (later a small cohort variant), no
 reproduction/poker/ball, a fixed scripted food-spawn schedule per seed.
 Compute the **oracle ceiling** on the same spawn script (full-knowledge
@@ -625,6 +625,14 @@ shared module on multiple ladders (foraging gym / soccer / poker) to produce a
 
 ## Shipped
 
+- **11.3 Foraging gym with an oracle ceiling.** Added
+  [`benchmarks/tank/foraging_gym.py`](../benchmarks/tank/foraging_gym.py), a
+  deterministic single-fish ruler that runs the production neutral
+  `ComposableBehavior` food path against a fixed seeded food schedule. It
+  reports gross energy collected / attainable oracle energy, plus the frozen
+  `random_walk_v1` floor and `full_information_greedy_v1` ceiling in standard
+  skill-ladder metadata. The oracle collects every scripted food item under the
+  same speed, bounds, and capture rules, so the score's 1.0 ceiling is real.
 - **6.2 Retired `Any` in composable food selection.** Replaced the broad food
   target and selection annotations in
   `core/algorithms/composable/food_selection.py` with the concrete `Food`

--- a/frontend/src/components/ForagingGymPanel.test.tsx
+++ b/frontend/src/components/ForagingGymPanel.test.tsx
@@ -1,0 +1,42 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ForagingGymResultCard } from './ForagingGymPanel';
+import { TankSkillsTab } from './tank_tabs/TankSkillsTab';
+import type { ForagingGymResult } from '../types/skill';
+
+const result: ForagingGymResult = {
+    benchmark_id: 'tank/foraging_gym',
+    seed: 42,
+    score: 0.75,
+    score_breakdown: {
+        composable_energy_ratio: 0.75,
+        random_walk_energy_ratio: 0.25,
+        oracle_energy_ratio: 1,
+    },
+    metadata: {
+        oracle_energy: 800,
+        composable: { energy_collected: 600, food_collected: 8, energy_spent: 20, travel_distance: 2000 },
+        random_walk: { energy_collected: 200, food_collected: 3, energy_spent: 30, travel_distance: 3000 },
+        oracle: { energy_collected: 800, food_collected: 12, energy_spent: 15, travel_distance: 1800 },
+        skill: { domain: 'foraging', benchmark_id: 'tank/foraging_gym', metric_name: 'energy_collected_over_oracle', skill_index: 67, rungs_beaten: 1, total_rungs: 2, rungs: [] },
+    },
+};
+
+describe('ForagingGymResultCard', () => {
+    it('shows the oracle-normalized result and both references', () => {
+        const html = renderToString(<ForagingGymResultCard result={result} />);
+
+        expect(html).toContain('75.0%');
+        expect(html).toContain('ABOVE RANDOM FLOOR');
+        expect(html).toContain('Oracle ceiling');
+        expect(html).toContain('600');
+        expect(html).toContain('12');
+    });
+
+    it('is mounted in the domain-neutral Skills tab', () => {
+        const html = renderToString(<TankSkillsTab />);
+
+        expect(html).toContain('Skills &amp; Benchmarks');
+        expect(html).toContain('Foraging Gym');
+    });
+});

--- a/frontend/src/components/ForagingGymPanel.tsx
+++ b/frontend/src/components/ForagingGymPanel.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useState } from 'react';
+import { colors } from '../styles/theme';
+import type { ForagingGymResult } from '../types/skill';
+
+const SEEDS = [42, 7, 123] as const;
+
+function percent(value: number): string {
+    return `${(value * 100).toFixed(1)}%`;
+}
+
+function energy(value: number): string {
+    return Math.round(value).toLocaleString();
+}
+
+export function ForagingGymResultCard({ result }: { result: ForagingGymResult }) {
+    const { composable_energy_ratio, random_walk_energy_ratio } = result.score_breakdown;
+    const { composable, random_walk, oracle, oracle_energy } = result.metadata;
+    const beatFloor = composable_energy_ratio > random_walk_energy_ratio;
+
+    return (
+        <div style={styles.result}>
+            <div style={styles.scoreRow}>
+                <div>
+                    <div style={styles.label}>COMPOSABLE FORAGING</div>
+                    <div style={styles.score}>{percent(composable_energy_ratio)}</div>
+                    <div style={styles.caption}>
+                        {energy(composable.energy_collected)} / {energy(oracle_energy)} energy · {composable.food_collected}/
+                        {oracle.food_collected} food
+                    </div>
+                </div>
+                <div style={{ ...styles.floorBadge, color: beatFloor ? colors.success : colors.danger }}>
+                    {beatFloor ? 'ABOVE RANDOM FLOOR' : 'BELOW RANDOM FLOOR'}
+                </div>
+            </div>
+
+            <div style={styles.track} aria-label="Composable energy captured relative to oracle ceiling">
+                <div
+                    style={{
+                        ...styles.fill,
+                        width: `${Math.max(0, Math.min(100, composable_energy_ratio * 100))}%`,
+                    }}
+                />
+            </div>
+
+            <div style={styles.referenceGrid}>
+                <div style={styles.reference}>
+                    <span style={styles.referenceName}>Random walk</span>
+                    <strong>{percent(random_walk_energy_ratio)}</strong>
+                    <span style={styles.referenceDetail}>{random_walk.food_collected} food</span>
+                </div>
+                <div style={styles.reference}>
+                    <span style={styles.referenceName}>Oracle ceiling</span>
+                    <strong>{percent(result.score_breakdown.oracle_energy_ratio)}</strong>
+                    <span style={styles.referenceDetail}>{oracle.food_collected} food</span>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export function ForagingGymPanel() {
+    const [seed, setSeed] = useState<number>(42);
+    const [result, setResult] = useState<ForagingGymResult | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const evaluate = useCallback(async (selectedSeed: number) => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`/api/skill/foraging-gym?seed=${selectedSeed}`);
+            if (!response.ok) throw new Error(`Evaluation failed (${response.status})`);
+            const data: ForagingGymResult = await response.json();
+            setResult(data);
+        } catch (cause) {
+            setError(cause instanceof Error ? cause.message : 'Evaluation unavailable');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        evaluate(seed);
+    }, [evaluate, seed]);
+
+    return (
+        <section style={styles.panel} aria-label="Foraging gym evaluator">
+            <div style={styles.header}>
+                <div>
+                    <div style={styles.title}>Foraging Gym</div>
+                    <div style={styles.description}>
+                        One fish, scripted food, no ecosystem confounders. 100% means every available calorie.
+                    </div>
+                </div>
+                <div style={styles.controls}>
+                    <label style={styles.seedLabel}>
+                        Seed
+                        <select value={seed} onChange={event => setSeed(Number(event.target.value))} style={styles.select}>
+                            {SEEDS.map(option => <option key={option} value={option}>{option}</option>)}
+                        </select>
+                    </label>
+                    <button type="button" onClick={() => evaluate(seed)} disabled={loading} style={styles.button}>
+                        {loading ? 'Evaluating…' : 'Run gym'}
+                    </button>
+                </div>
+            </div>
+
+            {error ? <div style={styles.error}>{error}</div> : result ? <ForagingGymResultCard result={result} /> : <div style={styles.loading}>Evaluating current behavior…</div>}
+        </section>
+    );
+}
+
+const styles = {
+    panel: {
+        backgroundColor: 'rgba(15, 23, 42, 0.52)',
+        border: `1px solid ${colors.border}`,
+        borderRadius: '10px',
+        padding: '14px',
+        display: 'flex',
+        flexDirection: 'column' as const,
+        gap: '12px',
+    },
+    header: { display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap' as const },
+    title: { color: colors.primary, fontWeight: 700, fontSize: '15px' },
+    description: { color: colors.textSecondary, fontSize: '11px', marginTop: '3px', maxWidth: '460px' },
+    controls: { display: 'flex', alignItems: 'end', gap: '8px' },
+    seedLabel: { color: colors.textSecondary, display: 'flex', flexDirection: 'column' as const, fontSize: '10px', gap: '3px' },
+    select: { backgroundColor: colors.bgLight, border: `1px solid ${colors.border}`, borderRadius: '5px', color: colors.text, padding: '4px 6px' },
+    button: { backgroundColor: colors.primary, border: 'none', borderRadius: '5px', color: '#fff', cursor: 'pointer', fontSize: '12px', fontWeight: 700, padding: '6px 10px' },
+    result: { display: 'flex', flexDirection: 'column' as const, gap: '10px' },
+    scoreRow: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '12px' },
+    label: { color: colors.textSecondary, fontSize: '10px', fontWeight: 700, letterSpacing: '0.05em' },
+    score: { color: colors.success, fontFamily: 'var(--font-mono)', fontSize: '28px', fontWeight: 800, lineHeight: 1.1 },
+    caption: { color: colors.textSecondary, fontSize: '11px', marginTop: '2px' },
+    floorBadge: { fontSize: '10px', fontWeight: 800, letterSpacing: '0.04em', textAlign: 'right' as const },
+    track: { backgroundColor: 'rgba(2, 6, 23, 0.7)', borderRadius: '999px', height: '12px', overflow: 'hidden' },
+    fill: { background: 'linear-gradient(90deg, #22c55e, #84cc16)', borderRadius: '999px', height: '100%', transition: 'width 180ms ease-out' },
+    referenceGrid: { display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '8px' },
+    reference: { backgroundColor: colors.bgLight, borderRadius: '6px', color: colors.text, display: 'flex', flexDirection: 'column' as const, gap: '2px', padding: '8px' },
+    referenceName: { color: colors.textSecondary, fontSize: '10px' },
+    referenceDetail: { color: colors.textSecondary, fontSize: '10px' },
+    loading: { color: colors.textSecondary, fontSize: '12px', padding: '8px 0' },
+    error: { color: colors.danger, fontSize: '12px', padding: '8px 0' },
+} as const;

--- a/frontend/src/components/PanelToggleBar.tsx
+++ b/frontend/src/components/PanelToggleBar.tsx
@@ -1,0 +1,39 @@
+import type { PanelId } from '../hooks/useVisiblePanels';
+import styles from './TankView.module.css';
+
+const PANEL_CONFIG: { id: PanelId; label: string; icon: string }[] = [
+    { id: 'insights', label: 'Insights', icon: '💬' },
+    { id: 'skills', label: 'Skills', icon: '🎯' },
+    { id: 'trends', label: 'Trends', icon: '📈' },
+    { id: 'ecosystem', label: 'Ecosystem', icon: '🌿' },
+    { id: 'genetics', label: 'Genetics', icon: '🧬' },
+    { id: 'soccer', label: 'Soccer', icon: '⚽' },
+    { id: 'poker', label: 'Poker', icon: '♠' },
+];
+
+interface PanelToggleBarProps {
+    visible: PanelId[];
+    onToggle: (id: PanelId) => void;
+}
+
+export function PanelToggleBar({ visible, onToggle }: PanelToggleBarProps) {
+    return (
+        <div className={styles.panelToggleBar}>
+            <span className={styles.panelToggleLabel}>Show panels:</span>
+            {PANEL_CONFIG.map(({ id, label, icon }) => {
+                const isVisible = visible.includes(id);
+                return (
+                    <button
+                        key={id}
+                        className={`${styles.panelToggle} ${isVisible ? styles.active : ''}`}
+                        onClick={() => onToggle(id)}
+                        aria-pressed={isVisible}
+                    >
+                        <span className={styles.panelToggleIcon}>{icon}</span>
+                        <span>{label}</span>
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -9,10 +9,11 @@ import {
     type ReactNode,
 } from 'react';
 import { useWebSocket, type ConnectionStatus } from '../hooks/useWebSocket';
-import { useVisiblePanels, type PanelId } from '../hooks/useVisiblePanels';
+import { useVisiblePanels } from '../hooks/useVisiblePanels';
 import { Canvas } from './Canvas';
 import { CommentaryFeed } from './CommentaryFeed';
 import { ControlPanel } from './ControlPanel';
+import { PanelToggleBar } from './PanelToggleBar';
 import { PokerScoreDisplay } from './PokerScoreDisplay';
 import { WorldModeSelector } from './WorldModeSelector';
 import { useViewMode } from '../hooks/useViewMode';
@@ -32,6 +33,9 @@ const TankSoccerTab = lazy(() =>
 const TankPokerTab = lazy(() =>
     import('./tank_tabs/TankPokerTab').then((module) => ({ default: module.TankPokerTab }))
 );
+const TankSkillsTab = lazy(() =>
+    import('./tank_tabs/TankSkillsTab').then((module) => ({ default: module.TankSkillsTab }))
+);
 const TankEcosystemTab = lazy(() =>
     import('./tank_tabs/TankEcosystemTab').then((module) => ({ default: module.TankEcosystemTab }))
 );
@@ -41,15 +45,6 @@ const TankGeneticsTab = lazy(() =>
 const TankTrendsTab = lazy(() =>
     import('./tank_tabs/TankTrendsTab').then((module) => ({ default: module.TankTrendsTab }))
 );
-
-const PANEL_CONFIG: { id: PanelId; label: string; icon: string }[] = [
-    { id: 'insights', label: 'Insights', icon: '💬' },
-    { id: 'soccer', label: 'Soccer', icon: '⚽' },
-    { id: 'poker', label: 'Poker', icon: '♠' },
-    { id: 'trends', label: 'Trends', icon: '📈' },
-    { id: 'ecosystem', label: 'Ecosystem', icon: '🌿' },
-    { id: 'genetics', label: 'Genetics', icon: '🧬' },
-];
 
 const CONNECTION_STATUS_DISPLAY: Record<ConnectionStatus, { label: string; color: string }> = {
     live: { label: 'LIVE', color: 'var(--color-success)' },
@@ -64,7 +59,7 @@ export function TankView({ worldId }: TankViewProps) {
     const [showEffects, setShowEffects] = useState(true);
     const [showSoccer, setShowSoccer] = useState<boolean | null>(null);  // null = not yet synced from server
     const userToggledSoccer = useRef(false);  // Track if user manually toggled
-    const { visible, toggle, isVisible } = useVisiblePanels(['soccer', 'ecosystem', 'insights']);
+    const { visible, toggle, isVisible } = useVisiblePanels(['skills', 'soccer', 'ecosystem', 'insights']);
 
     // Sync showSoccer state from server on initial load and ongoing updates
     useEffect(() => {
@@ -409,20 +404,7 @@ export function TankView({ worldId }: TankViewProps) {
             </div>
 
             {/* Panel Toggle Bar */}
-            <div className={styles.panelToggleBar}>
-                <span className={styles.panelToggleLabel}>Show panels:</span>
-                {PANEL_CONFIG.map(({ id, label, icon }) => (
-                    <button
-                        key={id}
-                        className={`${styles.panelToggle} ${isVisible(id) ? styles.active : ''}`}
-                        onClick={() => toggle(id)}
-                        aria-pressed={isVisible(id)}
-                    >
-                        <span className={styles.panelToggleIcon}>{icon}</span>
-                        <span>{label}</span>
-                    </button>
-                ))}
-            </div>
+            <PanelToggleBar visible={visible} onToggle={toggle} />
 
             {/* Panel Grid */}
             {visible.length > 0 && (
@@ -430,6 +412,14 @@ export function TankView({ worldId }: TankViewProps) {
                     {isVisible('insights') && (
                         <CollapsiblePanel title="Insights" icon="💬">
                             <CommentaryFeed worldId={effectiveWorldId} />
+                        </CollapsiblePanel>
+                    )}
+
+                    {isVisible('skills') && (
+                        <CollapsiblePanel title="Skills & Benchmarks" icon="🎯">
+                            <Suspense fallback={<PanelLoading />}>
+                                <TankSkillsTab />
+                            </Suspense>
                         </CollapsiblePanel>
                     )}
 

--- a/frontend/src/components/tank_tabs/TankSkillsTab.tsx
+++ b/frontend/src/components/tank_tabs/TankSkillsTab.tsx
@@ -1,0 +1,43 @@
+import { ForagingGymPanel } from '../ForagingGymPanel';
+import { SkillLadderPanel } from '../SkillLadderPanel';
+
+/** Research-facing, domain-neutral skill measurements and evaluators. */
+export function TankSkillsTab() {
+    return (
+        <div style={styles.layout}>
+            <div style={styles.intro}>
+                <div style={styles.title}>Skills &amp; Benchmarks</div>
+                <p style={styles.description}>
+                    Measure what agents can do outside the ecosystem composite. These frozen-ruler
+                    tests make scores comparable across simulation changes and champion re-baselines.
+                </p>
+            </div>
+
+            <ForagingGymPanel />
+            <SkillLadderPanel />
+        </div>
+    );
+}
+
+const styles = {
+    layout: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        gap: '16px',
+    },
+    intro: {
+        padding: '2px 4px 0',
+    },
+    title: {
+        color: '#f8fafc',
+        fontSize: '18px',
+        fontWeight: 700,
+    },
+    description: {
+        color: '#94a3b8',
+        fontSize: '13px',
+        lineHeight: 1.5,
+        margin: '4px 0 0',
+        maxWidth: '760px',
+    },
+} as const;

--- a/frontend/src/hooks/useVisiblePanels.ts
+++ b/frontend/src/hooks/useVisiblePanels.ts
@@ -1,9 +1,10 @@
 import { useCallback, useMemo, useState } from 'react';
 
-export type PanelId = 'soccer' | 'poker' | 'ecosystem' | 'genetics' | 'trends' | 'insights';
+export type PanelId = 'skills' | 'soccer' | 'poker' | 'ecosystem' | 'genetics' | 'trends' | 'insights';
 
-const STORAGE_KEY = 'tankview.visiblePanels.v1';
-const ALL_PANELS: PanelId[] = ['soccer', 'poker', 'ecosystem', 'genetics', 'trends', 'insights'];
+const STORAGE_KEY = 'tankview.visiblePanels.v2';
+const LEGACY_STORAGE_KEY = 'tankview.visiblePanels.v1';
+const ALL_PANELS: PanelId[] = ['skills', 'soccer', 'poker', 'ecosystem', 'genetics', 'trends', 'insights'];
 
 function sanitizePanels(value: unknown, fallback: PanelId[]): PanelId[] {
     if (!Array.isArray(value)) return fallback;
@@ -23,8 +24,14 @@ export function useVisiblePanels(defaultPanels: PanelId[] = ['soccer', 'poker'])
     const [visible, setVisibleState] = useState<PanelId[]>(() => {
         try {
             const raw = localStorage.getItem(STORAGE_KEY);
-            if (!raw) return defaultPanels;
-            return sanitizePanels(JSON.parse(raw), defaultPanels);
+            if (raw) return sanitizePanels(JSON.parse(raw), defaultPanels);
+
+            // Preserve existing panel choices while surfacing the new Skills
+            // panel once after the navigation migration.
+            const legacyRaw = localStorage.getItem(LEGACY_STORAGE_KEY);
+            if (!legacyRaw) return defaultPanels;
+            const legacyPanels = sanitizePanels(JSON.parse(legacyRaw), defaultPanels);
+            return legacyPanels.includes('skills') ? legacyPanels : [...legacyPanels, 'skills'];
         } catch {
             return defaultPanels;
         }

--- a/frontend/src/types/skill.ts
+++ b/frontend/src/types/skill.ts
@@ -25,3 +25,28 @@ export interface SkillLaddersResponse {
     schema_version: number;
     ladders: SkillLadder[];
 }
+
+export interface ForagingGymEpisode {
+    energy_collected: number;
+    food_collected: number;
+    energy_spent: number;
+    travel_distance: number;
+}
+
+export interface ForagingGymResult {
+    benchmark_id: 'tank/foraging_gym';
+    seed: number;
+    score: number;
+    score_breakdown: {
+        composable_energy_ratio: number;
+        random_walk_energy_ratio: number;
+        oracle_energy_ratio: number;
+    };
+    metadata: {
+        oracle_energy: number;
+        composable: ForagingGymEpisode;
+        random_walk: ForagingGymEpisode;
+        oracle: ForagingGymEpisode;
+        skill: SkillLadder;
+    };
+}

--- a/tests/core/test_foraging_gym.py
+++ b/tests/core/test_foraging_gym.py
@@ -1,0 +1,40 @@
+"""Regression tests for the frozen, isolated foraging skill ruler."""
+
+import math
+
+from benchmarks.tank import foraging_gym
+from core.foraging.gym import FOOD_COUNT, build_food_schedule, evaluate_foraging_gym
+
+
+def test_schedule_is_seeded_and_lane_transitions_are_oracle_feasible():
+    """A seed maps to one immutable schedule whose ceiling policy can traverse it."""
+    first = build_food_schedule(42)
+    assert first == build_food_schedule(42)
+    assert first != build_food_schedule(7)
+    assert len(first) == FOOD_COUNT
+
+
+def test_oracle_attains_the_full_scripted_energy_ceiling():
+    """The claimed ceiling is a reachable bound, never a fitted reference score."""
+    for seed in (42, 7, 123):
+        evaluation = evaluate_foraging_gym(seed)
+        assert evaluation.oracle.food_collected == FOOD_COUNT
+        assert math.isclose(evaluation.oracle.energy_collected, evaluation.oracle_energy)
+        assert 0.0 <= evaluation.composable_ratio <= 1.0
+        assert 0.0 <= evaluation.random_walk_ratio <= 1.0
+
+
+def test_benchmark_is_deterministic_and_emits_frozen_ruler_metadata():
+    first = foraging_gym.run(42)
+    second = foraging_gym.run(42)
+
+    assert first["score"] == second["score"]
+    assert 0.0 <= first["score"] <= 1.0
+    assert first["score_breakdown"]["oracle_energy_ratio"] == 1.0
+
+    skill = first["metadata"]["skill"]
+    assert skill["domain"] == "foraging"
+    assert [rung["rung_id"] for rung in skill["rungs"]] == [
+        "random_walk_v1",
+        "full_information_greedy_v1",
+    ]

--- a/tests/test_skill_api.py
+++ b/tests/test_skill_api.py
@@ -58,3 +58,14 @@ def test_ladders_endpoint_handles_empty_dir(tmp_path):
     resp = _client_for(tmp_path).get("/api/skill/ladders")
     assert resp.status_code == 200
     assert resp.json()["ladders"] == []
+
+
+def test_foraging_gym_endpoint_evaluates_current_substrate(tmp_path):
+    response = _client_for(tmp_path).get("/api/skill/foraging-gym?seed=42")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["benchmark_id"] == "tank/foraging_gym"
+    assert 0.0 <= body["score"] <= 1.0
+    assert body["score_breakdown"]["oracle_energy_ratio"] == 1.0
+    assert body["metadata"]["skill"]["domain"] == "foraging"


### PR DESCRIPTION
## What changed

- Adds a deterministic, isolated foraging evaluator with an attainable oracle ceiling and random-walk floor.
- Exposes the evaluator at `GET /api/skill/foraging-gym?seed=` for inspection of current source, without promoting a champion.
- Adds a first-class Skills panel in Tank View, with a persisted-panel migration so existing users see the evaluator once.
- Extracts panel-toggle UI from `TankView` to keep the component within the architecture size guardrail.

## Why

Foraging quality previously lacked a quick, behavior-focused ruler. This makes collection efficiency testable independently of long-running ecosystem noise and visible in the live UI.

## Validation

- `py tools/run_bench.py benchmarks/tank/foraging_gym.py --seed 42 --verify-determinism`
  - composable: `0.7667`; random walk: `0.4893`; oracle: `1.0000`
- `py tools/agent_gate.py`
- `py tools/pre_pr_gate.py`
- `cd frontend && npm run test -- --run && npm run lint && npm run build`

No champion baselines were changed; this PR adds the evaluator and UI surface only.