### PR TITLE
Add frontend payload contract test

### DIFF
--- a/frontend/src/types/payload.ts
+++ b/frontend/src/types/payload.ts
@@ -1,0 +1,58 @@
+/**
+ * Named wire-payload shapes shared by the backend contract tests and UI types.
+ *
+ * Kept separate from simulation.ts so the large application-facing type catalog
+ * stays within its file-size ratchet while these transport concerns evolve.
+ */
+
+import type {
+    AutoEvaluateStats,
+    EntityData,
+    MetricsHistory,
+    MetricsSample,
+    PokerEventData,
+    PokerLeaderboardEntry,
+    SoccerEventData,
+    SoccerLeagueLiveState,
+    StatsData,
+} from './simulation';
+
+export interface FullStateSnapshot {
+    frame: number;
+    elapsed_time: number;
+    entities: EntityData[];
+    stats: StatsData;
+    poker_events: PokerEventData[];
+    soccer_events: SoccerEventData[];
+    soccer_league_live?: SoccerLeagueLiveState | null;
+    poker_leaderboard: PokerLeaderboardEntry[];
+    auto_evaluation?: AutoEvaluateStats;
+    render_hint?: Record<string, unknown>;
+    metrics_history?: MetricsHistory | null;
+}
+
+export interface DeltaEntityUpdate {
+    id: number;
+    x: number;
+    y: number;
+    vel_x: number;
+    vel_y: number;
+    poker_effect_state?: EntityData['poker_effect_state'];
+    birth_effect_timer?: number;
+    death_effect_state?: EntityData['death_effect_state'];
+    soccer_effect_state?: EntityData['soccer_effect_state'];
+}
+
+export interface DeltaStateSnapshot {
+    frame: number;
+    elapsed_time: number;
+    updates: DeltaEntityUpdate[];
+    added: EntityData[];
+    removed: number[];
+    poker_events: PokerEventData[];
+    soccer_events?: SoccerEventData[];
+    soccer_league_live?: SoccerLeagueLiveState | null;
+    stats?: StatsData;
+    render_hint?: Record<string, unknown>;
+    new_metrics_sample?: MetricsSample | null;
+}

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -2,6 +2,8 @@
  * TypeScript types for simulation data
  */
 
+import type { DeltaStateSnapshot, FullStateSnapshot } from './payload';
+
 export interface FishGenomeData {
     speed: number;
     size: number;
@@ -522,6 +524,7 @@ export interface StatsData {
     fish_health_low: number;       // 15-30% energy
     fish_health_healthy: number;   // 30-80% energy
     fish_health_full: number;      // >80% energy
+    diversity_score: number;
     poker_stats: PokerStatsData;
     total_sexual_births: number;
     total_asexual_births: number;
@@ -543,19 +546,7 @@ export interface SimulationUpdate {
     render_hint?: Record<string, unknown>;
 
     // V1 schema: All data flows through nested snapshot
-    snapshot: {
-        frame: number;
-        elapsed_time: number;
-        entities: EntityData[];
-        stats: StatsData;
-        poker_events: PokerEventData[];
-        soccer_events: SoccerEventData[];
-        soccer_league_live?: SoccerLeagueLiveState | null;
-        poker_leaderboard: PokerLeaderboardEntry[];
-        auto_evaluation?: AutoEvaluateStats;
-        render_hint?: Record<string, unknown>;
-        metrics_history?: MetricsHistory | null;
-    };
+    snapshot: FullStateSnapshot;
 
     // Convenience fields (populated by useWebSocket from snapshot)
     frame?: number;
@@ -580,30 +571,7 @@ export interface DeltaUpdate {
     tank_soccer_enabled?: boolean;  // Whether tank practice soccer (ball/goals) is enabled
 
     // V1 schema: All data flows through nested snapshot
-    snapshot: {
-        frame: number;
-        elapsed_time: number;
-        updates: Pick<
-            EntityData,
-            'id'
-            | 'x'
-            | 'y'
-            | 'vel_x'
-            | 'vel_y'
-            | 'poker_effect_state'
-            | 'birth_effect_timer'
-            | 'death_effect_state'
-            | 'soccer_effect_state'
-        >[];
-        added: EntityData[];
-        removed: number[];
-        poker_events: PokerEventData[];
-        soccer_events?: SoccerEventData[];
-        soccer_league_live?: SoccerLeagueLiveState | null;
-        stats?: StatsData;
-        render_hint?: Record<string, unknown>;
-        new_metrics_sample?: MetricsSample | null;
-    };
+    snapshot: DeltaStateSnapshot;
 }
 
 export interface Command {

--- a/tests/test_frontend_payload_contract.py
+++ b/tests/test_frontend_payload_contract.py
@@ -1,0 +1,113 @@
+"""Guard the simulation wire schema against frontend TypeScript drift.
+
+The backend owns the serialized payload. This test parses the exported frontend
+interfaces and checks that every key emitted by the backend DTOs has a declared
+frontend field. It deliberately checks field presence rather than duplicating
+TypeScript's type checker; ``npm run build`` remains responsible for TS syntax
+and assignability.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+from backend.state_payloads import (
+    AutoEvaluateStatsPayload,
+    EntitySnapshot,
+    MetricsHistoryPayload,
+    MetricsPokerSamplePayload,
+    MetricsSamplePayload,
+    MetricsSoccerSamplePayload,
+    PokerEventPayload,
+    PokerLeaderboardEntryPayload,
+    PokerStatsPayload,
+    SoccerEventPayload,
+    StatsPayload,
+)
+
+
+TYPE_SOURCES = (
+    Path(__file__).resolve().parents[1] / "frontend" / "src" / "types" / "simulation.ts",
+    Path(__file__).resolve().parents[1] / "frontend" / "src" / "types" / "payload.ts",
+)
+
+
+def _type_source() -> str:
+    """Load the frontend's simulation and dedicated wire-payload contracts."""
+    return "\n".join(path.read_text(encoding="utf-8") for path in TYPE_SOURCES)
+
+
+def _interface_keys(source: str, interface_name: str) -> set[str]:
+    """Return the direct property names declared by one TypeScript interface."""
+    match = re.search(rf"export interface {re.escape(interface_name)}\s*{{", source)
+    assert match is not None, f"Frontend interface '{interface_name}' is missing"
+
+    depth = 0
+    end = None
+    for index in range(match.end() - 1, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                end = index
+                break
+    assert end is not None, f"Frontend interface '{interface_name}' is unterminated"
+
+    body = source[match.end() : end]
+    return set(re.findall(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\??\s*:", body, re.MULTILINE))
+
+
+def _assert_declares(interface_name: str, backend_keys: set[str], source: str) -> None:
+    missing = backend_keys - _interface_keys(source, interface_name)
+    assert not missing, f"{interface_name} is missing backend payload keys: {sorted(missing)}"
+
+
+def _dataclass_keys(payload_type: type[Any], excluded: set[str] | None = None) -> set[str]:
+    excluded = excluded or set()
+    return {field.name for field in fields(payload_type)} - excluded
+
+
+def test_full_and_delta_payloads_match_named_frontend_snapshots() -> None:
+    """Representative production payloads use only declared frontend keys."""
+    from backend.simulation_runner import SimulationRunner
+
+    source = _type_source()
+    runner = SimulationRunner(world_type="tank", seed=42)
+    runner.world.step()
+
+    full_payload = runner.get_state(force_full=True).to_dict()
+    _assert_declares("SimulationUpdate", set(full_payload), source)
+    _assert_declares("FullStateSnapshot", set(full_payload["snapshot"]), source)
+
+    for _ in range(5):
+        runner.world.step()
+    delta_payload = runner.get_state(force_full=False, allow_delta=True).to_dict()
+    _assert_declares("DeltaUpdate", set(delta_payload), source)
+    _assert_declares("DeltaStateSnapshot", set(delta_payload["snapshot"]), source)
+
+
+def test_every_backend_dto_field_has_a_frontend_declaration() -> None:
+    """DTO additions cannot silently bypass the web-client contract."""
+    source = _type_source()
+
+    contracts = {
+        "EntityData": _dataclass_keys(EntitySnapshot),
+        "DeltaEntityUpdate": set(EntitySnapshot(1, "fish", 0, 0, 1, 1).to_delta_dict()),
+        "StatsData": _dataclass_keys(StatsPayload, {"meta_stats"}),
+        "PokerStatsData": _dataclass_keys(PokerStatsPayload),
+        "PokerEventData": _dataclass_keys(PokerEventPayload),
+        "SoccerEventData": _dataclass_keys(SoccerEventPayload),
+        "PokerLeaderboardEntry": _dataclass_keys(PokerLeaderboardEntryPayload),
+        "AutoEvaluateStats": _dataclass_keys(AutoEvaluateStatsPayload),
+        "MetricsPokerSample": _dataclass_keys(MetricsPokerSamplePayload),
+        "MetricsSoccerSample": _dataclass_keys(MetricsSoccerSamplePayload),
+        "MetricsSample": _dataclass_keys(MetricsSamplePayload),
+        "MetricsHistory": _dataclass_keys(MetricsHistoryPayload),
+    }
+
+    for interface_name, backend_keys in contracts.items():
+        _assert_declares(interface_name, backend_keys, source)


### PR DESCRIPTION
## Summary

Adds a field-level contract test between backend simulation DTOs and frontend TypeScript payload types.

- Serializes representative full and delta production payloads and verifies all emitted top-level and snapshot fields are declared by the frontend types.
- Audits every field emitted by the state-payload DTOs (entities, stats, events, leaderboard, auto-evaluation, and metrics history).
- Extracts full/delta wire shapes into `frontend/src/types/payload.ts`, keeping the large application type catalog beneath its line-limit ratchet.
- Fixes the first detected drift: `StatsData` now declares backend-emitted `diversity_score`.

## Why

The backend DTOs and `simulation.ts` describe the same WebSocket contract but previously had no field-level guardrail. Future backend fields now fail Python CI until they are consciously represented in the client schema.

## Layer

Layer 2 only. No simulation, genome, RNG, scoring, benchmark, or champion behavior changes.

## Validation

- `pytest tests/test_frontend_payload_contract.py tests/test_websocket_payload_v1.py`
- `npm run build` — passed
- `npm run test -- --run` — 15 files / 59 tests passed
- `python -m mypy core/ backend/ tools/`
- `python tools/agent_gate.py` — 595 selected tests passed
- `python tools/pre_pr_gate.py` — passed (all serial shards)

No champion files were changed.