### PR TITLE
Add typed behavior graph vertical slice

### DIFF
--- a/core/behavior/__init__.py
+++ b/core/behavior/__init__.py
@@ -1,7 +1,10 @@
 """Shared, domain-neutral building blocks for organism behavior."""
 
 from core.behavior.nodes import NODE_REGISTRY, NodeCategory, NodeDefinition, NodeRegistry, ValueType
+from core.behavior.standard_nodes import register_standard_nodes
 from core.behavior.graph import BehaviorGraph, BehaviorGraphError, CompiledBehaviorGraph
+
+register_standard_nodes()
 
 __all__ = [
     "BehaviorGraph",
@@ -12,4 +15,5 @@ __all__ = [
     "NodeDefinition",
     "NodeRegistry",
     "ValueType",
+    "register_standard_nodes",
 ]

--- a/core/behavior/graph.py
+++ b/core/behavior/graph.py
@@ -22,11 +22,55 @@ from core.behavior.nodes import (
     NodeRegistry,
     NodeValue,
     Scalar,
+    ValueType,
 )
 
 
 class BehaviorGraphError(ValueError):
     """Raised when graph data cannot be validated or compiled."""
+
+
+def _is_vector(value: object) -> bool:
+    return (
+        isinstance(value, tuple)
+        and len(value) == 2
+        and all(type(component) is float and math.isfinite(component) for component in value)
+    )
+
+
+def _matches_value_type(value: object, value_type: ValueType) -> bool:
+    if value_type is ValueType.SCALAR:
+        return type(value) is float and math.isfinite(value)
+    if value_type is ValueType.BOOL:
+        return type(value) is bool
+    if value_type is ValueType.ENTITY_REF:
+        return type(value) is str
+    if value_type is ValueType.VECTOR:
+        return _is_vector(value)
+    if value_type is ValueType.UNIT_VECTOR:
+        if not _is_vector(value):
+            return False
+        vector = cast(tuple[float, float], value)
+        length = math.hypot(vector[0], vector[1])
+        return length == 0.0 or math.isclose(length, 1.0, rel_tol=1e-6, abs_tol=1e-6)
+    return False
+
+
+def _checked_evaluator(
+    evaluator: Callable[[object, Mapping[str, NodeValue]], NodeValue],
+    node_id: str,
+    output_type: ValueType,
+) -> Callable[[object, Mapping[str, NodeValue]], NodeValue]:
+    def evaluate(context: object, inputs: Mapping[str, NodeValue]) -> NodeValue:
+        value = evaluator(context, inputs)
+        if not _matches_value_type(value, output_type):
+            raise BehaviorGraphError(
+                f"Node {node_id!r} returned an invalid {output_type.value} output "
+                f"(got {type(value).__name__})."
+            )
+        return value
+
+    return evaluate
 
 
 def _parameters_from_dict(value: object) -> dict[str, NodeParameter]:
@@ -239,11 +283,26 @@ class BehaviorGraph:
             issues.extend(self._topology_issues(nodes_by_id))
 
         if registry is not None:
+            definitions = {}
             for node in sorted(self.nodes, key=lambda item: item.node_id):
                 try:
-                    registry.get(node.node_type)
+                    definitions[node.node_id] = registry.get(node.node_type)
                 except KeyError:
                     issues.append(f"node {node.node_id!r} uses unknown type {node.node_type!r}")
+
+            for node in sorted(self.nodes, key=lambda item: item.node_id):
+                definition = definitions.get(node.node_id)
+                if definition is None:
+                    continue
+                connected_ports = {
+                    connection.target_port
+                    for connection in self.connections
+                    if connection.target_id == node.node_id
+                }
+                for port_name in sorted(definition.input_ports):
+                    if port_name not in connected_ports:
+                        issues.append(f"required input {node.node_id!r}.{port_name} has no source")
+
             for connection in self.connections:
                 source = nodes_by_id.get(connection.source_id)
                 target = nodes_by_id.get(connection.target_id)
@@ -277,8 +336,17 @@ class BehaviorGraph:
                     ready.sort()
         return [] if visited == len(nodes_by_id) else ["graph contains a cycle"]
 
-    def compile(self, registry: NodeRegistry = NODE_REGISTRY) -> CompiledBehaviorGraph:
-        """Instantiate and bind an immutable flat execution plan once."""
+    def compile(
+        self,
+        registry: NodeRegistry = NODE_REGISTRY,
+        *,
+        validate_outputs: bool = False,
+    ) -> CompiledBehaviorGraph:
+        """Instantiate and bind an immutable flat execution plan once.
+
+        Set ``validate_outputs`` for debug or benchmark runs that should enforce
+        each node's declared runtime value type.
+        """
         issues = self.validate(registry)
         if issues:
             raise BehaviorGraphError("Cannot compile behavior graph: " + "; ".join(issues))
@@ -293,6 +361,7 @@ class BehaviorGraph:
         steps: list[_CompiledStep] = []
         for node_id in order:
             graph_node = nodes_by_id[node_id]
+            definition = registry.get(graph_node.node_type)
             node = registry.create(graph_node.node_type, graph_node.node_id, graph_node.parameters)
             inputs = tuple(
                 (connection.target_port, indices[connection.source_id])
@@ -300,7 +369,10 @@ class BehaviorGraph:
                     incoming[node_id], key=lambda connection: connection.target_port
                 )
             )
-            steps.append(_CompiledStep(_evaluator_for(node), inputs))
+            evaluator = _evaluator_for(node)
+            if validate_outputs:
+                evaluator = _checked_evaluator(evaluator, node_id, definition.output_type)
+            steps.append(_CompiledStep(evaluator, inputs))
         return CompiledBehaviorGraph(tuple(steps), indices[self.output_node_id])
 
     def _topological_order(self, nodes_by_id: Mapping[str, GraphNode]) -> tuple[str, ...]:

--- a/core/behavior/standard_nodes.py
+++ b/core/behavior/standard_nodes.py
@@ -1,0 +1,124 @@
+"""Small, domain-neutral nodes for the first behavior-graph vertical slice."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import cast
+
+from core.behavior.nodes import (
+    NODE_REGISTRY,
+    BehaviorNode,
+    NodeCategory,
+    NodeDefinition,
+    NodeParameter,
+    NodeRegistry,
+    NodeValue,
+    Scalar,
+    UnitVector,
+    ValueType,
+)
+from core.behavior.primitives.steering import normalized_components
+
+
+@dataclass
+class _ContextVectorSensor:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+    def sense(self, context: object) -> NodeValue:
+        if not isinstance(context, Mapping):
+            raise TypeError("context_vector_sensor requires a mapping context")
+        field = self.parameters.get("field")
+        if not isinstance(field, str):
+            raise ValueError("context_vector_sensor requires a string 'field' parameter")
+        raw_value = context.get(field)
+        if not isinstance(raw_value, Sequence) or isinstance(raw_value, (str, bytes)):
+            raise TypeError(f"context field {field!r} must contain a two-component vector")
+        components = cast(Sequence[object], raw_value)
+        if len(components) != 2:
+            raise TypeError(f"context field {field!r} must contain a two-component vector")
+        try:
+            if any(isinstance(component, bool) for component in components):
+                raise TypeError
+            x, y = float(cast(str | float | int, components[0])), float(
+                cast(str | float | int, components[1])
+            )
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"context field {field!r} must contain numeric components") from exc
+        if not math.isfinite(x) or not math.isfinite(y):
+            raise ValueError(f"context field {field!r} must contain finite components")
+        return (Scalar(x), Scalar(y))
+
+
+@dataclass
+class _NormalizeVectorSteering:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+    def steer(self, inputs: Mapping[str, NodeValue]) -> UnitVector:
+        raw_vector = inputs["vector"]
+        if not isinstance(raw_vector, tuple) or len(raw_vector) != 2:
+            raise TypeError("normalize_vector requires a two-component vector")
+        x, y = normalized_components(float(raw_vector[0]), float(raw_vector[1]))
+        return UnitVector((Scalar(x), Scalar(y)))
+
+
+def _context_vector_factory(node_id: str, parameters: Mapping[str, NodeParameter]) -> BehaviorNode:
+    return _ContextVectorSensor(
+        node_id,
+        "context_vector_sensor",
+        NodeCategory.SENSOR,
+        MappingProxyType(dict(parameters)),
+    )
+
+
+def _normalize_vector_factory(
+    node_id: str, parameters: Mapping[str, NodeParameter]
+) -> BehaviorNode:
+    return _NormalizeVectorSteering(
+        node_id,
+        "normalize_vector",
+        NodeCategory.STEERING,
+        MappingProxyType(dict(parameters)),
+    )
+
+
+def register_standard_nodes(registry: NodeRegistry = NODE_REGISTRY) -> None:
+    """Register the small standard node vocabulary exactly once per registry."""
+    definitions = (
+        NodeDefinition(
+            "context_vector_sensor",
+            NodeCategory.SENSOR,
+            {},
+            ValueType.VECTOR,
+            _context_vector_factory,
+        ),
+        NodeDefinition(
+            "normalize_vector",
+            NodeCategory.STEERING,
+            {"vector": ValueType.VECTOR},
+            ValueType.UNIT_VECTOR,
+            _normalize_vector_factory,
+        ),
+    )
+    for definition in definitions:
+        try:
+            registry.get(definition.node_type)
+        except KeyError:
+            registry.register(definition)
+
+
+__all__ = ["register_standard_nodes"]

--- a/tests/core/test_behavior_graph.py
+++ b/tests/core/test_behavior_graph.py
@@ -54,6 +54,20 @@ class _Threshold:
         return Bool(float(inputs["value"]) >= float(self.parameters["minimum"]))
 
 
+@dataclass
+class _InvalidEnergySensor:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+    def sense(self, context: object) -> NodeValue:
+        return Bool(True)
+
+
 def _registry(factory_calls: list[str] | None = None) -> NodeRegistry:
     registry = NodeRegistry()
 
@@ -78,6 +92,18 @@ def _registry(factory_calls: list[str] | None = None) -> NodeRegistry:
             ValueType.BOOL,
             threshold_factory,
         )
+    )
+    return registry
+
+
+def _invalid_output_registry() -> NodeRegistry:
+    registry = NodeRegistry()
+
+    def sensor_factory(node_id: str, parameters: Mapping[str, NodeParameter]) -> BehaviorNode:
+        return _InvalidEnergySensor(node_id, "energy_sensor", NodeCategory.SENSOR, parameters)
+
+    registry.register(
+        NodeDefinition("energy_sensor", NodeCategory.SENSOR, {}, ValueType.SCALAR, sensor_factory)
     )
     return registry
 
@@ -121,6 +147,29 @@ def test_compile_rejects_unknown_node_type_and_mismatched_port_type():
     )
     with pytest.raises(BehaviorGraphError, match="no input port"):
         mismatch.compile(_registry())
+
+
+def test_graph_rejects_missing_required_input_port():
+    graph = BehaviorGraph(
+        (
+            GraphNode("energy", "energy_sensor", {"field": "energy"}),
+            GraphNode("fed", "threshold", {"minimum": 0.5}),
+        ),
+        (),
+        "fed",
+    )
+
+    assert "required input 'fed'.value has no source" in graph.validate(_registry())
+    with pytest.raises(BehaviorGraphError, match=r"required input 'fed'\.value"):
+        graph.compile(_registry())
+
+
+def test_compile_can_validate_runtime_output_contracts():
+    graph = BehaviorGraph((GraphNode("energy", "energy_sensor", {}),), (), "energy")
+    compiled = graph.compile(_invalid_output_registry(), validate_outputs=True)
+
+    with pytest.raises(BehaviorGraphError, match="invalid scalar output"):
+        compiled.evaluate({})
 
 
 def test_graph_rejects_cycles_and_duplicate_input_sources():

--- a/tests/core/test_behavior_standard_nodes.py
+++ b/tests/core/test_behavior_standard_nodes.py
@@ -1,0 +1,37 @@
+"""Tests for the first production behavior-graph node vocabulary."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.behavior.graph import BehaviorGraph, GraphConnection, GraphNode
+from core.behavior.nodes import NODE_REGISTRY, NodeRegistry
+from core.behavior.standard_nodes import register_standard_nodes
+
+
+def test_standard_nodes_register_once_and_have_typed_contracts() -> None:
+    registry = NodeRegistry()
+    register_standard_nodes(registry)
+    register_standard_nodes(registry)
+
+    assert [definition.node_type for definition in registry.definitions()] == [
+        "context_vector_sensor",
+        "normalize_vector",
+    ]
+    assert registry.get("normalize_vector").input_ports["vector"].value == "vector"
+    assert registry.get("normalize_vector").output_type.value == "unit_vector"
+
+
+def test_standard_graph_replays_context_vector_into_normalized_steering() -> None:
+    graph = BehaviorGraph(
+        (
+            GraphNode("offset", "context_vector_sensor", {"field": "offset"}),
+            GraphNode("direction", "normalize_vector", {}),
+        ),
+        (GraphConnection("offset", "direction", "vector"),),
+        "direction",
+    )
+    compiled = graph.compile(NODE_REGISTRY, validate_outputs=True)
+
+    assert compiled.evaluate({"offset": (3, 4)}) == pytest.approx((0.6, 0.8))
+    assert compiled.evaluate({"offset": (0, 0)}) == (0.0, 0.0)


### PR DESCRIPTION
## What changed

This PR takes the dormant behavior-graph foundation one focused step toward a usable vertical slice:

- validates that every registry-declared input port has a source;
- optionally validates node outputs at runtime with `compile(validate_outputs=True)`;
- adds the first registered domain-neutral nodes:
  - `context_vector_sensor`
  - `normalize_vector`
- adds deterministic graph replay and contract tests.

## Why

The graph previously allowed a required input to remain unconnected, causing a later `KeyError` during evaluation. Its declared output types were also metadata-only. The new checks fail early and clearly, while output validation remains opt-in so the default compiled path stays lightweight.

The standard nodes demonstrate a small reusable sensor-to-steering pipeline without wiring graph behavior into live fish yet.

## Validation

- `py -3 tools/agent_gate.py` — passed
- `py -3 tools/pre_pr_gate.py --timeout 120` — passed across all four shards
- Focused graph tests — 8 passed
- Mypy, Ruff, Black, and diff checks — passed

This PR does not change benchmark scoring or production fish behavior.