### PR TITLE
Harden survival benchmark against starvation exploits

### DIFF
--- a/benchmarks/tank/survival_5k.py
+++ b/benchmarks/tank/survival_5k.py
@@ -19,6 +19,11 @@ from core.worlds.interfaces import FAST_STEP_ACTION
 BENCHMARK_ID = "tank/survival_5k"
 FRAMES = 5000
 EXPECTED_RUNTIME_SECONDS = 45
+SCORING_VERSION = 2
+# A survival benchmark must measure organisms that can find food, not merely
+# population turnover.  A candidate at or above this mortality share is
+# invalid and cannot become a champion under this ruler.
+MAX_VALID_STARVATION_RATE = 0.95
 
 # World configuration, replicating SimulationConfig.headless_fast() parameters.
 WORLD_CONFIG: dict[str, Any] = {
@@ -40,7 +45,55 @@ WORLD_CONFIG: dict[str, Any] = {
 
 # Effective configuration captured by the champion config hash
 # (core/solutions/config_hash.py). Anything that changes the score belongs here.
-CONFIG: dict[str, Any] = {"frames": FRAMES, "world_config": WORLD_CONFIG}
+CONFIG: dict[str, Any] = {
+    "frames": FRAMES,
+    "scoring_version": SCORING_VERSION,
+    "max_valid_starvation_rate": MAX_VALID_STARVATION_RATE,
+    "world_config": WORLD_CONFIG,
+}
+
+
+def calculate_score(
+    *,
+    avg_fish_energy: float,
+    avg_fish_pop: float,
+    max_generation: int,
+    starvation_rate: float,
+) -> tuple[float, dict[str, float], bool, str | None]:
+    """Calculate the survival score and report benchmark validity.
+
+    The hard starvation gate prevents an ecology whose deaths are primarily
+    starvation from ranking as a survival champion.  Keeping this calculation
+    pure makes the scoring contract cheap to test without running a world.
+    """
+    raw_score = (avg_fish_energy * avg_fish_pop) / 1000.0
+    score_valid = starvation_rate < MAX_VALID_STARVATION_RATE
+    starvation_penalty = 1.0
+    if starvation_rate > MAX_VALID_STARVATION_RATE:
+        starvation_penalty = max(0.1, 1.0 - (starvation_rate - MAX_VALID_STARVATION_RATE) * 10.0)
+
+    generation_multiplier = 1.0 + (max_generation * 0.05)
+    validity_gate = 1.0 if score_valid else 0.0
+    score = raw_score * starvation_penalty * generation_multiplier * validity_gate
+    invalid_reason = (
+        f"starvation_rate {starvation_rate:.4f} >= "
+        f"maximum valid rate {MAX_VALID_STARVATION_RATE:.4f}"
+        if not score_valid
+        else None
+    )
+    return (
+        score,
+        {
+            "avg_energy": avg_fish_energy,
+            "avg_pop": avg_fish_pop,
+            "raw_score": raw_score,
+            "starvation_penalty": starvation_penalty,
+            "generation_multiplier": generation_multiplier,
+            "validity_gate": validity_gate,
+        },
+        score_valid,
+        invalid_reason,
+    )
 
 
 def run(
@@ -117,30 +170,18 @@ def run(
     # (Penalizing early extinction heavily since integrals will be small)
     avg_fish_energy = total_fish_energy_integral / FRAMES
     avg_fish_pop = total_fish_pop_integral / FRAMES
-
-    # Apply starvation penalty when starvation rate exceeds 95%
-    starvation_penalty = 1.0
-    if starvation_rate > 0.95:
-        # Scales down linearly from 1.0 at 0.95 starvation rate to 0.5 at 1.0 starvation rate
-        starvation_penalty = max(0.1, 1.0 - (starvation_rate - 0.95) * 10.0)
-
-    # Add a bonus multiplier for achieving a higher max generation (evolutionary progress)
-    generation_multiplier = 1.0 + (max_generation * 0.05)
-
-    raw_score = (avg_fish_energy * avg_fish_pop) / 1000.0
-    score = raw_score * starvation_penalty * generation_multiplier
+    score, score_breakdown, score_valid, invalid_reason = calculate_score(
+        avg_fish_energy=avg_fish_energy,
+        avg_fish_pop=avg_fish_pop,
+        max_generation=max_generation,
+        starvation_rate=starvation_rate,
+    )
 
     return {
         "benchmark_id": BENCHMARK_ID,
         "seed": seed,
         "score": score,
-        "score_breakdown": {
-            "avg_energy": avg_fish_energy,
-            "avg_pop": avg_fish_pop,
-            "raw_score": raw_score,
-            "starvation_penalty": starvation_penalty,
-            "generation_multiplier": generation_multiplier,
-        },
+        "score_breakdown": score_breakdown,
         "runtime_seconds": runtime,
         "metadata": {
             "frames": FRAMES,
@@ -152,6 +193,8 @@ def run(
             "max_generation": max_generation,
             "extinction_frames": extinctions,
             "starvation_rate": round(starvation_rate, 4),
+            "score_valid": score_valid,
+            "score_invalid_reason": invalid_reason,
             "starvation_deaths": starvation_deaths,
             "total_deaths": total_deaths,
             "death_causes": death_causes,

--- a/docs/IMPROVEMENT_PROPOSALS.md
+++ b/docs/IMPROVEMENT_PROPOSALS.md
@@ -646,10 +646,13 @@ shared module on multiple ladders (foraging gym / soccer / poker) to produce a
   seeds before and after removal — no re-baseline.
 - **1.8 Align `survival_5k` benchmark scoring with healthy ecosystem indicators.**
   Refactored the score formula in `benchmarks/tank/survival_5k.py` to apply a
-  starvation penalty when the starvation rate exceeds 95% (scaling down the score
-  linearly to 0.5 at 1.0 starvation rate) and a bonus multiplier for achieving a
-  higher max generation (`1.0 + max_generation * 0.05`). Re-baselined the
-  champion to version 6 with the new scoring structure under seed 42.
+  hard validity gate at 95% starvation mortality, so a starvation-dominated
+  ecology cannot become a champion, plus a bonus multiplier for achieving a
+  higher max generation (`1.0 + max_generation * 0.05`). The scoring version is
+  included in `CONFIG`, forcing an explicit re-baseline instead of silently
+  comparing old champion scores. The current seed-42 champion is intentionally
+  invalid under this ruler (`starvation_rate=1.0`, score `0.0`); re-baselining
+  remains a maintainer decision after a valid candidate is found.
 - **1.7 Optimize `survival_5k` runtime & reliability.** Solved the benchmark
   execution performance cliff. Replaced the expensive frame-by-frame
   `world.get_stats()` calculator with direct, cheap list comprehensions over

--- a/tests/test_survival_benchmark_scoring.py
+++ b/tests/test_survival_benchmark_scoring.py
@@ -1,0 +1,48 @@
+"""Regression tests for the survival benchmark's ecological validity gate."""
+
+from benchmarks.tank.survival_5k import (
+    MAX_VALID_STARVATION_RATE,
+    calculate_score,
+)
+
+
+def test_valid_starvation_rate_keeps_normal_score_contract():
+    score, breakdown, valid, reason = calculate_score(
+        avg_fish_energy=100.0,
+        avg_fish_pop=20.0,
+        max_generation=4,
+        starvation_rate=0.5,
+    )
+
+    assert valid is True
+    assert reason is None
+    assert score == 2.4  # 2.0 raw score × 1.2 generation multiplier
+    assert breakdown["validity_gate"] == 1.0
+
+
+def test_starvation_at_validity_limit_scores_zero():
+    score, breakdown, valid, reason = calculate_score(
+        avg_fish_energy=100_000.0,
+        avg_fish_pop=100.0,
+        max_generation=100,
+        starvation_rate=MAX_VALID_STARVATION_RATE,
+    )
+
+    assert score == 0.0
+    assert breakdown["validity_gate"] == 0.0
+    assert valid is False
+    assert reason is not None
+    assert "maximum valid rate" in reason
+
+
+def test_total_starvation_cannot_produce_a_positive_score():
+    score, _, valid, reason = calculate_score(
+        avg_fish_energy=1_000_000.0,
+        avg_fish_pop=1_000.0,
+        max_generation=1_000,
+        starvation_rate=1.0,
+    )
+
+    assert score == 0.0
+    assert valid is False
+    assert reason is not None


### PR DESCRIPTION
## Summary

- Add a hard validity gate to `tank/survival_5k`: starvation mortality at or above 95% scores zero.
- Include the scoring policy version and threshold in `CONFIG`, forcing explicit champion re-baselining.
- Report `score_valid` and an explanatory invalidity reason in benchmark metadata.
- Add pure scoring regression tests and update the improvement ledger.

## Why

The previous penalty bottomed out at 0.5, allowing the current champion to score 388.22 despite all 228 recorded deaths being starvation deaths. That rewarded population turnover rather than organism survival.

The corrected seed-42 run is deterministic and now reports score 0.0 with `score_valid: false`. The existing champion was deliberately not re-baselined; a valid candidate must be found first.

## Validation

- `py tools/smoke_gate.py` — 43 passed
- `py -m pytest -q tests/test_survival_benchmark_scoring.py tests/test_run_bench.py tests/test_benchmark_determinism.py` — 20 passed
- `py tools/run_bench.py benchmarks/tank/survival_5k.py --seed 42 --verify-determinism` — passed
- Seed-42 benchmark runtime: 26.9s, budget ~45s
- `git diff --check` — passed