### PR TITLE
Add dormant behavior graph foundation

### DIFF
--- a/core/behavior/__init__.py
+++ b/core/behavior/__init__.py
@@ -1,1 +1,15 @@
 """Shared, domain-neutral building blocks for organism behavior."""
+
+from core.behavior.nodes import NODE_REGISTRY, NodeCategory, NodeDefinition, NodeRegistry, ValueType
+from core.behavior.graph import BehaviorGraph, BehaviorGraphError, CompiledBehaviorGraph
+
+__all__ = [
+    "BehaviorGraph",
+    "BehaviorGraphError",
+    "CompiledBehaviorGraph",
+    "NODE_REGISTRY",
+    "NodeCategory",
+    "NodeDefinition",
+    "NodeRegistry",
+    "ValueType",
+]

--- a/core/behavior/graph.py
+++ b/core/behavior/graph.py
@@ -1,0 +1,332 @@
+"""Dormant, typed behavior-graph data and its compiled interpreter.
+
+Graphs are genome data only in this stage: no production fish asks this module
+for a movement decision.  Compiling validates the graph and turns it into a
+flat sequence of callables once, so activating graph-backed behavior later
+does not add graph traversal to the per-frame hot path.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from core.behavior.nodes import (
+    NODE_REGISTRY,
+    BehaviorNode,
+    Bool,
+    NodeCategory,
+    NodeParameter,
+    NodeRegistry,
+    NodeValue,
+    Scalar,
+)
+
+
+class BehaviorGraphError(ValueError):
+    """Raised when graph data cannot be validated or compiled."""
+
+
+def _parameters_from_dict(value: object) -> dict[str, NodeParameter]:
+    if not isinstance(value, dict):
+        raise BehaviorGraphError("Node parameters must be an object.")
+
+    parameters: dict[str, NodeParameter] = {}
+    for name, parameter in value.items():
+        if not isinstance(name, str) or not name.isidentifier():
+            raise BehaviorGraphError(f"Invalid node parameter name {name!r}.")
+        if isinstance(parameter, (bool, str)):
+            parameters[name] = Bool(parameter) if isinstance(parameter, bool) else parameter
+        elif isinstance(parameter, (int, float)) and math.isfinite(float(parameter)):
+            parameters[name] = Scalar(float(parameter))
+        else:
+            raise BehaviorGraphError(
+                f"Node parameter {name!r} must be a finite scalar, bool, or string."
+            )
+    return parameters
+
+
+@dataclass(frozen=True)
+class GraphNode:
+    """One serializable node instance in a behavior graph."""
+
+    node_id: str
+    node_type: str
+    parameters: Mapping[str, NodeParameter]
+
+    def __post_init__(self) -> None:
+        if not self.node_id or not self.node_id.isidentifier():
+            raise BehaviorGraphError(f"Invalid graph node id {self.node_id!r}.")
+        if not self.node_type or not self.node_type.isidentifier():
+            raise BehaviorGraphError(f"Invalid graph node type {self.node_type!r}.")
+        object.__setattr__(self, "parameters", _parameters_from_dict(dict(self.parameters)))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.node_id,
+            "type": self.node_type,
+            "parameters": dict(sorted(self.parameters.items())),
+        }
+
+    @classmethod
+    def from_dict(cls, data: object) -> GraphNode:
+        if not isinstance(data, dict):
+            raise BehaviorGraphError("Graph nodes must be objects.")
+        return cls(
+            node_id=data.get("id", ""),
+            node_type=data.get("type", ""),
+            parameters=_parameters_from_dict(data.get("parameters", {})),
+        )
+
+
+@dataclass(frozen=True)
+class GraphConnection:
+    """A typed edge from one node output to a named target input port."""
+
+    source_id: str
+    target_id: str
+    target_port: str
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("source", self.source_id),
+            ("target", self.target_id),
+            ("target port", self.target_port),
+        ):
+            if not value or not value.isidentifier():
+                raise BehaviorGraphError(f"Invalid graph {label} {value!r}.")
+
+    def to_dict(self) -> dict[str, str]:
+        return {"source": self.source_id, "target": self.target_id, "port": self.target_port}
+
+    @classmethod
+    def from_dict(cls, data: object) -> GraphConnection:
+        if not isinstance(data, dict):
+            raise BehaviorGraphError("Graph connections must be objects.")
+        return cls(
+            source_id=data.get("source", ""),
+            target_id=data.get("target", ""),
+            target_port=data.get("port", ""),
+        )
+
+
+@dataclass(frozen=True)
+class _CompiledStep:
+    evaluate: Callable[[object, Mapping[str, NodeValue]], NodeValue]
+    inputs: tuple[tuple[str, int], ...]
+
+    def run(self, context: object, values: list[NodeValue]) -> NodeValue:
+        return self.evaluate(context, {port: values[index] for port, index in self.inputs})
+
+
+@dataclass(frozen=True)
+class CompiledBehaviorGraph:
+    """Flat, prevalidated execution plan for a :class:`BehaviorGraph`."""
+
+    steps: tuple[_CompiledStep, ...]
+    output_index: int
+
+    def evaluate(self, context: object) -> NodeValue:
+        """Run the precompiled plan without parsing or traversing graph topology."""
+        values: list[NodeValue] = []
+        for step in self.steps:
+            values.append(step.run(context, values))
+        return values[self.output_index]
+
+
+def _evaluator_for(node: BehaviorNode) -> Callable[[object, Mapping[str, NodeValue]], NodeValue]:
+    """Bind a node's category-specific method once at compile time."""
+    if node.category is NodeCategory.SENSOR:
+        sense = getattr(node, "sense", None)
+        if not callable(sense):
+            raise BehaviorGraphError(f"Sensor node {node.node_id!r} must provide sense(context).")
+        return lambda context, _inputs: cast(NodeValue, sense(context))
+
+    method_name = {
+        NodeCategory.SELECTOR: "select",
+        NodeCategory.STEERING: "steer",
+        NodeCategory.MEMORY: "update",
+        NodeCategory.ARBITER: "arbitrate",
+    }[node.category]
+    method = getattr(node, method_name, None)
+    if not callable(method):
+        raise BehaviorGraphError(
+            f"{node.category.value.title()} node {node.node_id!r} must provide {method_name}(inputs)."
+        )
+    return lambda _context, inputs: cast(NodeValue, method(inputs))
+
+
+@dataclass(frozen=True)
+class BehaviorGraph:
+    """An immutable, acyclic behavior graph with an explicit output node."""
+
+    nodes: tuple[GraphNode, ...]
+    connections: tuple[GraphConnection, ...]
+    output_node_id: str
+
+    def __post_init__(self) -> None:
+        if not self.nodes:
+            raise BehaviorGraphError("A behavior graph must contain at least one node.")
+        if not self.output_node_id or not self.output_node_id.isidentifier():
+            raise BehaviorGraphError(f"Invalid graph output node {self.output_node_id!r}.")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-compatible graph representation."""
+        return {
+            "nodes": [node.to_dict() for node in sorted(self.nodes, key=lambda node: node.node_id)],
+            "connections": [
+                connection.to_dict()
+                for connection in sorted(
+                    self.connections,
+                    key=lambda connection: (
+                        connection.target_id,
+                        connection.target_port,
+                        connection.source_id,
+                    ),
+                )
+            ],
+            "output": self.output_node_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: object) -> BehaviorGraph:
+        if not isinstance(data, dict):
+            raise BehaviorGraphError("Behavior graph must be an object.")
+        raw_nodes = data.get("nodes")
+        raw_connections = data.get("connections", [])
+        if not isinstance(raw_nodes, list) or not isinstance(raw_connections, list):
+            raise BehaviorGraphError("Behavior graph nodes and connections must be lists.")
+        graph = cls(
+            nodes=tuple(GraphNode.from_dict(node) for node in raw_nodes),
+            connections=tuple(
+                GraphConnection.from_dict(connection) for connection in raw_connections
+            ),
+            output_node_id=data.get("output", ""),
+        )
+        issues = graph.validate()
+        if issues:
+            raise BehaviorGraphError("Invalid behavior graph: " + "; ".join(issues))
+        return graph
+
+    def validate(self, registry: NodeRegistry | None = None) -> tuple[str, ...]:
+        """Return deterministic structural and optional registry-contract issues."""
+        issues: list[str] = []
+        nodes_by_id: dict[str, GraphNode] = {}
+        for node in self.nodes:
+            if node.node_id in nodes_by_id:
+                issues.append(f"duplicate node id {node.node_id!r}")
+            nodes_by_id[node.node_id] = node
+
+        if self.output_node_id not in nodes_by_id:
+            issues.append(f"output node {self.output_node_id!r} does not exist")
+
+        incoming: set[tuple[str, str]] = set()
+        for connection in self.connections:
+            if connection.source_id not in nodes_by_id:
+                issues.append(f"connection source {connection.source_id!r} does not exist")
+            if connection.target_id not in nodes_by_id:
+                issues.append(f"connection target {connection.target_id!r} does not exist")
+            key = (connection.target_id, connection.target_port)
+            if key in incoming:
+                issues.append(
+                    f"input {connection.target_id!r}.{connection.target_port} has multiple sources"
+                )
+            incoming.add(key)
+
+        if not issues:
+            issues.extend(self._topology_issues(nodes_by_id))
+
+        if registry is not None:
+            for node in sorted(self.nodes, key=lambda item: item.node_id):
+                try:
+                    registry.get(node.node_type)
+                except KeyError:
+                    issues.append(f"node {node.node_id!r} uses unknown type {node.node_type!r}")
+            for connection in self.connections:
+                source = nodes_by_id.get(connection.source_id)
+                target = nodes_by_id.get(connection.target_id)
+                if source is None or target is None:
+                    continue
+                try:
+                    registry.validate_connection(
+                        source.node_type, target.node_type, connection.target_port
+                    )
+                except (KeyError, TypeError) as exc:
+                    issues.append(str(exc))
+
+        return tuple(issues)
+
+    def _topology_issues(self, nodes_by_id: Mapping[str, GraphNode]) -> list[str]:
+        incoming_count = dict.fromkeys(nodes_by_id, 0)
+        outgoing: dict[str, list[str]] = {node_id: [] for node_id in nodes_by_id}
+        for connection in self.connections:
+            incoming_count[connection.target_id] += 1
+            outgoing[connection.source_id].append(connection.target_id)
+
+        ready = sorted(node_id for node_id, count in incoming_count.items() if count == 0)
+        visited = 0
+        while ready:
+            node_id = ready.pop(0)
+            visited += 1
+            for target in sorted(outgoing[node_id]):
+                incoming_count[target] -= 1
+                if incoming_count[target] == 0:
+                    ready.append(target)
+                    ready.sort()
+        return [] if visited == len(nodes_by_id) else ["graph contains a cycle"]
+
+    def compile(self, registry: NodeRegistry = NODE_REGISTRY) -> CompiledBehaviorGraph:
+        """Instantiate and bind an immutable flat execution plan once."""
+        issues = self.validate(registry)
+        if issues:
+            raise BehaviorGraphError("Cannot compile behavior graph: " + "; ".join(issues))
+
+        nodes_by_id = {node.node_id: node for node in self.nodes}
+        order = self._topological_order(nodes_by_id)
+        indices = {node_id: index for index, node_id in enumerate(order)}
+        incoming: dict[str, list[GraphConnection]] = {node_id: [] for node_id in order}
+        for connection in self.connections:
+            incoming[connection.target_id].append(connection)
+
+        steps: list[_CompiledStep] = []
+        for node_id in order:
+            graph_node = nodes_by_id[node_id]
+            node = registry.create(graph_node.node_type, graph_node.node_id, graph_node.parameters)
+            inputs = tuple(
+                (connection.target_port, indices[connection.source_id])
+                for connection in sorted(
+                    incoming[node_id], key=lambda connection: connection.target_port
+                )
+            )
+            steps.append(_CompiledStep(_evaluator_for(node), inputs))
+        return CompiledBehaviorGraph(tuple(steps), indices[self.output_node_id])
+
+    def _topological_order(self, nodes_by_id: Mapping[str, GraphNode]) -> tuple[str, ...]:
+        incoming_count = dict.fromkeys(nodes_by_id, 0)
+        outgoing: dict[str, list[str]] = {node_id: [] for node_id in nodes_by_id}
+        for connection in self.connections:
+            incoming_count[connection.target_id] += 1
+            outgoing[connection.source_id].append(connection.target_id)
+
+        ready = sorted(node_id for node_id, count in incoming_count.items() if count == 0)
+        order: list[str] = []
+        while ready:
+            node_id = ready.pop(0)
+            order.append(node_id)
+            for target in sorted(outgoing[node_id]):
+                incoming_count[target] -= 1
+                if incoming_count[target] == 0:
+                    ready.append(target)
+                    ready.sort()
+        return tuple(order)
+
+
+__all__ = [
+    "BehaviorGraph",
+    "BehaviorGraphError",
+    "CompiledBehaviorGraph",
+    "GraphConnection",
+    "GraphNode",
+]

--- a/core/behavior/nodes.py
+++ b/core/behavior/nodes.py
@@ -1,0 +1,252 @@
+"""Typed, domain-neutral contracts for future behavior-graph nodes.
+
+The behavior graph is deliberately not wired into genomes or the simulation yet.
+This module defines the small vocabulary that any future graph node must use,
+and a registry that makes node metadata deterministic and validates graph-port
+compatibility before an interpreter is introduced.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import NewType, Protocol, TypeAlias
+
+
+# These are semantic types, not runtime wrappers.  Keeping vectors in a
+# normalized, domain-neutral frame prevents a tank coordinate or soccer field
+# coordinate from leaking into the graph's shared middle layer.
+Scalar = NewType("Scalar", float)
+Bool = NewType("Bool", bool)
+EntityRef = NewType("EntityRef", str)
+Vector: TypeAlias = tuple[Scalar, Scalar]
+UnitVector = NewType("UnitVector", Vector)
+NodeValue: TypeAlias = Scalar | Bool | EntityRef | Vector | UnitVector
+NodeParameter: TypeAlias = Scalar | Bool | str
+
+
+class ValueType(str, Enum):
+    """The closed set of values that may cross a graph port."""
+
+    SCALAR = "scalar"
+    VECTOR = "vector"
+    UNIT_VECTOR = "unit_vector"
+    ENTITY_REF = "entity_ref"
+    BOOL = "bool"
+
+
+class NodeCategory(str, Enum):
+    """The five readable roles allowed in the shared behavior substrate."""
+
+    SENSOR = "sensor"
+    SELECTOR = "selector"
+    STEERING = "steering"
+    MEMORY = "memory"
+    ARBITER = "arbiter"
+
+
+class BehaviorNode(Protocol):
+    """Metadata and serialization contract common to every behavior node."""
+
+    node_id: str
+    node_type: str
+    category: NodeCategory
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        """Return deterministic, JSON-safe node parameters."""
+        ...
+
+
+class SensorNode(BehaviorNode, Protocol):
+    """Reads a domain adapter's observation into the shared value vocabulary."""
+
+    def sense(self, context: object) -> NodeValue:
+        """Produce one value without consuming graph inputs."""
+        ...
+
+
+class SelectorNode(BehaviorNode, Protocol):
+    """Chooses one value from typed candidate inputs."""
+
+    def select(self, inputs: Mapping[str, NodeValue]) -> NodeValue:
+        """Select a value using only declared input ports."""
+        ...
+
+
+class SteeringNode(BehaviorNode, Protocol):
+    """Converts typed target inputs into a normalized movement direction."""
+
+    def steer(self, inputs: Mapping[str, NodeValue]) -> UnitVector:
+        """Return a direction in the normalized shared frame."""
+        ...
+
+
+class MemoryNode(BehaviorNode, Protocol):
+    """Maintains explicit, serializable graph-local state."""
+
+    def update(self, inputs: Mapping[str, NodeValue]) -> NodeValue:
+        """Update memory and expose its current typed value."""
+        ...
+
+
+class ArbiterNode(BehaviorNode, Protocol):
+    """Resolves typed competing outputs into one selected output."""
+
+    def arbitrate(self, inputs: Mapping[str, NodeValue]) -> NodeValue:
+        """Choose one value according to the node's explicit policy."""
+        ...
+
+
+NodeFactory: TypeAlias = Callable[[str, Mapping[str, NodeParameter]], BehaviorNode]
+
+
+def _normalized_ports(ports: Mapping[str, ValueType]) -> Mapping[str, ValueType]:
+    """Validate and freeze port metadata supplied by a node definition."""
+    normalized = dict(ports)
+    for name, value_type in normalized.items():
+        if not name or not name.isidentifier():
+            raise ValueError(f"Node port names must be valid identifiers, got {name!r}.")
+        if not isinstance(value_type, ValueType):
+            raise TypeError(f"Port {name!r} must declare a ValueType, got {value_type!r}.")
+    return MappingProxyType(normalized)
+
+
+@dataclass(frozen=True)
+class NodeDefinition:
+    """Static, serializable metadata for one registered node implementation."""
+
+    node_type: str
+    category: NodeCategory
+    input_ports: Mapping[str, ValueType]
+    output_type: ValueType
+    factory: NodeFactory
+
+    def __post_init__(self) -> None:
+        if not self.node_type or not self.node_type.isidentifier():
+            raise ValueError(
+                f"Node types must be non-empty alphanumeric identifiers, got {self.node_type!r}."
+            )
+        if not isinstance(self.category, NodeCategory):
+            raise TypeError(f"Node {self.node_type!r} must declare a NodeCategory.")
+        if not isinstance(self.output_type, ValueType):
+            raise TypeError(f"Node {self.node_type!r} must declare a ValueType output.")
+        if not callable(self.factory):
+            raise TypeError(f"Node {self.node_type!r} must provide a factory.")
+        object.__setattr__(self, "input_ports", _normalized_ports(self.input_ports))
+
+    def to_dict(self) -> dict[str, object]:
+        """Return stable metadata for graph serialization and inspection."""
+        return {
+            "node_type": self.node_type,
+            "category": self.category.value,
+            "input_ports": {
+                name: value_type.value for name, value_type in sorted(self.input_ports.items())
+            },
+            "output_type": self.output_type.value,
+        }
+
+
+class NodeRegistry:
+    """Registry for behavior nodes and their type-safe graph connections.
+
+    Definitions, rather than domain objects, are registered.  That keeps
+    serialization, future mutation, and future crossover centered on one stable
+    schema, while each domain remains responsible only for sensor binding and
+    actuator adaptation.
+    """
+
+    def __init__(self) -> None:
+        self._definitions: dict[str, NodeDefinition] = {}
+
+    def register(self, definition: NodeDefinition) -> None:
+        """Register one node type exactly once."""
+        if definition.node_type in self._definitions:
+            raise ValueError(f"Node type {definition.node_type!r} is already registered.")
+        self._definitions[definition.node_type] = definition
+
+    def get(self, node_type: str) -> NodeDefinition:
+        """Return a definition or raise a clear error for an unknown node."""
+        try:
+            return self._definitions[node_type]
+        except KeyError as exc:
+            raise KeyError(f"Unknown behavior node type {node_type!r}.") from exc
+
+    def definitions(self) -> tuple[NodeDefinition, ...]:
+        """Return definitions in stable order, independent of registration order."""
+        return tuple(self._definitions[name] for name in sorted(self._definitions))
+
+    def create(
+        self, node_type: str, node_id: str, parameters: Mapping[str, NodeParameter]
+    ) -> BehaviorNode:
+        """Create a node and confirm it matches its registered metadata."""
+        definition = self.get(node_type)
+        node = definition.factory(node_id, MappingProxyType(dict(parameters)))
+        if node.node_id != node_id:
+            raise ValueError(
+                f"Factory for {node_type!r} returned node id {node.node_id!r}, expected {node_id!r}."
+            )
+        if node.node_type != node_type:
+            raise ValueError(f"Factory for {node_type!r} returned node type {node.node_type!r}.")
+        if node.category is not definition.category:
+            raise ValueError(
+                f"Factory for {node_type!r} returned category {node.category.value!r}, "
+                f"expected {definition.category.value!r}."
+            )
+        return node
+
+    def validate_connection(
+        self, source_node_type: str, target_node_type: str, target_port: str
+    ) -> None:
+        """Require a source output to exactly match a target input port's type."""
+        source = self.get(source_node_type)
+        target = self.get(target_node_type)
+        try:
+            expected = target.input_ports[target_port]
+        except KeyError as exc:
+            raise KeyError(f"Node {target_node_type!r} has no input port {target_port!r}.") from exc
+        if source.output_type is not expected:
+            raise TypeError(
+                f"Cannot connect {source_node_type!r} ({source.output_type.value}) to "
+                f"{target_node_type!r}.{target_port} ({expected.value})."
+            )
+
+    def serialize(self, node: BehaviorNode) -> dict[str, object]:
+        """Serialize every registered node through the same stable envelope."""
+        definition = self.get(node.node_type)
+        if node.category is not definition.category:
+            raise ValueError(
+                f"Node {node.node_id!r} category does not match {node.node_type!r}'s definition."
+            )
+        return {
+            "id": node.node_id,
+            "type": definition.node_type,
+            "parameters": dict(sorted(node.to_parameters().items())),
+        }
+
+
+NODE_REGISTRY = NodeRegistry()
+
+
+__all__ = [
+    "ArbiterNode",
+    "BehaviorNode",
+    "Bool",
+    "EntityRef",
+    "MemoryNode",
+    "NODE_REGISTRY",
+    "NodeCategory",
+    "NodeDefinition",
+    "NodeFactory",
+    "NodeParameter",
+    "NodeRegistry",
+    "NodeValue",
+    "Scalar",
+    "SelectorNode",
+    "SensorNode",
+    "SteeringNode",
+    "UnitVector",
+    "ValueType",
+    "Vector",
+]

--- a/core/genetics/behavioral.py
+++ b/core/genetics/behavioral.py
@@ -53,6 +53,7 @@ from core.genetics.trait import GeneticTrait, TraitSpec, random_genetic_trait
 
 if TYPE_CHECKING:
     from core.algorithms.composable import ComposableBehavior
+    from core.behavior.graph import BehaviorGraph
     from core.genetics.physical import PhysicalTraits
     from core.poker.strategy.implementations import PokerStrategyAlgorithm
 
@@ -171,6 +172,10 @@ class BehavioralTraits:
     # Soccer policy (soccer training world behavior)
     soccer_policy_id: GeneticTrait[str | None] | None = None
     soccer_policy_params: GeneticTrait[dict[str, float] | None] | None = None
+
+    # Dormant graph substrate.  A missing trait deliberately keeps the current
+    # composable behavior path and consumes no additional RNG during founding.
+    behavior_graph: GeneticTrait["BehaviorGraph | None"] | None = None
 
     @classmethod
     def random(

--- a/core/genetics/behavioral_inheritance.py
+++ b/core/genetics/behavioral_inheritance.py
@@ -177,6 +177,32 @@ def inherit_poker_strategy(
         return ComposablePokerStrategy.create_random(rng=rng)
 
 
+def inherit_behavior_graph(
+    parent1_trait: GeneticTrait | None,
+    parent2_trait: GeneticTrait | None,
+    *,
+    weight1: float,
+    rng: pyrandom.Random,
+) -> GeneticTrait | None:
+    """Inherit dormant graph data without perturbing graph-free RNG schedules."""
+    graph1 = parent1_trait.value if parent1_trait is not None else None
+    graph2 = parent2_trait.value if parent2_trait is not None else None
+    if graph1 is None and graph2 is None:
+        return None
+
+    if graph1 is None:
+        chosen = graph2
+    elif graph2 is None:
+        chosen = graph1
+    else:
+        chosen = graph1 if rng.random() < weight1 else graph2
+    assert chosen is not None
+    # Graph mutation is deliberately deferred to Theme 12.5.  Cloning avoids
+    # aliasing a mutable trait container across parent and offspring genomes.
+    copied = type(chosen).from_dict(chosen.to_dict())
+    return inherit_trait_meta(parent1_trait, parent2_trait, copied, rng)
+
+
 def inherit_behavioral_traits(
     specs: list[TraitSpec],
     parent1: "BehavioralTraits",
@@ -261,6 +287,10 @@ def inherit_behavioral_traits(
     )
     inherited["mate_preferences"] = inherit_trait_meta(
         parent1.mate_preferences, parent2.mate_preferences, mate_prefs, rng
+    )
+
+    inherited["behavior_graph"] = inherit_behavior_graph(
+        parent1.behavior_graph, parent2.behavior_graph, weight1=weight1, rng=rng
     )
 
     # Inherit per-kind policy traits (new multi-policy system)
@@ -376,6 +406,16 @@ def recombine_behavioral_traits(
     inherited["mate_preferences"] = inherit_trait_meta(
         parent1.mate_preferences, parent2.mate_preferences, mate_prefs, rng
     )
+
+    graph1 = parent1.behavior_graph.value if parent1.behavior_graph is not None else None
+    graph2 = parent2.behavior_graph.value if parent2.behavior_graph is not None else None
+    if graph1 is None and graph2 is None:
+        inherited["behavior_graph"] = None
+    else:
+        graph_weight = 1.0 if rng.random() < parent1_probability else 0.0
+        inherited["behavior_graph"] = inherit_behavior_graph(
+            parent1.behavior_graph, parent2.behavior_graph, weight1=graph_weight, rng=rng
+        )
 
     # Inherit per-kind policy traits (new multi-policy system)
     for kind in ("movement_policy", "poker_policy", "soccer_policy"):

--- a/core/genetics/genome.py
+++ b/core/genetics/genome.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from core.code_pool.genome_code_pool import GenomeCodePool
 
 logger = logging.getLogger(__name__)
-GENOME_SCHEMA_VERSION = 2  # Bumped from 1: added code_policy_{kind,component_id,params}
+GENOME_SCHEMA_VERSION = 3  # Bumped from 2: added optional dormant behavior_graph.
 
 
 class GeneticCrossoverMode(Enum):
@@ -100,9 +100,16 @@ class Genome:
 
         This is intended as a stable boundary format for persistence and transfer.
         """
+        has_behavior_graph = bool(
+            self.behavioral.behavior_graph and self.behavioral.behavior_graph.value is not None
+        )
         return genome_to_dict(
             self,
-            schema_version=GENOME_SCHEMA_VERSION,
+            # Preserve the exact v2 payload for the dormant default.  Version
+            # 3 is reserved for genomes that actually carry the new graph.
+            schema_version=(
+                GENOME_SCHEMA_VERSION if has_behavior_graph else GENOME_SCHEMA_VERSION - 1
+            ),
         )
 
     @classmethod
@@ -141,6 +148,18 @@ class Genome:
                 BEHAVIORAL_TRAIT_SPECS, self.behavioral, path="genome.behavioral"
             )
         )
+
+        behavior_graph = self.behavioral.behavior_graph
+        if behavior_graph is not None and behavior_graph.value is not None:
+            from core.behavior.graph import BehaviorGraph
+
+            if not isinstance(behavior_graph.value, BehaviorGraph):
+                issues.append("genome.behavioral.behavior_graph: expected BehaviorGraph")
+            else:
+                issues.extend(
+                    f"genome.behavioral.behavior_graph: {issue}"
+                    for issue in behavior_graph.value.validate()
+                )
 
         # Validate per-kind policy params fields
         for kind, id_attr, params_attr in [

--- a/core/genetics/genome_codec.py
+++ b/core/genetics/genome_codec.py
@@ -41,6 +41,12 @@ def genome_to_dict(
         genome.behavioral.poker_strategy.value if genome.behavioral.poker_strategy else None
     )
     poker_strategy_dict = poker_strategy.to_dict() if poker_strategy is not None else None
+    behavior_graph = genome.behavioral.behavior_graph
+    behavior_graph_dict = (
+        behavior_graph.value.to_dict()
+        if behavior_graph is not None and behavior_graph.value
+        else None
+    )
 
     values: dict[str, Any] = {}
     values.update(trait_values_to_dict(PHYSICAL_TRAIT_SPECS, genome.physical))
@@ -55,6 +61,7 @@ def genome_to_dict(
         ("behavior", genome.behavioral.behavior),
         ("poker_strategy", genome.behavioral.poker_strategy),
         ("mate_preferences", genome.behavioral.mate_preferences),
+        ("behavior_graph", genome.behavioral.behavior_graph),
     ):
         if trait is not None:
             meta = trait_meta_for_trait(trait)
@@ -96,7 +103,7 @@ def genome_to_dict(
             if meta:
                 trait_meta[name] = meta
 
-    return {
+    result = {
         "schema_version": schema_version,
         **values,
         # Behavior (new system - replaces behavior_algorithm + poker_algorithm)
@@ -117,6 +124,11 @@ def genome_to_dict(
         "soccer_policy_params": soccer_policy_params,
         "trait_meta": trait_meta,
     }
+    # Omit the dormant field when absent so existing genome payloads retain
+    # their shape apart from the explicit schema-version bump.
+    if behavior_graph_dict is not None:
+        result["behavior_graph"] = behavior_graph_dict
+    return result
 
 
 def genome_from_dict(
@@ -207,6 +219,25 @@ def genome_from_dict(
                 genome.behavioral.poker_strategy.value = strat
     except GENOME_DECODE_ERRORS:
         logger.debug("Failed deserializing poker_strategy; keeping default", exc_info=True)
+
+    # Dormant behavior graph.  Loading it does not activate it; the movement
+    # path remains the existing composable behavior until a later graph adapter
+    # explicitly opts in.
+    try:
+        from core.behavior.graph import BehaviorGraph
+        from core.genetics.trait import GeneticTrait
+
+        graph_data = data.get("behavior_graph")
+        if isinstance(graph_data, dict):
+            graph = BehaviorGraph.from_dict(graph_data)
+            graph_trait = GeneticTrait(graph)
+            if isinstance(trait_meta, dict):
+                graph_meta = trait_meta.get("behavior_graph")
+                if isinstance(graph_meta, dict):
+                    apply_trait_meta_to_trait(graph_trait, graph_meta)
+            genome.behavioral.behavior_graph = graph_trait
+    except GENOME_DECODE_ERRORS:
+        logger.debug("Failed deserializing behavior_graph; keeping default", exc_info=True)
 
     # New per-kind policy fields
     try:

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -14,11 +14,8 @@ use and a better example of software design.
 high-impact, low-effort items. When you complete one, move it to the
 "Shipped" section at the bottom with the PR link.
 
-**Best current starter picks:**
+**Best current starter pick:**
 
-- **11.3** — the foraging gym with an oracle ceiling: the first absolute
-  foraging skill measure, self-contained, and the template for Theme 11's
-  remaining rulers.
 - **6.2** — retire `Any` in one small core module, after re-running the grep
   and skipping files already checked in the notes below.
 
@@ -559,25 +556,6 @@ output. Acceptance: all four champions reproduce bit-exactly. Highest
 value-per-risk — it makes the "reusable primitive" story real with zero
 behavior change. Keep every new file under the god-class ceiling from the start.
 
-### 12.2 Typed node interfaces + registry — `S` · ★★
-**Layer 2 (no sim change).** Define the shared type vocabulary (`Scalar`,
-`Vector`/`UnitVector` in a normalized frame, `EntityRef`, `Bool`) and the
-`Sensor`/`Selector`/`Steering`/`Memory`/`Arbiter` node Protocols in
-`core/behavior/nodes.py`, plus a registry. Interfaces + unit tests only; no
-genome wiring yet. This is the type discipline that prevents "graph soup": a
-domain pulls in only the node *types* it needs (poker never grows steering;
-soccer never grows a poker branch), and the registry treats every node
-uniformly for serialization/mutation/crossover.
-
-### 12.3 Dormant `behavior_graph` genome field + interpreter — `M` · ★★
-**Layer 1.** Add an optional `behavior_graph` trait to `BehavioralTraits`
-(default `None`) with serialization (bump `GENOME_SCHEMA_VERSION` in
-`genome_codec.py`), validation, and a graph interpreter that **no fish selects
-yet**. Baseline byte-identical (field absent = today's path). Ship a golden
-replay fixture that exercises the interpreter in isolation. The interpreter must
-compile each genome's graph to a flat callable *once* (not per tick) — the move
-loop and `core/spatial/grid.py` are hot paths.
-
 ### 12.4 Foraging graph that reproduces `ComposableBehavior` — `M` · ★★★
 **Layer 1 (the risky step — isolate it).** Build a graph over the 12.1
 primitives that reproduces `ComposableBehavior.execute()` for foraging
@@ -625,6 +603,23 @@ shared module on multiple ladders (foraging gym / soccer / poker) to produce a
 
 ## Shipped
 
+- **12.3 Dormant `behavior_graph` genome field + interpreter.** Added
+  [`core/behavior/graph.py`](../core/behavior/graph.py), an immutable acyclic
+  graph format with typed registry validation and a compiler that binds a flat
+  execution plan once, outside the per-tick path. `BehavioralTraits` now carries
+  an optional graph trait, persisted under schema version 3 only when present
+  and inherited without consuming extra RNG for graph-free genomes. The golden
+  replay fixture ([`scalar_threshold_v1.json`](../tests/fixtures/behavior_graphs/scalar_threshold_v1.json))
+  proves deterministic isolated graph execution. No production fish selects the
+  graph yet; existing `ComposableBehavior` remains the live path.
+- **12.2 Typed node interfaces + registry.** Added
+  [`core/behavior/nodes.py`](../core/behavior/nodes.py), defining the closed
+  `Scalar`/`Vector`/`UnitVector`/`EntityRef`/`Bool` vocabulary; the five
+  readable node-role Protocols; and a deterministic `NodeRegistry`. The
+  registry stores immutable port contracts, validates exact type-compatible
+  connections, and serializes every node through one stable envelope. No
+  production node, genome, or simulation path is wired yet; focused unit tests
+  cover metadata, factory validation, serialization, and connection rejection.
 - **11.3 Foraging gym with an oracle ceiling.** Added
   [`benchmarks/tank/foraging_gym.py`](../benchmarks/tank/foraging_gym.py), a
   deterministic single-fish ruler that runs the production neutral

--- a/tests/core/test_behavior_graph.py
+++ b/tests/core/test_behavior_graph.py
@@ -1,0 +1,153 @@
+"""Tests for dormant behavior-graph validation, compilation, and replay."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from core.behavior.graph import BehaviorGraph, BehaviorGraphError, GraphConnection, GraphNode
+from core.behavior.nodes import (
+    BehaviorNode,
+    Bool,
+    NodeCategory,
+    NodeDefinition,
+    NodeParameter,
+    NodeRegistry,
+    NodeValue,
+    Scalar,
+    ValueType,
+)
+
+FIXTURE = Path(__file__).parents[1] / "fixtures" / "behavior_graphs" / "scalar_threshold_v1.json"
+
+
+@dataclass
+class _EnergySensor:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+    def sense(self, context: object) -> NodeValue:
+        assert isinstance(context, Mapping)
+        return Scalar(float(context[self.parameters["field"]]))
+
+
+@dataclass
+class _Threshold:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+    def select(self, inputs: Mapping[str, NodeValue]) -> NodeValue:
+        return Bool(float(inputs["value"]) >= float(self.parameters["minimum"]))
+
+
+def _registry(factory_calls: list[str] | None = None) -> NodeRegistry:
+    registry = NodeRegistry()
+
+    def sensor_factory(node_id: str, parameters: Mapping[str, NodeParameter]) -> BehaviorNode:
+        if factory_calls is not None:
+            factory_calls.append(node_id)
+        return _EnergySensor(node_id, "energy_sensor", NodeCategory.SENSOR, parameters)
+
+    def threshold_factory(node_id: str, parameters: Mapping[str, NodeParameter]) -> BehaviorNode:
+        if factory_calls is not None:
+            factory_calls.append(node_id)
+        return _Threshold(node_id, "threshold", NodeCategory.SELECTOR, parameters)
+
+    registry.register(
+        NodeDefinition("energy_sensor", NodeCategory.SENSOR, {}, ValueType.SCALAR, sensor_factory)
+    )
+    registry.register(
+        NodeDefinition(
+            "threshold",
+            NodeCategory.SELECTOR,
+            {"value": ValueType.SCALAR},
+            ValueType.BOOL,
+            threshold_factory,
+        )
+    )
+    return registry
+
+
+def test_golden_graph_replay_compiles_once_and_replays_expected_outputs():
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    graph = BehaviorGraph.from_dict(payload["graph"])
+    factory_calls: list[str] = []
+    compiled = graph.compile(_registry(factory_calls))
+
+    assert factory_calls == ["energy", "fed"]
+    assert [compiled.evaluate(frame["context"]) for frame in payload["replay"]] == [
+        frame["output"] for frame in payload["replay"]
+    ]
+    assert factory_calls == ["energy", "fed"]
+
+
+def test_graph_round_trip_is_canonical():
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    graph = BehaviorGraph.from_dict(payload["graph"])
+
+    assert BehaviorGraph.from_dict(graph.to_dict()) == graph
+
+
+def test_compile_rejects_unknown_node_type_and_mismatched_port_type():
+    unknown = BehaviorGraph(
+        (GraphNode("missing", "missing_type", {}),),
+        (),
+        "missing",
+    )
+    with pytest.raises(BehaviorGraphError, match="unknown type"):
+        unknown.compile(_registry())
+
+    mismatch = BehaviorGraph(
+        (
+            GraphNode("energy", "energy_sensor", {"field": "energy"}),
+            GraphNode("fed", "threshold", {"minimum": 0.5}),
+        ),
+        (GraphConnection("energy", "fed", "missing"),),
+        "fed",
+    )
+    with pytest.raises(BehaviorGraphError, match="no input port"):
+        mismatch.compile(_registry())
+
+
+def test_graph_rejects_cycles_and_duplicate_input_sources():
+    cyclic = {
+        "nodes": [
+            {"id": "left", "type": "energy_sensor", "parameters": {}},
+            {"id": "right", "type": "threshold", "parameters": {}},
+        ],
+        "connections": [
+            {"source": "left", "target": "right", "port": "value"},
+            {"source": "right", "target": "left", "port": "value"},
+        ],
+        "output": "right",
+    }
+    with pytest.raises(BehaviorGraphError, match="cycle"):
+        BehaviorGraph.from_dict(cyclic)
+
+    duplicate = BehaviorGraph(
+        (
+            GraphNode("one", "energy_sensor", {}),
+            GraphNode("two", "energy_sensor", {}),
+            GraphNode("target", "threshold", {}),
+        ),
+        (
+            GraphConnection("one", "target", "value"),
+            GraphConnection("two", "target", "value"),
+        ),
+        "target",
+    )
+    assert "input 'target'.value has multiple sources" in duplicate.validate()

--- a/tests/core/test_behavior_nodes.py
+++ b/tests/core/test_behavior_nodes.py
@@ -1,0 +1,148 @@
+"""Tests for the dormant shared behavior-graph contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import pytest
+
+from core.behavior.nodes import (
+    BehaviorNode,
+    NodeCategory,
+    NodeDefinition,
+    NodeParameter,
+    NodeRegistry,
+    Scalar,
+    ValueType,
+)
+
+
+@dataclass
+class _TestNode:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+
+def _factory(node_type: str, category: NodeCategory):
+    def create(node_id: str, parameters: Mapping[str, NodeParameter]) -> BehaviorNode:
+        return _TestNode(node_id, node_type, category, parameters)
+
+    return create
+
+
+def _definition(
+    node_type: str,
+    category: NodeCategory,
+    output_type: ValueType,
+    input_ports: Mapping[str, ValueType] | None = None,
+) -> NodeDefinition:
+    return NodeDefinition(
+        node_type=node_type,
+        category=category,
+        input_ports=input_ports or {},
+        output_type=output_type,
+        factory=_factory(node_type, category),
+    )
+
+
+def test_definition_serialization_is_stable_and_port_metadata_is_immutable():
+    definition = _definition(
+        "choose_target",
+        NodeCategory.SELECTOR,
+        ValueType.ENTITY_REF,
+        {"candidates": ValueType.ENTITY_REF, "urgency": ValueType.SCALAR},
+    )
+
+    assert definition.to_dict() == {
+        "node_type": "choose_target",
+        "category": "selector",
+        "input_ports": {"candidates": "entity_ref", "urgency": "scalar"},
+        "output_type": "entity_ref",
+    }
+    with pytest.raises(TypeError):
+        definition.input_ports["extra"] = ValueType.BOOL  # type: ignore[index]
+
+
+def test_registry_orders_definitions_and_rejects_duplicate_node_types():
+    registry = NodeRegistry()
+    registry.register(_definition("zeta", NodeCategory.SENSOR, ValueType.SCALAR))
+    alpha = _definition("alpha", NodeCategory.SENSOR, ValueType.BOOL)
+    registry.register(alpha)
+
+    assert [definition.node_type for definition in registry.definitions()] == ["alpha", "zeta"]
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(alpha)
+
+
+def test_registry_creates_and_serializes_nodes_with_one_common_envelope():
+    registry = NodeRegistry()
+    registry.register(_definition("energy_sensor", NodeCategory.SENSOR, ValueType.SCALAR))
+
+    node = registry.create("energy_sensor", "energy-1", {"scale": Scalar(0.5)})
+
+    assert registry.serialize(node) == {
+        "id": "energy-1",
+        "type": "energy_sensor",
+        "parameters": {"scale": 0.5},
+    }
+
+
+def test_registry_rejects_factory_metadata_mismatch():
+    registry = NodeRegistry()
+
+    def wrong_factory(node_id: str, parameters: Mapping[str, NodeParameter]) -> BehaviorNode:
+        return _TestNode(node_id, "wrong", NodeCategory.SENSOR, parameters)
+
+    registry.register(
+        NodeDefinition(
+            "expected",
+            NodeCategory.SENSOR,
+            {},
+            ValueType.SCALAR,
+            wrong_factory,
+        )
+    )
+
+    with pytest.raises(ValueError, match="returned node type"):
+        registry.create("expected", "node-1", {})
+
+
+def test_registry_accepts_only_exactly_typed_connections():
+    registry = NodeRegistry()
+    registry.register(_definition("energy_sensor", NodeCategory.SENSOR, ValueType.SCALAR))
+    registry.register(
+        _definition(
+            "threshold",
+            NodeCategory.SELECTOR,
+            ValueType.BOOL,
+            {"value": ValueType.SCALAR},
+        )
+    )
+    registry.register(_definition("target_sensor", NodeCategory.SENSOR, ValueType.ENTITY_REF))
+
+    registry.validate_connection("energy_sensor", "threshold", "value")
+    with pytest.raises(TypeError, match="Cannot connect"):
+        registry.validate_connection("target_sensor", "threshold", "value")
+    with pytest.raises(KeyError, match="no input port"):
+        registry.validate_connection("energy_sensor", "threshold", "missing")
+
+
+@pytest.mark.parametrize("node_type", ["", "not a node", "with-dash", "1starts_with_digit"])
+def test_definition_rejects_invalid_node_type_names(node_type: str):
+    with pytest.raises(ValueError, match="identifiers"):
+        _definition(node_type, NodeCategory.SENSOR, ValueType.SCALAR)
+
+
+def test_definition_rejects_invalid_port_metadata():
+    with pytest.raises(ValueError, match="valid identifiers"):
+        _definition(
+            "sensor", NodeCategory.SENSOR, ValueType.SCALAR, {"not a port": ValueType.SCALAR}
+        )
+    with pytest.raises(TypeError, match="ValueType"):
+        _definition("sensor", NodeCategory.SENSOR, ValueType.SCALAR, {"value": "scalar"})  # type: ignore[dict-item]

--- a/tests/fixtures/behavior_graphs/scalar_threshold_v1.json
+++ b/tests/fixtures/behavior_graphs/scalar_threshold_v1.json
@@ -1,0 +1,17 @@
+{
+  "graph": {
+    "nodes": [
+      {"id": "energy", "type": "energy_sensor", "parameters": {"field": "energy"}},
+      {"id": "fed", "type": "threshold", "parameters": {"minimum": 0.5}}
+    ],
+    "connections": [
+      {"source": "energy", "target": "fed", "port": "value"}
+    ],
+    "output": "fed"
+  },
+  "replay": [
+    {"context": {"energy": 0.25}, "output": false},
+    {"context": {"energy": 0.5}, "output": true},
+    {"context": {"energy": 0.9}, "output": true}
+  ]
+}

--- a/tests/test_genome_compatibility.py
+++ b/tests/test_genome_compatibility.py
@@ -3,6 +3,7 @@ import random
 import pytest
 
 import core.genetics.genome_codec as genome_codec
+from core.behavior.graph import BehaviorGraph
 from core.genetics import Genome
 from core.genetics.trait import GeneticTrait
 
@@ -135,6 +136,27 @@ def test_genome_with_code_policy_round_trip():
     assert g2.behavioral.poker_policy_id.value == "comp_poker"
     assert g2.behavioral.poker_policy_params is not None
     assert g2.behavioral.poker_policy_params.value == {"bet": 0.5}
+
+
+def test_dormant_behavior_graph_round_trip_without_affecting_default_payload():
+    graph_data = {
+        "nodes": [{"id": "sensor", "type": "energy_sensor", "parameters": {}}],
+        "connections": [],
+        "output": "sensor",
+    }
+    genome = Genome.random(use_algorithm=False, rng=random.Random(456))
+    assert genome.behavioral.behavior_graph is None
+    default_payload = genome.to_dict()
+    assert "behavior_graph" not in default_payload
+    assert default_payload["schema_version"] == 2
+
+    genome.behavioral.behavior_graph = GeneticTrait(BehaviorGraph.from_dict(graph_data))
+    encoded = genome.to_dict()
+    assert encoded["schema_version"] == 3
+    restored = Genome.from_dict(encoded, rng=random.Random(456), use_algorithm=False)
+
+    assert restored.behavioral.behavior_graph is not None
+    assert restored.behavioral.behavior_graph.value == genome.behavioral.behavior_graph.value
 
 
 def test_malformed_behavior_payload_keeps_default_behavior():


### PR DESCRIPTION
## What changed

Adds Theme 12.2 and 12.3's dormant shared behavior-graph foundation:

- typed behavioral-node contracts and deterministic registry metadata
- immutable graph serialization, port validation, and one-time compiled execution plans
- optional `BehavioralTraits.behavior_graph` persistence and inheritance
- an isolated golden graph replay fixture and focused tests

## Why

This establishes a small, typed, interpretable substrate for reusable cross-domain behavior modules without changing the live fish decision path.

Graph-free genomes retain their v2 serialized payload and RNG schedule. Genomes that carry a graph use schema v3.

## Layer

Layer 1 foundation, behavior-preserving: no production fish selects the graph yet; `ComposableBehavior` remains the live path.

## Validation

- `py tools\agent_gate.py`
- `py tools\pre_pr_gate.py`
- `py tools\run_bench.py benchmarks\tank\survival_5k.py --seed 42 --verify-determinism`

The survival benchmark reproduced exactly at seed 42:

- score: `388.222695`
- all score-breakdown components matched the champion
- subprocess determinism check passed