### PR TITLE
Fix world-agnostic runner test race

### DIFF
--- a/tests/test_simulation_runner_world_agnostic.py
+++ b/tests/test_simulation_runner_world_agnostic.py
@@ -125,8 +125,6 @@ class TestNonTankWorldAgnosticism:
         """Non-tank worlds should support universal commands."""
         runner = SimulationRunner(world_type="petri", seed=42)
 
-        runner.start()
-
         # Universal commands should work
         result = runner.handle_command("pause")
         assert result is None
@@ -136,11 +134,11 @@ class TestNonTankWorldAgnosticism:
         assert result is None
         assert runner.world.paused is False
 
-        # Stepping should work without errors
+        # Use the runner's synchronized stepping API. Calling world.step()
+        # directly while a background runner thread is active races the
+        # mutation queue and can leave a removal pending at frame end.
         for _ in range(10):
-            runner.world.step()
-
-        runner.stop()
+            runner.step()
 
     def test_non_tank_rejects_tank_commands(self):
         """Non-tank worlds should reject tank-specific commands gracefully."""


### PR DESCRIPTION
## Summary

- Fix the intermittent `test_non_tank_world_basic_operations` failure under coverage.
- Exercise synchronous stepping through `SimulationRunner.step()`, which holds the runner lock.
- Keep the end-of-frame mutation invariant unchanged.

## Root cause

The test started the runner's background simulation thread and then called `runner.world.step()` directly. That bypassed the runner lock. Under coverage timing, the background and direct steps could overlap, leaving a removal queued at the end-of-frame and triggering:

`RuntimeError: End-of-frame invariant violated: pending entity mutations remain (spawns=0, removals=1)`

The isolated test often passed, which made this an order/timing-sensitive suite failure.

## Validation

- `py -m pytest -q tests/test_simulation_runner_world_agnostic.py` — 19 passed
- Exact coverage command from the failure:
  `py -m pytest tests/ -m "not slow and not integration and not manual" --cov=core --cov=backend --cov-fail-under=70 -n auto -q`
  — 2088 passed, 2 skipped, coverage 77.73%
- `py tools/agent_gate.py` — passed
  - 596 curated tests passed
  - mypy passed across 435 source files
- `git diff --check` — passed