### PR TITLE
Extend typed behavior graph vector composition

### DIFF
--- a/core/behavior/standard_nodes.py
+++ b/core/behavior/standard_nodes.py
@@ -11,6 +11,7 @@ from typing import cast
 from core.behavior.nodes import (
     NODE_REGISTRY,
     BehaviorNode,
+    Bool,
     NodeCategory,
     NodeDefinition,
     NodeParameter,
@@ -34,17 +35,12 @@ class _ContextVectorSensor:
         return self.parameters
 
     def sense(self, context: object) -> NodeValue:
-        if not isinstance(context, Mapping):
-            raise TypeError("context_vector_sensor requires a mapping context")
-        field = self.parameters.get("field")
-        if not isinstance(field, str):
-            raise ValueError("context_vector_sensor requires a string 'field' parameter")
-        raw_value = context.get(field)
+        raw_value = _context_value(context, self.parameters, "context_vector_sensor")
         if not isinstance(raw_value, Sequence) or isinstance(raw_value, (str, bytes)):
-            raise TypeError(f"context field {field!r} must contain a two-component vector")
+            raise TypeError("context_vector_sensor field must contain a two-component vector")
         components = cast(Sequence[object], raw_value)
         if len(components) != 2:
-            raise TypeError(f"context field {field!r} must contain a two-component vector")
+            raise TypeError("context_vector_sensor field must contain a two-component vector")
         try:
             if any(isinstance(component, bool) for component in components):
                 raise TypeError
@@ -52,10 +48,47 @@ class _ContextVectorSensor:
                 cast(str | float | int, components[1])
             )
         except (TypeError, ValueError) as exc:
-            raise TypeError(f"context field {field!r} must contain numeric components") from exc
+            raise TypeError("context_vector_sensor field must contain numeric components") from exc
         if not math.isfinite(x) or not math.isfinite(y):
-            raise ValueError(f"context field {field!r} must contain finite components")
+            raise ValueError("context_vector_sensor field must contain finite components")
         return (Scalar(x), Scalar(y))
+
+
+@dataclass
+class _ContextScalarSensor:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+    def sense(self, context: object) -> NodeValue:
+        value = _context_value(context, self.parameters, "context_scalar_sensor")
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("context_scalar_sensor field must contain a numeric scalar")
+        scalar = float(value)
+        if not math.isfinite(scalar):
+            raise ValueError("context_scalar_sensor field must contain a finite scalar")
+        return Scalar(scalar)
+
+
+@dataclass
+class _ContextBoolSensor:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+    def sense(self, context: object) -> NodeValue:
+        value = _context_value(context, self.parameters, "context_bool_sensor")
+        if type(value) is not bool:
+            raise TypeError("context_bool_sensor field must contain a boolean")
+        return Bool(value)
 
 
 @dataclass
@@ -74,6 +107,106 @@ class _NormalizeVectorSteering:
             raise TypeError("normalize_vector requires a two-component vector")
         x, y = normalized_components(float(raw_vector[0]), float(raw_vector[1]))
         return UnitVector((Scalar(x), Scalar(y)))
+
+
+@dataclass
+class _WeightedVectorSteering:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+    def steer(self, inputs: Mapping[str, NodeValue]) -> UnitVector:
+        first_x, first_y = _vector_components(inputs, "first", self.node_type)
+        second_x, second_y = _vector_components(inputs, "second", self.node_type)
+        first_weight = _parameter_float(self.parameters, "first_weight", 1.0)
+        second_weight = _parameter_float(self.parameters, "second_weight", 1.0)
+        x, y = normalized_components(
+            first_x * first_weight + second_x * second_weight,
+            first_y * first_weight + second_y * second_weight,
+        )
+        return UnitVector((Scalar(x), Scalar(y)))
+
+
+@dataclass
+class _ThresholdVectorSelector:
+    node_id: str
+    node_type: str
+    category: NodeCategory
+    parameters: Mapping[str, NodeParameter]
+
+    def to_parameters(self) -> Mapping[str, NodeParameter]:
+        return self.parameters
+
+    def select(self, inputs: Mapping[str, NodeValue]) -> NodeValue:
+        raw_value = inputs.get("value")
+        if type(raw_value) is not float or not math.isfinite(raw_value):
+            raise TypeError("threshold_vector_selector requires a finite scalar 'value'")
+        selected_port = (
+            "when_true"
+            if raw_value >= _parameter_float(self.parameters, "threshold", 0.0)
+            else "when_false"
+        )
+        return _vector_value(inputs, selected_port, self.node_type)
+
+
+def _context_value(
+    context: object,
+    parameters: Mapping[str, NodeParameter],
+    node_type: str,
+) -> object:
+    if not isinstance(context, Mapping):
+        raise TypeError(f"{node_type} requires a mapping context")
+    field = parameters.get("field")
+    if not isinstance(field, str):
+        raise ValueError(f"{node_type} requires a string 'field' parameter")
+    return context.get(field)
+
+
+def _parameter_float(parameters: Mapping[str, NodeParameter], name: str, default: float) -> float:
+    value = parameters.get(name, Scalar(default))
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"Node parameter {name!r} must be a finite scalar")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"Node parameter {name!r} must be a finite scalar")
+    return result
+
+
+def _vector_value(
+    inputs: Mapping[str, NodeValue], port: str, node_type: str
+) -> tuple[float, float]:
+    value = inputs.get(port)
+    if (
+        not isinstance(value, tuple)
+        or len(value) != 2
+        or not all(type(component) is float and math.isfinite(component) for component in value)
+    ):
+        raise TypeError(f"{node_type} requires a finite two-component vector '{port}'")
+    return float(value[0]), float(value[1])
+
+
+def _vector_components(
+    inputs: Mapping[str, NodeValue], port: str, node_type: str
+) -> tuple[float, float]:
+    return _vector_value(inputs, port, node_type)
+
+
+def _context_sensor_factory(
+    node_type: str,
+    node_class: type[_ContextScalarSensor] | type[_ContextBoolSensor],
+    node_id: str,
+    parameters: Mapping[str, NodeParameter],
+) -> BehaviorNode:
+    return node_class(
+        node_id,
+        node_type,
+        NodeCategory.SENSOR,
+        MappingProxyType(dict(parameters)),
+    )
 
 
 def _context_vector_factory(node_id: str, parameters: Mapping[str, NodeParameter]) -> BehaviorNode:
@@ -96,6 +229,26 @@ def _normalize_vector_factory(
     )
 
 
+def _weighted_vector_factory(node_id: str, parameters: Mapping[str, NodeParameter]) -> BehaviorNode:
+    return _WeightedVectorSteering(
+        node_id,
+        "weighted_vector",
+        NodeCategory.STEERING,
+        MappingProxyType(dict(parameters)),
+    )
+
+
+def _threshold_vector_factory(
+    node_id: str, parameters: Mapping[str, NodeParameter]
+) -> BehaviorNode:
+    return _ThresholdVectorSelector(
+        node_id,
+        "threshold_vector_selector",
+        NodeCategory.SELECTOR,
+        MappingProxyType(dict(parameters)),
+    )
+
+
 def register_standard_nodes(registry: NodeRegistry = NODE_REGISTRY) -> None:
     """Register the small standard node vocabulary exactly once per registry."""
     definitions = (
@@ -107,11 +260,47 @@ def register_standard_nodes(registry: NodeRegistry = NODE_REGISTRY) -> None:
             _context_vector_factory,
         ),
         NodeDefinition(
+            "context_scalar_sensor",
+            NodeCategory.SENSOR,
+            {},
+            ValueType.SCALAR,
+            lambda node_id, parameters: _context_sensor_factory(
+                "context_scalar_sensor", _ContextScalarSensor, node_id, parameters
+            ),
+        ),
+        NodeDefinition(
+            "context_bool_sensor",
+            NodeCategory.SENSOR,
+            {},
+            ValueType.BOOL,
+            lambda node_id, parameters: _context_sensor_factory(
+                "context_bool_sensor", _ContextBoolSensor, node_id, parameters
+            ),
+        ),
+        NodeDefinition(
             "normalize_vector",
             NodeCategory.STEERING,
             {"vector": ValueType.VECTOR},
             ValueType.UNIT_VECTOR,
             _normalize_vector_factory,
+        ),
+        NodeDefinition(
+            "weighted_vector",
+            NodeCategory.STEERING,
+            {"first": ValueType.VECTOR, "second": ValueType.VECTOR},
+            ValueType.UNIT_VECTOR,
+            _weighted_vector_factory,
+        ),
+        NodeDefinition(
+            "threshold_vector_selector",
+            NodeCategory.SELECTOR,
+            {
+                "value": ValueType.SCALAR,
+                "when_true": ValueType.VECTOR,
+                "when_false": ValueType.VECTOR,
+            },
+            ValueType.VECTOR,
+            _threshold_vector_factory,
         ),
     )
     for definition in definitions:

--- a/tests/core/test_behavior_standard_nodes.py
+++ b/tests/core/test_behavior_standard_nodes.py
@@ -15,11 +15,17 @@ def test_standard_nodes_register_once_and_have_typed_contracts() -> None:
     register_standard_nodes(registry)
 
     assert [definition.node_type for definition in registry.definitions()] == [
+        "context_bool_sensor",
+        "context_scalar_sensor",
         "context_vector_sensor",
         "normalize_vector",
+        "threshold_vector_selector",
+        "weighted_vector",
     ]
     assert registry.get("normalize_vector").input_ports["vector"].value == "vector"
     assert registry.get("normalize_vector").output_type.value == "unit_vector"
+    assert registry.get("weighted_vector").input_ports["first"].value == "vector"
+    assert registry.get("threshold_vector_selector").output_type.value == "vector"
 
 
 def test_standard_graph_replays_context_vector_into_normalized_steering() -> None:
@@ -35,3 +41,47 @@ def test_standard_graph_replays_context_vector_into_normalized_steering() -> Non
 
     assert compiled.evaluate({"offset": (3, 4)}) == pytest.approx((0.6, 0.8))
     assert compiled.evaluate({"offset": (0, 0)}) == (0.0, 0.0)
+
+
+def test_threshold_selector_and_weighted_steering_form_typed_vertical_slice() -> None:
+    graph = BehaviorGraph(
+        (
+            GraphNode("energy", "context_scalar_sensor", {"field": "energy"}),
+            GraphNode("target", "context_vector_sensor", {"field": "target"}),
+            GraphNode("fallback", "context_vector_sensor", {"field": "fallback"}),
+            GraphNode("choice", "threshold_vector_selector", {"threshold": 0.5}),
+            GraphNode(
+                "direction",
+                "weighted_vector",
+                {"first_weight": 2.0, "second_weight": 1.0},
+            ),
+        ),
+        (
+            GraphConnection("energy", "choice", "value"),
+            GraphConnection("target", "choice", "when_true"),
+            GraphConnection("fallback", "choice", "when_false"),
+            GraphConnection("choice", "direction", "first"),
+            GraphConnection("fallback", "direction", "second"),
+        ),
+        "direction",
+    )
+    compiled = graph.compile(NODE_REGISTRY, validate_outputs=True)
+
+    assert compiled.evaluate(
+        {"energy": 0.8, "target": (1, 0), "fallback": (0, 1)}
+    ) == pytest.approx((0.894427, 0.447214), abs=1e-6)
+    assert compiled.evaluate(
+        {"energy": 0.2, "target": (1, 0), "fallback": (0, 1)}
+    ) == pytest.approx((0.0, 1.0))
+
+
+def test_context_scalar_sensor_rejects_boolean_values() -> None:
+    graph = BehaviorGraph(
+        (GraphNode("energy", "context_scalar_sensor", {"field": "energy"}),),
+        (),
+        "energy",
+    )
+    compiled = graph.compile(NODE_REGISTRY, validate_outputs=True)
+
+    with pytest.raises(TypeError, match="numeric scalar"):
+        compiled.evaluate({"energy": True})


### PR DESCRIPTION
## Summary

- Add scalar and boolean context sensors to the typed behavior-graph vocabulary.
- Add a threshold vector selector.
- Add weighted vector steering that normalizes its composed output.
- Exercise the sensor → selector → steering path with runtime output validation.

## Why

The behavior graph had serialization, compilation, and one vector sensor/normalizer, but no meaningful decision composition. This adds a small, inspectable vertical slice while keeping graph execution dormant in production fish, so existing simulation trajectories and champions are unchanged.

## Validation

- `py tools/agent_gate.py` — passed
  - 596 curated tests passed
  - mypy passed across 435 source files
- Focused graph tests — 20 passed
- `py -m mypy core/behavior` — passed
- `git diff --check` — passed

This PR intentionally does not add graph mutation/crossover or wire graphs into live fish behavior; those remain separate follow-up work.