### PR TITLE
Extract shared steering primitives

### DIFF
--- a/core/algorithms/base.py
+++ b/core/algorithms/base.py
@@ -29,6 +29,7 @@ from core.config.fish import (
 )
 from core.config.food import BASE_FOOD_DETECTION_RANGE, PREDATOR_DEFAULT_FAR_DISTANCE
 from core.entities import Crab, Food
+from core.behavior.primitives.steering import safe_normalize
 from core.math_utils import Vector2
 from core.util.rng import require_rng_param
 
@@ -270,10 +271,7 @@ class BehaviorHelpersMixin:
         Returns:
             Normalized vector or Vector2(0, 0) if vector length is zero or near-zero
         """
-        length = vector.length()
-        if length < 1e-6:  # Use small epsilon to handle floating point errors
-            return Vector2(0, 0)
-        return vector.normalize()
+        return safe_normalize(vector)
 
     def _get_predator_threat(
         self, fish: "Fish", max_distance: float = float("inf")

--- a/core/algorithms/composable/actions.py
+++ b/core/algorithms/composable/actions.py
@@ -1,6 +1,7 @@
 import math
 from typing import TYPE_CHECKING, Any
 
+from core.behavior.primitives.steering import boids_steering, flee_direction, seek_direction
 from core.entities import Crab
 from core.entities import Fish as FishClass
 from core.math_utils import Vector2
@@ -100,7 +101,7 @@ class BehaviorActionsMixin:
         if distance > flee_threshold:
             return 0.0, 0.0, False
 
-        escape_dir = self._safe_normalize(fish.pos - predator.pos)
+        escape_dir = flee_direction(fish.pos, predator.pos)
 
         # Aggression modulates flee speed: low aggression = faster flee,
         # high aggression = slower (more defiant) escape
@@ -169,7 +170,7 @@ class BehaviorActionsMixin:
         target_pos = predict_food_target(fish, nearest_food, distance, prediction_skill)
 
         # Now calculate direction to predicted target position
-        direction = self._safe_normalize(target_pos - fish.pos)
+        direction = seek_direction(fish.pos, target_pos)
         predicted_distance = (target_pos - fish.pos).length()
 
         # hunting_stamina provides sustained speed boost for longer chases
@@ -209,7 +210,7 @@ class BehaviorActionsMixin:
                     math.sin(self._circle_angle) * circle_radius,
                 )
                 circle_target = Vector2(target_pos.x + offset.x, target_pos.y + offset.y)
-                circle_dir = self._safe_normalize(circle_target - fish.pos)
+                circle_dir = seek_direction(fish.pos, circle_target)
                 return circle_dir.x * base_speed * 0.8, circle_dir.y * base_speed * 0.8
             else:
                 # Too far - approach predicted position
@@ -327,7 +328,7 @@ class BehaviorActionsMixin:
                     leader = other
 
             if leader:
-                direction = self._safe_normalize(leader.pos - fish.pos)
+                direction = seek_direction(fish.pos, leader.pos)
                 dist = (leader.pos - fish.pos).length()
                 if dist > follow_dist:
                     return direction.x * 0.6, direction.y * 0.6
@@ -361,7 +362,7 @@ class BehaviorActionsMixin:
             if nearby:
                 # Move away from nearest fish
                 nearest = min(nearby, key=lambda f: (f.pos - fish.pos).length())
-                direction = self._safe_normalize(fish.pos - nearest.pos)
+                direction = flee_direction(fish.pos, nearest.pos)
                 return direction.x * 0.5, direction.y * 0.5, True
             return 0.0, 0.0, False
 
@@ -377,7 +378,7 @@ class BehaviorActionsMixin:
             engage_chance = 0.2 + aggression * 0.2
             if nearby and fish.environment.rng.random() < engage_chance:
                 nearest = min(nearby, key=lambda f: (f.pos - fish.pos).length())
-                direction = self._safe_normalize(nearest.pos - fish.pos)
+                direction = seek_direction(fish.pos, nearest.pos)
                 speed = 0.5 + aggression * 0.2  # 0.5 to 0.7
                 return direction.x * speed, direction.y * speed, True
             return 0.0, 0.0, False
@@ -389,7 +390,7 @@ class BehaviorActionsMixin:
             nearby = self._find_nearby_fish(fish, seek_radius)
             if nearby:
                 nearest = min(nearby, key=lambda f: (f.pos - fish.pos).length())
-                direction = self._safe_normalize(nearest.pos - fish.pos)
+                direction = seek_direction(fish.pos, nearest.pos)
                 speed = 0.7 + aggression * 0.3  # 0.7 to 1.0
                 return direction.x * speed, direction.y * speed, True
             return 0.0, 0.0, False
@@ -463,37 +464,4 @@ class BehaviorActionsMixin:
         separation: float,
     ) -> tuple[float, float]:
         """Classic boids algorithm for schooling."""
-        if not neighbors:
-            return 0.0, 0.0
-
-        # Cohesion: steer toward center of neighbors
-        center_x = sum(f.pos.x for f in neighbors) / len(neighbors)
-        center_y = sum(f.pos.y for f in neighbors) / len(neighbors)
-        cohesion_dir = self._safe_normalize(Vector2(center_x - fish.pos.x, center_y - fish.pos.y))
-
-        # Alignment: match average heading (approximate from positions)
-        # Simplified: move toward where neighbors are heading (their forward direction)
-        align_x, align_y = 0.0, 0.0
-        for neighbor in neighbors:
-            if hasattr(neighbor, "vel"):
-                align_x += neighbor.vel.x
-                align_y += neighbor.vel.y
-        if len(neighbors) > 0:
-            align_x /= len(neighbors)
-            align_y /= len(neighbors)
-        align_dir = self._safe_normalize(Vector2(align_x, align_y))
-
-        # Separation: steer away from very close neighbors
-        sep_x, sep_y = 0.0, 0.0
-        for neighbor in neighbors:
-            dist = (neighbor.pos - fish.pos).length()
-            if dist < separation and dist > 0:
-                away = self._safe_normalize(fish.pos - neighbor.pos)
-                sep_x += away.x / dist
-                sep_y += away.y / dist
-
-        # Combine forces
-        vx = cohesion_dir.x * cohesion + align_dir.x * alignment + sep_x * 0.5
-        vy = cohesion_dir.y * cohesion + align_dir.y * alignment + sep_y * 0.5
-
-        return vx, vy
+        return boids_steering(fish.pos, neighbors, cohesion, alignment, separation)

--- a/core/behavior/__init__.py
+++ b/core/behavior/__init__.py
@@ -1,0 +1,1 @@
+"""Shared, domain-neutral building blocks for organism behavior."""

--- a/core/behavior/primitives/__init__.py
+++ b/core/behavior/primitives/__init__.py
@@ -1,0 +1,1 @@
+"""Small deterministic primitives shared by current and future behaviors."""

--- a/core/behavior/primitives/steering.py
+++ b/core/behavior/primitives/steering.py
@@ -1,0 +1,143 @@
+"""Deterministic steering math shared across Tank World domains.
+
+This module is intentionally a small collection of pure functions. It is the
+first reusable-behavior step: existing fish and soccer call sites delegate here
+without changing genomes, action selection, or RNG consumption.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Protocol, cast
+
+from core.math_utils import Vector2
+
+
+class Positioned(Protocol):
+    """Minimal position contract needed by :func:`boids_steering`."""
+
+    pos: Vector2
+
+
+class HasVelocity(Protocol):
+    """Optional velocity contract used for boids alignment."""
+
+    vel: Vector2
+
+
+def safe_normalize(vector: Vector2) -> Vector2:
+    """Normalize ``vector``, returning zero for zero or near-zero length."""
+    length = vector.length()
+    if length < 1e-6:
+        return Vector2(0, 0)
+    return vector.normalize()
+
+
+def seek_direction(origin: Vector2, target: Vector2) -> Vector2:
+    """Return the safe unit direction from ``origin`` toward ``target``."""
+    return safe_normalize(target - origin)
+
+
+def flee_direction(origin: Vector2, threat: Vector2) -> Vector2:
+    """Return the safe unit direction from ``threat`` away from ``origin``."""
+    return safe_normalize(origin - threat)
+
+
+def normalized_components(x: float, y: float) -> tuple[float, float]:
+    """Return normalized scalar components, preserving a zero vector exactly."""
+    length_sq = x * x + y * y
+    if length_sq > 0:
+        length = math.sqrt(length_sq)
+        return x / length, y / length
+    return 0.0, 0.0
+
+
+def flee_components(x: float, y: float) -> tuple[float, float]:
+    """Return normalized scalar components pointing opposite ``(x, y)``."""
+    normalized_x, normalized_y = normalized_components(x, y)
+    if normalized_x == 0.0 and normalized_y == 0.0:
+        return 0.0, 0.0
+    return -normalized_x, -normalized_y
+
+
+def normalize_angle(angle: float) -> float:
+    """Normalize an angle to the inclusive range ``[-pi, pi]``."""
+    while angle > math.pi:
+        angle -= 2 * math.pi
+    while angle < -math.pi:
+        angle += 2 * math.pi
+    return angle
+
+
+def lead_target(
+    target_x: float, target_y: float, velocity_x: float, velocity_y: float, lead: float
+) -> tuple[float, float]:
+    """Return a constant-velocity lead point for a moving target."""
+    return target_x + velocity_x * lead, target_y + velocity_y * lead
+
+
+def turn_then_dash(
+    target_x: float,
+    target_y: float,
+    facing_angle: float,
+    stamina_ratio: float,
+    stamina_floor: float,
+    align_threshold: float = 0.25,
+    commit_dist: float = 0.4,
+) -> tuple[float, float]:
+    """Return turn and dash values for a target in the actor's relative frame."""
+    distance = math.sqrt(target_x * target_x + target_y * target_y)
+    angle_delta = normalize_angle(math.atan2(target_y, target_x) - facing_angle)
+
+    if abs(angle_delta) >= align_threshold:
+        return max(-1.0, min(1.0, (angle_delta * 1.5) / math.pi)), 0.0
+
+    if distance > commit_dist:
+        dash = (
+            1.0
+            if stamina_ratio > stamina_floor
+            else max(0.3, stamina_ratio / max(stamina_floor, 1e-6))
+        )
+    else:
+        dash = 0.0
+    return 0.0, dash
+
+
+def boids_steering(
+    position: Vector2,
+    neighbors: Sequence[Positioned],
+    cohesion: float,
+    alignment: float,
+    separation: float,
+) -> tuple[float, float]:
+    """Return the existing cohesion, alignment, and separation steering vector."""
+    if not neighbors:
+        return 0.0, 0.0
+
+    center_x = sum(neighbor.pos.x for neighbor in neighbors) / len(neighbors)
+    center_y = sum(neighbor.pos.y for neighbor in neighbors) / len(neighbors)
+    cohesion_direction = safe_normalize(Vector2(center_x - position.x, center_y - position.y))
+
+    alignment_x, alignment_y = 0.0, 0.0
+    for neighbor in neighbors:
+        if hasattr(neighbor, "vel"):
+            velocity = cast(HasVelocity, neighbor).vel
+            alignment_x += velocity.x
+            alignment_y += velocity.y
+    alignment_x /= len(neighbors)
+    alignment_y /= len(neighbors)
+    alignment_direction = safe_normalize(Vector2(alignment_x, alignment_y))
+
+    separation_x, separation_y = 0.0, 0.0
+    for neighbor in neighbors:
+        distance = (neighbor.pos - position).length()
+        if distance < separation and distance > 0:
+            away = safe_normalize(position - neighbor.pos)
+            separation_x += away.x / distance
+            separation_y += away.y / distance
+
+    return (
+        cohesion_direction.x * cohesion + alignment_direction.x * alignment + separation_x * 0.5,
+        cohesion_direction.y * cohesion + alignment_direction.y * alignment + separation_y * 0.5,
+    )

--- a/core/code_pool/pool.py
+++ b/core/code_pool/pool.py
@@ -7,6 +7,14 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from core.behavior.primitives.steering import (
+    flee_components,
+    lead_target,
+    normalize_angle,
+    normalized_components,
+    turn_then_dash,
+)
+
 from .models import CodeComponent, CompilationError, ComponentNotFoundError
 from .sandbox import build_restricted_globals, parse_and_validate
 
@@ -186,10 +194,7 @@ def seek_nearest_food_policy(
         except (TypeError, ValueError):
             dx = 0.0
             dy = 0.0
-        length_sq = dx * dx + dy * dy
-        if length_sq > 0:
-            length = math.sqrt(length_sq)
-            return (dx / length, dy / length)
+        return normalized_components(dx, dy)
     return (0.0, 0.0)
 
 
@@ -214,11 +219,7 @@ def flee_from_threat_policy(
         except (TypeError, ValueError):
             dx = 0.0
             dy = 0.0
-        length_sq = dx * dx + dy * dy
-        if length_sq > 0:
-            length = math.sqrt(length_sq)
-            # Flee in opposite direction
-            return (-dx / length, -dy / length)
+        return flee_components(dx, dy)
     return (0.0, 0.0)
 
 
@@ -251,11 +252,7 @@ _ENGINE_KICKABLE_DIST = 0.98
 
 def _norm_angle(angle: float) -> float:
     """Normalize an angle to [-pi, pi]."""
-    while angle > math.pi:
-        angle -= 2 * math.pi
-    while angle < -math.pi:
-        angle += 2 * math.pi
-    return angle
+    return normalize_angle(angle)
 
 
 def _scaled_param(
@@ -293,29 +290,16 @@ def _steer_action(
     the player aligns before dashing; ``commit_dist`` (``pursuit_commit``) is
     how close to the target it keeps dashing before easing off.
     """
-    dist = math.sqrt(tx * tx + ty * ty)
-    angle_delta = _norm_angle(math.atan2(ty, tx) - facing_angle)
-
-    if abs(angle_delta) >= align_threshold:
-        return {
-            "turn": max(-1.0, min(1.0, (angle_delta * 1.5) / math.pi)),
-            "dash": 0.0,
-            "kick_power": 0.0,
-            "kick_angle": 0.0,
-        }
-
-    # Full power while fresh; taper near the stamina floor so a long chase
-    # doesn't crash through the RCSS effort floor.
-    if dist > commit_dist:
-        dash = (
-            1.0
-            if stamina_ratio > stamina_floor
-            else max(0.3, stamina_ratio / max(stamina_floor, 1e-6))
-        )
-    else:
-        dash = 0.0
-
-    return {"turn": 0.0, "dash": dash, "kick_power": 0.0, "kick_angle": 0.0}
+    turn, dash = turn_then_dash(
+        tx,
+        ty,
+        facing_angle,
+        stamina_ratio,
+        stamina_floor,
+        align_threshold=align_threshold,
+        commit_dist=commit_dist,
+    )
+    return {"turn": turn, "dash": dash, "kick_power": 0.0, "kick_angle": 0.0}
 
 
 def _soccer_policy_core(observation: dict[str, Any], role: str) -> dict[str, float]:
@@ -382,8 +366,7 @@ def _soccer_policy_core(observation: dict[str, Any], role: str) -> dict[str, flo
 
     # --- Off the ball: role-specific positioning ---
     # Lead the ball's velocity to intercept where it is going, not where it is.
-    ix = brx + ball_vx * intercept_lead
-    iy = bry + ball_vy * intercept_lead
+    ix, iy = lead_target(brx, bry, ball_vx, ball_vy, intercept_lead)
 
     if role == "striker":
         # Ball in the offensive zone (near opponent goal) or close by: press.

--- a/tests/core/behavior/test_steering_primitives.py
+++ b/tests/core/behavior/test_steering_primitives.py
@@ -1,0 +1,75 @@
+"""Focused behavioral-equivalence tests for shared steering primitives."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import pytest
+
+from core.behavior.primitives.steering import (
+    boids_steering,
+    flee_components,
+    flee_direction,
+    lead_target,
+    normalize_angle,
+    normalized_components,
+    safe_normalize,
+    seek_direction,
+    turn_then_dash,
+)
+from core.math_utils import Vector2
+
+
+@dataclass
+class _Boid:
+    pos: Vector2
+    vel: Vector2
+
+
+def test_safe_normalization_and_directions_handle_zero_and_exact_target() -> None:
+    origin = Vector2(3, -2)
+
+    assert safe_normalize(Vector2(0, 0)) == Vector2(0, 0)
+    assert safe_normalize(Vector2(1e-7, 0)) == Vector2(0, 0)
+    assert seek_direction(origin, origin) == Vector2(0, 0)
+    assert flee_direction(origin, origin) == Vector2(0, 0)
+    assert seek_direction(origin, Vector2(6, 2)) == Vector2(0.6, 0.8)
+    assert flee_direction(origin, Vector2(6, 2)) == Vector2(-0.6, -0.8)
+
+
+def test_scalar_directions_preserve_zero_and_opposite_heading() -> None:
+    assert normalized_components(0.0, 0.0) == (0.0, 0.0)
+    assert flee_components(0.0, 0.0) == (0.0, 0.0)
+    assert math.copysign(1.0, flee_components(0.0, 0.0)[0]) == 1.0
+    assert normalized_components(3.0, 4.0) == (0.6, 0.8)
+    assert flee_components(3.0, 4.0) == (-0.6, -0.8)
+
+
+def test_turn_then_dash_honors_turn_limit_commit_distance_and_stamina_floor() -> None:
+    # An external target requires a bounded turn before any dash.
+    turn, dash = turn_then_dash(-100.0, 0.0, 0.0, 1.0, 0.35)
+    assert turn == pytest.approx(1.0)
+    assert dash == 0.0
+
+    # An aligned target inside the commit radius is intentionally not chased.
+    assert turn_then_dash(0.4, 0.0, 0.0, 1.0, 0.35) == (0.0, 0.0)
+
+    # Low stamina preserves the legacy taper while an aligned target is distant.
+    assert turn_then_dash(2.0, 0.0, 0.0, 0.1, 0.35) == pytest.approx((0.0, 0.3))
+
+
+def test_lead_angle_and_boids_primitives_are_deterministic() -> None:
+    assert lead_target(4.0, -2.0, 0.5, -1.5, 6.0) == (7.0, -11.0)
+    assert normalize_angle(3 * math.pi) == pytest.approx(math.pi)
+    assert normalize_angle(-3 * math.pi) == pytest.approx(-math.pi)
+
+    neighbors = [_Boid(Vector2(2, 0), Vector2(1, 0)), _Boid(Vector2(0, 2), Vector2(0, 1))]
+    first = boids_steering(Vector2(0, 0), neighbors, cohesion=0.4, alignment=0.2, separation=3.0)
+    second = boids_steering(Vector2(0, 0), neighbors, cohesion=0.4, alignment=0.2, separation=3.0)
+
+    assert first == second
+    assert boids_steering(Vector2(0, 0), [], cohesion=0.4, alignment=0.2, separation=3.0) == (
+        0.0,
+        0.0,
+    )


### PR DESCRIPTION
## Summary

Extracts the first shared, deterministic behavior-primitives library without changing organism behavior or genome representation.

- Adds typed seek/flee, normalization, target-leading, turn-then-dash, and boids primitives.
- Delegates composable foraging and soccer/code-pool steering call sites to those pure functions.
- Adds focused zero-vector, exact-target, turn/stamina, lead, boids, and repeated-call tests.

The new module explicitly documents that this is a pre-genome refactor: it adds no behavior graph, genome fields, mutation/crossover changes, scoring changes, or RNG consumption.

## Validation

- `python -m ruff check .`
- `python -m black --check .`
- `python -m mypy core/ backend/ tools/`
- `python tools/smoke_gate.py`
- `python tools/agent_gate.py` (595 selected tests passed)
- Determinism checks: `survival_5k`, `foraging_gym`, and `soccer/training_5k`
- Seed-42 champion reproduction confirmed for `tank/survival_5k`, `tank/ecosystem_health_10k`, `soccer/training_3k`, and `soccer/training_5k`.

No champion files were changed.