### PR TITLE
UI: unify panel show/hide into a single toggle state, mobile-friendly panels

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15,6 +15,7 @@
     width: 100%;
     max-width: 1400px;
     margin: 0 auto;
+    box-sizing: border-box;
 }
 
 /* Glass Panel Utility */
@@ -34,6 +35,7 @@
     width: 100%;
     max-width: 1200px;
     padding: 4px;
+    box-sizing: border-box;
     /* Slim border for the "tank glass" effect */
     border-radius: 20px;
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0.01) 100%);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -260,6 +260,8 @@ function NavBar() {
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: '8px 16px',
         }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
                 <Link
@@ -301,7 +303,6 @@ function NavBar() {
                 display: 'flex',
                 alignItems: 'center',
                 gap: '12px',
-                minWidth: '150px',
                 justifyContent: 'flex-end',
             }}>
                 {isNetwork ? (

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -56,7 +56,8 @@ export function ControlPanel({ onCommand, isConnected, fastForwardEnabled, showE
             justifyContent: 'space-between',
             padding: '12px 24px',
             flex: 1,
-            gap: '24px',
+            gap: '12px 24px',
+            flexWrap: 'wrap',
         }}>
             {/* Primary Actions */}
             <div style={{ display: 'flex', gap: '12px' }}>

--- a/frontend/src/components/PanelToggleBar.tsx
+++ b/frontend/src/components/PanelToggleBar.tsx
@@ -19,7 +19,7 @@ interface PanelToggleBarProps {
 export function PanelToggleBar({ visible, onToggle }: PanelToggleBarProps) {
     return (
         <div className={styles.panelToggleBar}>
-            <span className={styles.panelToggleLabel}>Show panels:</span>
+            <span className={styles.panelToggleLabel}>Panels</span>
             {PANEL_CONFIG.map(({ id, label, icon }) => {
                 const isVisible = visible.includes(id);
                 return (

--- a/frontend/src/components/TankView.module.css
+++ b/frontend/src/components/TankView.module.css
@@ -297,6 +297,7 @@
     padding: 8px 12px;
     max-width: 1140px;
     width: 100%;
+    box-sizing: border-box;
     background: rgba(15, 23, 42, 0.6);
     border-radius: 12px;
     border: 1px solid rgba(51, 65, 85, 0.4);
@@ -348,7 +349,7 @@
     line-height: 1;
 }
 
-/* Panel Grid */
+/* Panel Grid (single column by design) */
 .panelGrid {
     display: grid;
     grid-template-columns: 1fr;
@@ -362,13 +363,61 @@
     min-width: 0; /* Prevent overflow */
 }
 
-/* Responsive adjustments */
-@media (max-width: 1100px) {
-    .panelGrid {
-        grid-template-columns: 1fr;
-    }
+.panelGrid > * {
+    min-width: 0; /* Let panel content (charts, tables) shrink with the column */
 }
 
+/* Panel header: title + hide button (visibility is owned by the toggle bar) */
+.panelHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 8px 6px 16px;
+    background: rgba(255, 255, 255, 0.03);
+    border-bottom: 1px solid var(--card-border);
+}
+
+.panelHeaderTitle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    color: var(--color-text-main);
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.panelClose {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: #94a3b8;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.panelClose:hover {
+    background: rgba(51, 65, 85, 0.6);
+    color: #e2e8f0;
+}
+
+.panelBody {
+    padding: 16px;
+    min-width: 0;
+    /* Intrinsically wide content (poker table, event logs) scrolls inside
+       the panel instead of widening the page on small screens */
+    overflow-x: auto;
+}
+
+/* Responsive adjustments */
 @media (max-width: 600px) {
     .panelToggleBar {
         justify-content: center;
@@ -378,6 +427,26 @@
         width: 100%;
         text-align: center;
         margin-bottom: 4px;
+    }
+
+    /* Comfortable touch targets on small screens */
+    .panelToggle {
+        padding: 10px 14px;
+        min-height: 40px;
+    }
+
+    .panelClose {
+        width: 40px;
+        height: 40px;
+    }
+
+    .panelGrid {
+        gap: 12px;
+        margin-bottom: 24px;
+    }
+
+    .panelBody {
+        padding: 12px;
     }
 }
 

--- a/frontend/src/components/TankView.tsx
+++ b/frontend/src/components/TankView.tsx
@@ -187,7 +187,7 @@ export function TankView({ worldId }: TankViewProps) {
             >
                 <div
                     className="glass-panel"
-                    style={{ padding: '12px 20px', display: 'flex', alignItems: 'center', gap: '32px' }}
+                    style={{ padding: '12px 20px', display: 'flex', alignItems: 'center', gap: '12px 32px', flexWrap: 'wrap' }}
                 >
                     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                         <span
@@ -402,21 +402,21 @@ export function TankView({ worldId }: TankViewProps) {
             {visible.length > 0 && (
                 <div className={styles.panelGrid}>
                     {isVisible('insights') && (
-                        <CollapsiblePanel title="Insights" icon="💬">
+                        <Panel title="Insights" icon="💬" onClose={() => toggle('insights')}>
                             <CommentaryFeed worldId={effectiveWorldId} />
-                        </CollapsiblePanel>
+                        </Panel>
                     )}
 
                     {isVisible('skills') && (
-                        <CollapsiblePanel title="Skills & Benchmarks" icon="🎯">
+                        <Panel title="Skills & Benchmarks" icon="🎯" onClose={() => toggle('skills')}>
                             <Suspense fallback={<PanelLoading />}>
                                 <TankSkillsTab />
                             </Suspense>
-                        </CollapsiblePanel>
+                        </Panel>
                     )}
 
                     {isVisible('soccer') && (
-                        <CollapsiblePanel title="Soccer League" icon="⚽">
+                        <Panel title="Soccer League" icon="⚽" onClose={() => toggle('soccer')}>
                             <Suspense fallback={<PanelLoading />}>
                                 <TankSoccerTab
                                     liveState={state?.soccer_league_live ?? null}
@@ -424,11 +424,11 @@ export function TankView({ worldId }: TankViewProps) {
                                     currentFrame={state?.snapshot?.frame ?? state?.frame ?? 0}
                                 />
                             </Suspense>
-                        </CollapsiblePanel>
+                        </Panel>
                     )}
 
                     {isVisible('poker') && (
-                        <CollapsiblePanel title="Poker" icon="♠">
+                        <Panel title="Poker" icon="♠" onClose={() => toggle('poker')}>
                             <Suspense fallback={<PanelLoading />}>
                                 <TankPokerTab
                                     worldId={effectiveWorldId}
@@ -441,34 +441,34 @@ export function TankView({ worldId }: TankViewProps) {
                                     worldType={effectiveWorldType}
                                 />
                             </Suspense>
-                        </CollapsiblePanel>
+                        </Panel>
                     )}
 
                     {isVisible('trends') && (
-                        <CollapsiblePanel title="Trends" icon="📈">
+                        <Panel title="Trends" icon="📈" onClose={() => toggle('trends')}>
                             <Suspense fallback={<PanelLoading />}>
                                 <TankTrendsTab history={state?.metrics_history ?? null} />
                             </Suspense>
-                        </CollapsiblePanel>
+                        </Panel>
                     )}
 
                     {isVisible('ecosystem') && (
-                        <CollapsiblePanel title="Ecosystem" icon="🌿">
+                        <Panel title="Ecosystem" icon="🌿" onClose={() => toggle('ecosystem')}>
                             <Suspense fallback={<PanelLoading />}>
                                 <TankEcosystemTab
                                     stats={state?.stats ?? null}
                                     autoEvaluation={state?.auto_evaluation}
                                 />
                             </Suspense>
-                        </CollapsiblePanel>
+                        </Panel>
                     )}
 
                     {isVisible('genetics') && (
-                        <CollapsiblePanel title="Genetics" icon="🧬">
+                        <Panel title="Genetics" icon="🧬" onClose={() => toggle('genetics')}>
                             <Suspense fallback={<PanelLoading />}>
                                 <TankGeneticsTab worldId={effectiveWorldId} />
                             </Suspense>
-                        </CollapsiblePanel>
+                        </Panel>
                     )}
                 </div>
             )}
@@ -534,48 +534,34 @@ function PanelLoading() {
     );
 }
 
-function CollapsiblePanel({ title, icon, children }: { title: string; icon: string; children: ReactNode }) {
-    const [isOpen, setIsOpen] = useState(true);
-
+function Panel({
+    title,
+    icon,
+    onClose,
+    children,
+}: {
+    title: string;
+    icon: string;
+    onClose: () => void;
+    children: ReactNode;
+}) {
     return (
         <div className={styles.dashboardPanel} style={{ padding: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-            <button
-                onClick={() => setIsOpen(!isOpen)}
-                style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    width: '100%',
-                    padding: '12px 16px',
-                    background: 'rgba(255, 255, 255, 0.03)',
-                    border: 'none',
-                    borderBottom: isOpen ? '1px solid var(--card-border)' : 'none',
-                    color: 'var(--color-text-main)',
-                    cursor: 'pointer',
-                    fontSize: '14px',
-                    fontWeight: 600,
-                    transition: 'background 0.2s',
-                }}
-                onMouseEnter={(e) => e.currentTarget.style.background = 'rgba(255, 255, 255, 0.06)'}
-                onMouseLeave={(e) => e.currentTarget.style.background = 'rgba(255, 255, 255, 0.03)'}
-            >
-                <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <div className={styles.panelHeader}>
+                <div className={styles.panelHeaderTitle}>
                     <span style={{ fontSize: '16px' }}>{icon}</span>
                     <span>{title}</span>
                 </div>
-                <div style={{
-                    transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
-                    transition: 'transform 0.2s',
-                    opacity: 0.5
-                }}>
-                    ▼
-                </div>
-            </button>
-            {isOpen && (
-                <div style={{ padding: '16px' }}>
-                    {children}
-                </div>
-            )}
+                <button
+                    className={styles.panelClose}
+                    onClick={onClose}
+                    aria-label={`Hide ${title} panel`}
+                    title={`Hide ${title} panel`}
+                >
+                    ×
+                </button>
+            </div>
+            <div className={styles.panelBody}>{children}</div>
         </div>
     );
 }

--- a/frontend/src/components/tank_tabs/TankTrendsTab.tsx
+++ b/frontend/src/components/tank_tabs/TankTrendsTab.tsx
@@ -852,7 +852,7 @@ function TankTrendsTabComponent({ history }: TankTrendsTabProps) {
             {/* Charts Grid */}
             <div style={{
                 display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fit, minmax(450px, 1fr))',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(min(450px, 100%), 1fr))',
                 gap: '16px'
             }}>
                 {/* Population */}

--- a/frontend/src/hooks/useVisiblePanels.ts
+++ b/frontend/src/hooks/useVisiblePanels.ts
@@ -48,12 +48,17 @@ export function useVisiblePanels(defaultPanels: PanelId[] = ['soccer', 'poker'])
 
     const isVisible = useCallback((id: PanelId) => visible.includes(id), [visible]);
 
-    const toggle = useCallback(
-        (id: PanelId) => {
-            persist(visible.includes(id) ? visible.filter((p) => p !== id) : [...visible, id]);
-        },
-        [persist, visible]
-    );
+    const toggle = useCallback((id: PanelId) => {
+        setVisibleState((prev) => {
+            const next = prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id];
+            try {
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+            } catch {
+                // ignore storage failures (private mode, quota, etc.)
+            }
+            return next;
+        });
+    }, []);
 
     const setVisible = useCallback(
         (ids: PanelId[]) => {


### PR DESCRIPTION
## Summary

The dashboard had two overlapping controls for the same intent: the "Show panels:" pill bar (mount/unmount, persisted) and a per-panel collapse chevron (hides the body but leaves a stub header, not persisted). This PR unifies them into **one visibility state with two entry points**:

- The pill bar stays the single source of truth (persisted to `localStorage`).
- Each panel header now has a **close (×) button** that calls the same `toggle()` — hiding a panel removes it from the grid *and* deselects its pill. The chevron/stub-header behavior is gone.
- Label shortened from "Show panels:" to "Panels" since the pills now simply reflect what's on screen.

The panel grid remains **single column** by design.

## Mobile

Verified at 375×812 with **all seven panels enabled** — no horizontal page overflow (was 841px scroll width on a 375px viewport before):

- ≤600px: 40px tap targets for pills and panel close buttons, tighter panel padding.
- `box-sizing: border-box` on `.main`, `.canvas-wrapper`, and `.panelToggleBar` (the app has no global border-box reset, so `width: 100%` + padding overflowed).
- NavBar, stats HUD, and control bar now wrap instead of forcing the page wide.
- Trends chart grid: `minmax(450px, 1fr)` → `minmax(min(450px, 100%), 1fr)` (identical on desktop, shrinks on narrow screens).
- Intrinsically wide panel content (poker table ~1100px, soccer event log lines) scrolls horizontally *inside* the panel body instead of widening the page.

## Robustness fix

`useVisiblePanels.toggle` closed over a stale `visible` array, so multiple toggles in the same tick clobbered each other (observed while driving the UI programmatically). Now a functional `setState` update.

## Verification

Driven in-browser against the live backend (Vite dev server, seed-42 world at frame ~86k):

- × on Insights → panel unmounts, pill deselects, `tankview.visiblePanels.v2` updates.
- Pill click → panel remounts; state survives page reload.
- Hiding all panels → grid unmounts entirely, pill bar remains for recovery.
- 4 same-tick toggles all apply (previously only the last one won).
- Desktop (1280px) and mobile (375px): no horizontal overflow, correct layouts.

Gates: `agent_gate.py` (595 passed), `npm run lint`, `tsc -b && vite build`, `vitest run` (59 passed), pre-commit hooks.

Layer 2 (UI/meta) change only — no algorithm or benchmark code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
